### PR TITLE
Tweak horizontal example layout

### DIFF
--- a/Example/HorizonCalendarExample/HorizonCalendarExample/DemoPickerViewController.swift
+++ b/Example/HorizonCalendarExample/HorizonCalendarExample/DemoPickerViewController.swift
@@ -108,7 +108,7 @@ extension DemoPickerViewController: UITableViewDelegate {
     let demoViewController = demoDestinations[indexPath.item].destinationType.init(
       monthsLayout: monthsLayoutPicker.selectedSegmentIndex == 0
         ? .vertical(pinDaysOfWeekToTop: false)
-        : .horizontal(monthWidth: min(view.bounds.width - 128, 512)))
+        : .horizontal(monthWidth: min(min(view.bounds.width, view.bounds.height) - 64, 512)))
 
     navigationController?.pushViewController(demoViewController, animated: true)
   }

--- a/HorizonCalendar.podspec
+++ b/HorizonCalendar.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name = "HorizonCalendar"
-  spec.version = "1.0.2"
+  spec.version = "1.0.3"
   spec.license = "Apache License, Version 2.0"
   spec.summary = "A declarative, performant, calendar UI component that supports use cases ranging from simple date pickers to fully-featured calendar apps."
 

--- a/HorizonCalendar.xcodeproj/project.pbxproj
+++ b/HorizonCalendar.xcodeproj/project.pbxproj
@@ -528,7 +528,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.2;
+				MARKETING_VERSION = 1.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.HorizonCalendar;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -562,7 +562,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.2;
+				MARKETING_VERSION = 1.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.HorizonCalendar;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";


### PR DESCRIPTION
## Details
This PR fixes an assert I was hitting due to the horizontal calendar not having enough room to layout (without size going negative) on iPhone 8. The root cause was having a monthsWidth that was too constrained. This bug only affects the example project.

## Related Issue

<!--- If this is related to any issues, link them here. -->

## Motivation and Context

Improve example app.

## How Has This Been Tested

Tested on a few different iPhone simulators and iPad simulator.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
