### PR TITLE
Bk/fix scroll to item bug

### DIFF
--- a/HorizonCalendar.podspec
+++ b/HorizonCalendar.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name = "HorizonCalendar"
-  spec.version = "1.1.0"
+  spec.version = "1.1.1"
   spec.license = "Apache License, Version 2.0"
   spec.summary = "A declarative, performant, calendar UI component that supports use cases ranging from simple date pickers to fully-featured calendar apps."
 

--- a/HorizonCalendar.xcodeproj/project.pbxproj
+++ b/HorizonCalendar.xcodeproj/project.pbxproj
@@ -528,7 +528,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.0;
+				MARKETING_VERSION = 1.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.HorizonCalendar;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -562,7 +562,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.0;
+				MARKETING_VERSION = 1.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.HorizonCalendar;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Sources/Internal/VisibleCalendarItem.swift
+++ b/Sources/Internal/VisibleCalendarItem.swift
@@ -23,7 +23,7 @@ import CoreGraphics
 /// - Note: This is a reference type because it's heavily used in `Set`s, especially in the reuse manager. By making it a reference
 /// type, we avoid `VisibleCalendarItem` `initializeWithCopy` when mutating the `Set`s. This type also caches its hash
 /// value, which otherwise would be recomputed for every `Set` operation performed by the reuse manager. On an iPhone 6s, this
-/// reduces CPU usage by nearly 10% when programatically scrolling down at a rate of 500 points / frame.
+/// reduces CPU usage by nearly 10% when programmatically scrolling down at a rate of 500 points / frame.
 final class VisibleCalendarItem {
 
   // MARK: Lifecycle

--- a/Sources/Internal/VisibleItemsProvider.swift
+++ b/Sources/Internal/VisibleItemsProvider.swift
@@ -61,9 +61,18 @@ final class VisibleItemsProvider {
     -> LayoutItem
   {
     let baseMonthFrame = frameProvider.frameOfMonth(month, withOrigin: offset)
-    let finalMonthFrame = translatedFrame(baseMonthFrame, for: scrollPosition, offset: offset)
-    let finalFrame = frameProvider.frameOfMonthHeader(inMonthWithOrigin: finalMonthFrame.origin)
-    return LayoutItem(itemType: .monthHeader(month), frame: finalFrame)
+    let proposedMonthFrame = proposedScrollToItemFrame(
+      fromBaseFrame: baseMonthFrame,
+      for: scrollPosition,
+      offset: offset)
+    let proposedMonthHeaderFrame = frameProvider.frameOfMonthHeader(
+      inMonthWithOrigin: proposedMonthFrame.origin)
+    let finalMonthHeaderFrame = correctedScrollToItemFrameForContentBoundaries(
+      fromProposedFrame: proposedMonthHeaderFrame,
+      ofTargetInMonth: month,
+      withFrame: proposedMonthFrame,
+      bounds: CGRect(origin: offset, size: size))
+    return LayoutItem(itemType: .monthHeader(month), frame: finalMonthHeaderFrame)
   }
 
   func anchorDayItem(
@@ -72,9 +81,20 @@ final class VisibleItemsProvider {
     scrollPosition: CalendarViewScrollPosition)
     -> LayoutItem
   {
-    let baseFrame = frameProvider.frameOfDay(day, inMonthWithOrigin: offset)
-    let finalFrame = translatedFrame(baseFrame, for: scrollPosition, offset: offset)
-    return LayoutItem(itemType: .day(day), frame: finalFrame)
+    let baseDayFrame = frameProvider.frameOfDay(day, inMonthWithOrigin: offset)
+    let proposedDayFrame = proposedScrollToItemFrame(
+      fromBaseFrame: baseDayFrame,
+      for: scrollPosition,
+      offset: offset)
+    let proposedMonthOrigin = frameProvider.originOfMonth(
+      containing: LayoutItem(itemType: .day(day), frame: proposedDayFrame))
+    let proposedMonthFrame = frameProvider.frameOfMonth(day.month, withOrigin: proposedMonthOrigin)
+    let finalDayFrame = correctedScrollToItemFrameForContentBoundaries(
+      fromProposedFrame: proposedDayFrame,
+      ofTargetInMonth: day.month,
+      withFrame: proposedMonthFrame,
+      bounds: CGRect(origin: offset, size: size))
+    return LayoutItem(itemType: .day(day), frame: finalDayFrame)
   }
 
   func detailsForVisibleItems(
@@ -785,8 +805,8 @@ final class VisibleItemsProvider {
     }
   }
 
-  private func translatedFrame(
-    _ frame: CGRect,
+  private func proposedScrollToItemFrame(
+    fromBaseFrame frame: CGRect,
     for scrollPosition: CalendarViewScrollPosition,
     offset: CGPoint)
     -> CGRect
@@ -826,6 +846,84 @@ final class VisibleItemsProvider {
       }
 
       return CGRect(x: x, y: frame.minY, width: frame.width, height: frame.height)
+    }
+  }
+
+  private func correctedScrollToItemFrameForContentBoundaries(
+    fromProposedFrame proposedFrame: CGRect,
+    ofTargetInMonth month: Month,
+    withFrame monthFrame: CGRect,
+    bounds: CGRect)
+    -> CGRect
+  {
+    var minimumScrollOffset: CGFloat?
+    var maximumScrollOffset: CGFloat?
+
+    var currentMonth = month
+    var currentMonthFrame = monthFrame
+
+    // Look backwards for boundary-determining months
+    while bounds.contains(currentMonthFrame.origin), minimumScrollOffset == nil {
+      determineContentBoundariesIfNeeded(
+        for: currentMonth,
+        withFrame: currentMonthFrame,
+        inBounds: bounds,
+        minimumScrollOffset: &minimumScrollOffset,
+        maximumScrollOffset: &maximumScrollOffset)
+
+      let previousMonth = calendar.month(byAddingMonths: -1, to: currentMonth)
+      let previousMonthOrigin = frameProvider.originOfMonth(
+        previousMonth,
+        beforeMonthWithOrigin: currentMonthFrame.origin)
+      let previousMonthFrame = frameProvider.frameOfMonth(
+        previousMonth,
+        withOrigin: previousMonthOrigin)
+
+      currentMonth = previousMonth
+      currentMonthFrame = previousMonthFrame
+    }
+
+    // Look forwards for boundary-determining months
+    currentMonth = month
+    currentMonthFrame = monthFrame
+    while
+      bounds.contains(CGPoint(x: currentMonthFrame.maxX, y: currentMonthFrame.maxY)),
+      maximumScrollOffset == nil
+    {
+      determineContentBoundariesIfNeeded(
+        for: currentMonth,
+        withFrame: currentMonthFrame,
+        inBounds: bounds,
+        minimumScrollOffset: &minimumScrollOffset,
+        maximumScrollOffset: &maximumScrollOffset)
+
+      let nextMonth = calendar.month(byAddingMonths: 1, to: currentMonth)
+      let nextMonthOrigin = frameProvider.originOfMonth(
+        nextMonth,
+        afterMonthWithOrigin: currentMonthFrame.origin)
+      let nextMonthFrame = frameProvider.frameOfMonth(nextMonth, withOrigin: nextMonthOrigin)
+
+      currentMonth = nextMonth
+      currentMonthFrame = nextMonthFrame
+    }
+
+    // Adjust the proposed frame if we're near a boundary so that the final frame is valid
+    if let minimumScrollOffset = minimumScrollOffset {
+      switch content.monthsLayout {
+      case .vertical:
+        return proposedFrame.applying(.init(translationX: 0, y: bounds.minY - minimumScrollOffset))
+      case .horizontal:
+        return proposedFrame.applying(.init(translationX: bounds.minX - minimumScrollOffset, y: 0))
+      }
+    } else if let maximumScrollOffset = maximumScrollOffset {
+      switch content.monthsLayout {
+      case .vertical:
+        return proposedFrame.applying(.init(translationX: 0, y: bounds.maxY - maximumScrollOffset))
+      case .horizontal:
+        return proposedFrame.applying(.init(translationX: bounds.maxX - maximumScrollOffset, y: 0))
+      }
+    } else {
+      return proposedFrame
     }
   }
 

--- a/Sources/Internal/VisibleItemsProvider.swift
+++ b/Sources/Internal/VisibleItemsProvider.swift
@@ -849,6 +849,15 @@ final class VisibleItemsProvider {
     }
   }
 
+  /// This function takes a proposed frame for a target item toward which we're programmatically scrolling, and adjusts it such that it's a
+  /// valid frame when the calendar is at rest / not being overscrolled.
+  ///
+  /// A concrete example of when we'd need this correction is when we scroll to the first visible month with a scroll position of
+  /// `.centered` - the proposed frame would position the month in the middle of the bounds, even though that is not a valid resting
+  /// position for that month. Keep in mind that the first month in the calendar is going to be adjacent with the top / leading edge,
+  /// depending on whether the months layout is `.vertical` or `.horizontal`, respectively. This function recognizes that
+  /// situation by looking to see if we're close to the beginning / end of the calendar's content, and determines a correct final frame for
+  /// a programmatic scroll.
   private func correctedScrollToItemFrameForContentBoundaries(
     fromProposedFrame proposedFrame: CGRect,
     ofTargetInMonth month: Month,

--- a/Sources/Internal/VisibleItemsProvider.swift
+++ b/Sources/Internal/VisibleItemsProvider.swift
@@ -79,7 +79,7 @@ final class VisibleItemsProvider {
 
   func detailsForVisibleItems(
     surroundingPreviouslyVisibleLayoutItem previouslyVisibleLayoutItem: LayoutItem,
-    inBounds bounds: CGRect)
+    offset: CGPoint)
     -> VisibleItemsDetails
   {
     var visibleItems = Set<VisibleCalendarItem>()
@@ -107,6 +107,7 @@ final class VisibleItemsProvider {
     //
     // One can think of `extendedBounds`'s purpose as increasing the layout region to compensate
     // for extremely fast scrolling / large per-frame bounds differences.
+    let bounds = CGRect(origin: offset, size: size)
     let minX = min(bounds.minX, previouslyVisibleLayoutItem.frame.minX)
     let minY = min(bounds.minY, previouslyVisibleLayoutItem.frame.minY)
     let maxX = max(bounds.maxX, previouslyVisibleLayoutItem.frame.maxX)

--- a/Sources/Public/CalendarView.swift
+++ b/Sources/Public/CalendarView.swift
@@ -186,7 +186,7 @@ public final class CalendarView: UIView {
 
     let currentVisibleItemsDetails = visibleItemsProvider.detailsForVisibleItems(
       surroundingPreviouslyVisibleLayoutItem: anchorLayoutItem,
-      inBounds: scrollView.bounds)
+      offset: scrollView.contentOffset)
     self.anchorLayoutItem = currentVisibleItemsDetails.centermostLayoutItem
 
     updateVisibleViews(

--- a/Sources/Public/CalendarViewScrollPosition.swift
+++ b/Sources/Public/CalendarViewScrollPosition.swift
@@ -17,7 +17,7 @@ import CoreGraphics
 
 // MARK: - CalendarViewScrollPosition
 
-/// The scroll position for programatically scrolling to a day or month.
+/// The scroll position for programmatically scrolling to a day or month.
 public enum CalendarViewScrollPosition {
 
   /// The position that centers the day or month in the visible bounds of the calendar along its scrollable axis.

--- a/Tests/VisibleItemsProviderTests.swift
+++ b/Tests/VisibleItemsProviderTests.swift
@@ -200,7 +200,7 @@ final class VisibleItemsProviderTests: XCTestCase {
       offset: CGPoint(x: 0, y: 200),
       scrollPosition: .lastFullyVisiblePosition)
     XCTAssert(
-      dayItem2.description == "[itemType: .layoutItemType(.day(2020-01-28)), frame: (96.5, 644.5, 35.5, 35.5)]",
+      dayItem2.description == "[itemType: .layoutItemType(.day(2020-01-28)), frame: (96.5, 391.5, 35.5, 35.5)]",
       "Unexpected initial day item.")
 
     let dayItem3 = verticalPartialMonthVisibleItemsProvider.anchorDayItem(
@@ -208,7 +208,7 @@ final class VisibleItemsProviderTests: XCTestCase {
       offset: CGPoint(x: 0, y: 600),
       scrollPosition: .centered)
     XCTAssert(
-      dayItem3.description == "[itemType: .layoutItemType(.day(2020-01-28)), frame: (96.5, 822.0, 35.5, 36.0)]",
+      dayItem3.description == "[itemType: .layoutItemType(.day(2020-01-28)), frame: (96.5, 791.5, 35.5, 35.5)]",
       "Unexpected initial day item.")
   }
 

--- a/Tests/VisibleItemsProviderTests.swift
+++ b/Tests/VisibleItemsProviderTests.swift
@@ -247,7 +247,7 @@ final class VisibleItemsProviderTests: XCTestCase {
       surroundingPreviouslyVisibleLayoutItem: LayoutItem(
         itemType: .monthHeader(Month(era: 1, year: 2020, month: 03, isInGregorianCalendar: true)),
         frame: CGRect(x: 0, y: 200, width: 320, height: 50)),
-      inBounds: CGRect(x: 0, y: 150, width: 320, height: 480))
+      offset: CGPoint(x: 0, y: 150))
 
     let expectedVisibleItemDescriptions: Set<String> = [
       "[itemType: .layoutItemType(.day(2020-03-23)), frame: (50.5, 503.0, 36.0, 35.5)]",
@@ -317,7 +317,7 @@ final class VisibleItemsProviderTests: XCTestCase {
       surroundingPreviouslyVisibleLayoutItem: LayoutItem(
         itemType: .monthHeader(Month(era: 1, year: 2020, month: 06, isInGregorianCalendar: true)),
         frame: CGRect(x: 0, y: 450, width: 320, height: 40)),
-      inBounds: CGRect(x: 0, y: 450, width: 320, height: 480))
+      offset: CGPoint(x: 0, y: 450))
 
     let expectedVisibleItemDescriptions: Set<String> = [
       "[itemType: .layoutItemType(.day(2020-06-18)), frame: (188.0, 641.5, 35.5, 35.5)]",
@@ -382,7 +382,7 @@ final class VisibleItemsProviderTests: XCTestCase {
       surroundingPreviouslyVisibleLayoutItem: LayoutItem(
         itemType: .monthHeader(Month(era: 1, year: 2020, month: 01, isInGregorianCalendar: true)),
         frame: CGRect(x: 0, y: 200, width: 320, height: 50)),
-      inBounds: CGRect(x: 0, y: 150, width: 320, height: 480))
+      offset: CGPoint(x: 0, y: 150))
 
     let expectedVisibleItemDescriptions: Set<String> = [
       "[itemType: .layoutItemType(.dayOfWeekInMonth(.sixth, 2020-01)), frame: (233.5, 280.0, 36.0, 35.5)]",
@@ -428,7 +428,7 @@ final class VisibleItemsProviderTests: XCTestCase {
       surroundingPreviouslyVisibleLayoutItem: LayoutItem(
         itemType: .monthHeader(Month(era: 1, year: 2020, month: 05, isInGregorianCalendar: true)),
         frame: CGRect(x: 250, y: 0, width: 300, height: 50)),
-      inBounds: CGRect(x: 100, y: 0, width: 300, height: 480))
+      offset: CGPoint(x: 100, y: 0))
 
     let expectedVisibleItemDescriptions: Set<String> = [
       "[itemType: .layoutItemType(.day(2020-05-06)), frame: (383.5, 185.5, 33.0, 33.0)]",
@@ -497,7 +497,7 @@ final class VisibleItemsProviderTests: XCTestCase {
       surroundingPreviouslyVisibleLayoutItem: LayoutItem(
         itemType: .monthHeader(Month(era: 1, year: 2020, month: 12, isInGregorianCalendar: true)),
         frame: CGRect(x: 0, y: 3000, width: 320, height: 50)),
-      inBounds: CGRect(x: 0, y: 150, width: 320, height: 480))
+      offset: CGPoint(x: 0, y: 150))
 
     let expectedVisibleItemDescriptions: Set<String> = [
       "[itemType: .layoutItemType(.day(2020-05-08)), frame: (233.5, 215.0, 36.0, 35.5)]",
@@ -567,7 +567,7 @@ final class VisibleItemsProviderTests: XCTestCase {
       surroundingPreviouslyVisibleLayoutItem: LayoutItem(
         itemType: .monthHeader(Month(era: 1, year: 2020, month: 01, isInGregorianCalendar: true)),
         frame: CGRect(x: 0, y: 0, width: 320, height: 50)),
-      inBounds: CGRect(x: 0, y: -50, width: 320, height: 480))
+      offset: CGPoint(x: 0, y: -50))
 
     let expectedVisibleItemDescriptions: Set<String> = [
       "[itemType: .layoutItemType(.dayOfWeekInMonth(.sixth, 2020-01)), frame: (233.5, 80.0, 36.0, 35.5)]",
@@ -630,7 +630,7 @@ final class VisibleItemsProviderTests: XCTestCase {
       surroundingPreviouslyVisibleLayoutItem: LayoutItem(
         itemType: .monthHeader(Month(era: 1, year: 2020, month: 01, isInGregorianCalendar: true)),
         frame: CGRect(x: 0, y: 45, width: 320, height: 40)),
-      inBounds: CGRect(x: 0, y: 50, width: 320, height: 480))
+      offset: CGPoint(x: 0, y: 50))
 
     let expectedVisibleItemDescriptions: Set<String> = [
       "[itemType: .layoutItemType(.day(2020-01-14)), frame: (96.5, 236.5, 35.5, 35.5)]",
@@ -696,7 +696,7 @@ final class VisibleItemsProviderTests: XCTestCase {
       surroundingPreviouslyVisibleLayoutItem: LayoutItem(
         itemType: .monthHeader(Month(era: 1, year: 2020, month: 12, isInGregorianCalendar: true)),
         frame: CGRect(x: 0, y: 690, width: 320, height: 50)),
-      inBounds: CGRect(x: 0, y: 690, width: 320, height: 480))
+      offset: CGPoint(x: 0, y: 690))
 
     let expectedVisibleItemDescriptions: Set<String> = [
       "[itemType: .layoutItemType(.dayOfWeekInMonth(.fourth, 2020-12)), frame: (142.0, 770.0, 36.0, 35.5)]",
@@ -729,7 +729,7 @@ final class VisibleItemsProviderTests: XCTestCase {
       surroundingPreviouslyVisibleLayoutItem: LayoutItem(
         itemType: .monthHeader(Month(era: 1, year: 2020, month: 12, isInGregorianCalendar: true)),
         frame: CGRect(x: 1200, y: 0, width: 300, height: 50)),
-      inBounds: CGRect(x: 1000, y: 0, width: 300, height: 480))
+      offset: CGPoint(x: 1000, y: 0))
 
     let expectedVisibleItemDescriptions: Set<String> = [
       "[itemType: .layoutItemType(.day(2020-11-24)), frame: (975.5, 291.5, 33.0, 33.0)]",
@@ -756,7 +756,7 @@ final class VisibleItemsProviderTests: XCTestCase {
       "[itemType: .layoutItemType(.day(2020-11-26)), frame: (1061.5, 291.5, 33.0, 33.0)]",
       "[itemType: .layoutItemType(.day(2020-11-20)), frame: (1104.5, 238.5, 32.5, 33.0)]",
       "[itemType: .layoutItemType(.day(2020-12-14)), frame: (1248.0, 238.5, 32.5, 33.0)]",
-      "[itemType: .overlayItem(.monthHeader(2020-11)), frame: (1000.0, 0.0, 300.0, 480.0)]",
+      "[itemType: .overlayItem(.monthHeader(2020-11)), frame: (1000.0, 0.0, 320.0, 480.0)]",
       "[itemType: .layoutItemType(.dayOfWeekInMonth(.last, 2020-11)), frame: (1147.0, 80.0, 33.0, 33.0)]",
       "[itemType: .layoutItemType(.day(2020-12-13)), frame: (1205.0, 238.5, 33.0, 33.0)]",
       "[itemType: .layoutItemType(.day(2020-11-03)), frame: (975.5, 133.0, 33.0, 32.5)]",


### PR DESCRIPTION
## Details

This fixes a bug in the `scrollToDay` and `scrollToMonth` functions. Prior to this change, scrolling to an item that was close to the content boundary could result in a temporary layout glitch. 

For example, if you scroll to the first visible month with a scroll position of `.centered`, the calendar will try to layout with the assumption that having the first visible month centered on the screen was a valid position, which it's not (the first visible month needs to be at the start of the scrollable content - it can't be centered unless you're over-scrolling / rubber banding, neither of which are valid final resting positions).

You can see an example of this bug when programmatically scrolling to the first visible day in the calendar with scroll position set to `.lastFullyVisiblePosition`

| Before | After |
| ---- | ---- |
| ![ezgif-6-f4210c1b82de](https://user-images.githubusercontent.com/746571/85917157-a96f8d80-b80c-11ea-9ebd-f21cd2339a1b.gif) | ![ezgif-6-6091550d0003](https://user-images.githubusercontent.com/746571/85917174-c99f4c80-b80c-11ea-9730-6f1919638711.gif) | 

2 of the commits are small refactors. If you review the commits in order, they build on one another in a pretty straightforward way.

## Related Issue

N/A

## Motivation and Context

Bug fix

## How Has This Been Tested

Tested

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
