### PR TITLE
Bk/fix scroll to item bug 2

### DIFF
--- a/HorizonCalendar.podspec
+++ b/HorizonCalendar.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name = "HorizonCalendar"
-  spec.version = "1.1.1"
+  spec.version = "1.1.2"
   spec.license = "Apache License, Version 2.0"
   spec.summary = "A declarative, performant, calendar UI component that supports use cases ranging from simple date pickers to fully-featured calendar apps."
 

--- a/HorizonCalendar.xcodeproj/project.pbxproj
+++ b/HorizonCalendar.xcodeproj/project.pbxproj
@@ -528,7 +528,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.1;
+				MARKETING_VERSION = 1.1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.HorizonCalendar;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -562,7 +562,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.1;
+				MARKETING_VERSION = 1.1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.HorizonCalendar;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Sources/Internal/VisibleItemsProvider.swift
+++ b/Sources/Internal/VisibleItemsProvider.swift
@@ -872,7 +872,10 @@ final class VisibleItemsProvider {
     var currentMonthFrame = monthFrame
 
     // Look backwards for boundary-determining months
-    while bounds.contains(currentMonthFrame.origin), minimumScrollOffset == nil {
+    while
+      bounds.contains(currentMonthFrame.origin.alignedToPixels(forScreenWithScale: scale)),
+      minimumScrollOffset == nil
+    {
       determineContentBoundariesIfNeeded(
         for: currentMonth,
         withFrame: currentMonthFrame,
@@ -896,7 +899,9 @@ final class VisibleItemsProvider {
     currentMonth = month
     currentMonthFrame = monthFrame
     while
-      bounds.contains(CGPoint(x: currentMonthFrame.maxX, y: currentMonthFrame.maxY)),
+      bounds.contains(
+        CGPoint(x: currentMonthFrame.maxX - 1, y: currentMonthFrame.maxY - 1)
+          .alignedToPixels(forScreenWithScale: scale)),
       maximumScrollOffset == nil
     {
       determineContentBoundariesIfNeeded(
@@ -917,22 +922,24 @@ final class VisibleItemsProvider {
     }
 
     // Adjust the proposed frame if we're near a boundary so that the final frame is valid
-    if let minimumScrollOffset = minimumScrollOffset {
-      switch content.monthsLayout {
-      case .vertical:
+    switch content.monthsLayout {
+    case .vertical:
+      if let minimumScrollOffset = minimumScrollOffset, minimumScrollOffset > bounds.minY {
         return proposedFrame.applying(.init(translationX: 0, y: bounds.minY - minimumScrollOffset))
-      case .horizontal:
-        return proposedFrame.applying(.init(translationX: bounds.minX - minimumScrollOffset, y: 0))
-      }
-    } else if let maximumScrollOffset = maximumScrollOffset {
-      switch content.monthsLayout {
-      case .vertical:
+      } else if let maximumScrollOffset = maximumScrollOffset, maximumScrollOffset < bounds.maxY {
         return proposedFrame.applying(.init(translationX: 0, y: bounds.maxY - maximumScrollOffset))
-      case .horizontal:
-        return proposedFrame.applying(.init(translationX: bounds.maxX - maximumScrollOffset, y: 0))
+      } else {
+        return proposedFrame
       }
-    } else {
-      return proposedFrame
+
+    case .horizontal:
+      if let minimumScrollOffset = minimumScrollOffset, minimumScrollOffset > bounds.minX {
+        return proposedFrame.applying(.init(translationX: bounds.minX - minimumScrollOffset, y: 0))
+      } else if let maximumScrollOffset = maximumScrollOffset, maximumScrollOffset < bounds.maxX {
+        return proposedFrame.applying(.init(translationX: bounds.maxX - maximumScrollOffset, y: 0))
+      } else {
+        return proposedFrame
+      }
     }
   }
 

--- a/Sources/Internal/VisibleItemsProvider.swift
+++ b/Sources/Internal/VisibleItemsProvider.swift
@@ -620,7 +620,6 @@ final class VisibleItemsProvider {
             determineContentBoundariesIfNeeded(
               for: day.month,
               withFrame: monthFrame,
-              inBounds: bounds,
               minimumScrollOffset: &minimumScrollOffset,
               maximumScrollOffset: &maximumScrollOffset)
           }
@@ -661,11 +660,10 @@ final class VisibleItemsProvider {
   private func determineContentBoundariesIfNeeded(
     for month: Month,
     withFrame monthFrame: CGRect,
-    inBounds bounds: CGRect,
     minimumScrollOffset: inout CGFloat?,
     maximumScrollOffset: inout CGFloat?)
   {
-    if month == content.dayRange.lowerBound.month, monthFrame.intersects(bounds) {
+    if month == content.dayRange.lowerBound.month {
       switch content.monthsLayout {
       case .vertical(let options):
         minimumScrollOffset = monthFrame.minY -
@@ -675,7 +673,7 @@ final class VisibleItemsProvider {
       }
     }
 
-    if month == content.dayRange.upperBound.month, monthFrame.intersects(bounds) {
+    if month == content.dayRange.upperBound.month {
       switch content.monthsLayout {
       case .vertical:
         maximumScrollOffset = monthFrame.maxY
@@ -879,7 +877,6 @@ final class VisibleItemsProvider {
       determineContentBoundariesIfNeeded(
         for: currentMonth,
         withFrame: currentMonthFrame,
-        inBounds: bounds,
         minimumScrollOffset: &minimumScrollOffset,
         maximumScrollOffset: &maximumScrollOffset)
 
@@ -907,7 +904,6 @@ final class VisibleItemsProvider {
       determineContentBoundariesIfNeeded(
         for: currentMonth,
         withFrame: currentMonthFrame,
-        inBounds: bounds,
         minimumScrollOffset: &minimumScrollOffset,
         maximumScrollOffset: &maximumScrollOffset)
 

--- a/Tests/VisibleItemsProviderTests.swift
+++ b/Tests/VisibleItemsProviderTests.swift
@@ -170,7 +170,7 @@ final class VisibleItemsProviderTests: XCTestCase {
       offset: CGPoint(x: 0, y: 200),
       scrollPosition: .firstFullyVisiblePosition)
     XCTAssert(
-      dayItem2.description == "[itemType: .layoutItemType(.day(2020-12-31)), frame: (188.0, 200.0, 35.5, 35.5)]",
+      dayItem2.description == "[itemType: .layoutItemType(.day(2020-12-31)), frame: (188.0, 644.5, 35.5, 35.5)]",
       "Unexpected initial day item.")
 
     let dayItem3 = verticalPinnedDaysOfWeekVisibleItemsProvider.anchorDayItem(
@@ -178,7 +178,7 @@ final class VisibleItemsProviderTests: XCTestCase {
       offset: CGPoint(x: 0, y: 200),
       scrollPosition: .centered)
     XCTAssert(
-      dayItem3.description == "[itemType: .layoutItemType(.day(2020-12-31)), frame: (188.0, 440.0, 35.5, 35.5)]",
+      dayItem3.description == "[itemType: .layoutItemType(.day(2020-12-31)), frame: (188.0, 644.5, 35.5, 35.5)]",
       "Unexpected initial day item.")
 
     let dayItem4 = horizontalVisibleItemsProvider.anchorDayItem(

--- a/Tests/VisibleItemsProviderTests.swift
+++ b/Tests/VisibleItemsProviderTests.swift
@@ -156,6 +156,48 @@ final class VisibleItemsProviderTests: XCTestCase {
       "Unexpected initial day item.")
   }
 
+  func testInitialVisiblePositionsNeedingCorrection() {
+    let dayItem1 = verticalVisibleItemsProvider.anchorDayItem(
+      for: Day(month: Month(era: 1, year: 2020, month: 01, isInGregorianCalendar: true), day: 01),
+      offset: CGPoint(x: 0, y: 400),
+      scrollPosition: .lastFullyVisiblePosition)
+    XCTAssert(
+      dayItem1.description == "[itemType: .layoutItemType(.day(2020-01-01)), frame: (142.0, 535.5, 36.0, 36.0)]",
+      "Unexpected initial day item.")
+
+    let dayItem2 = verticalVisibleItemsProvider.anchorDayItem(
+      for: Day(month: Month(era: 1, year: 2020, month: 12, isInGregorianCalendar: true), day: 31),
+      offset: CGPoint(x: 0, y: 200),
+      scrollPosition: .firstFullyVisiblePosition)
+    XCTAssert(
+      dayItem2.description == "[itemType: .layoutItemType(.day(2020-12-31)), frame: (188.0, 200.0, 35.5, 35.5)]",
+      "Unexpected initial day item.")
+
+    let dayItem3 = verticalPinnedDaysOfWeekVisibleItemsProvider.anchorDayItem(
+      for: Day(month: Month(era: 1, year: 2020, month: 12, isInGregorianCalendar: true), day: 31),
+      offset: CGPoint(x: 0, y: 200),
+      scrollPosition: .centered)
+    XCTAssert(
+      dayItem3.description == "[itemType: .layoutItemType(.day(2020-12-31)), frame: (188.0, 440.0, 35.5, 35.5)]",
+      "Unexpected initial day item.")
+
+    let dayItem4 = horizontalVisibleItemsProvider.anchorDayItem(
+      for: Day(month: Month(era: 1, year: 2020, month: 01, isInGregorianCalendar: true), day: 01),
+      offset: CGPoint(x: 600, y: 0),
+      scrollPosition: .lastFullyVisiblePosition)
+    XCTAssert(
+      dayItem4.description == "[itemType: .layoutItemType(.day(2020-01-01)), frame: (733.5, 133.0, 33.0, 32.5)]",
+      "Unexpected initial day item.")
+
+    let dayItem5 = horizontalVisibleItemsProvider.anchorDayItem(
+      for: Day(month: Month(era: 1, year: 2020, month: 12, isInGregorianCalendar: true), day: 28),
+      offset: CGPoint(x: 100, y: 0),
+      scrollPosition: .firstFullyVisiblePosition)
+    XCTAssert(
+      dayItem5.description == "[itemType: .layoutItemType(.day(2020-12-28)), frame: (168.0, 344.5, 32.5, 32.5)]",
+      "Unexpected initial day item.")
+  }
+
   func testVerticalPinnedDaysOfWeekInitialVisibleDay() {
     let day = Day(month: Month(era: 1, year: 2020, month: 04, isInGregorianCalendar: true), day: 20)
 


### PR DESCRIPTION
## Details

After I merged this https://github.com/airbnb/HorizonCalendar/pull/17, I found some other bugs and edge cases. I've improved the logic and tested extensively, including dedicated unit tests for these cases.

Ass a reminder, this is fixing the case where you tell the calendar to scroll to the first visible date with a `.centered` scroll position, for example, which is not possible since the first visible date won't be in a natural resting position if it's centered. This logic corrects for that and ensures that our target scroll position is always a valid resting state for the calendar's scroll view.

## Related Issue

N/A

## Motivation and Context

Trying to get this working perfectly!

## How Has This Been Tested

Testing on real device and added unit tests.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
