### PR TITLE
Bk/scroll behavior improvements

### DIFF
--- a/HorizonCalendar.podspec
+++ b/HorizonCalendar.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name = "HorizonCalendar"
-  spec.version = "1.1.2"
+  spec.version = "1.1.3"
   spec.license = "Apache License, Version 2.0"
   spec.summary = "A declarative, performant, calendar UI component that supports use cases ranging from simple date pickers to fully-featured calendar apps."
 

--- a/HorizonCalendar.xcodeproj/project.pbxproj
+++ b/HorizonCalendar.xcodeproj/project.pbxproj
@@ -528,7 +528,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.2;
+				MARKETING_VERSION = 1.1.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.HorizonCalendar;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -562,7 +562,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.2;
+				MARKETING_VERSION = 1.1.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.HorizonCalendar;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Tests/ScrollMetricsMutatorTests.swift
+++ b/Tests/ScrollMetricsMutatorTests.swift
@@ -26,19 +26,21 @@ final class ScrollMetricsMutatorTests: XCTestCase {
     verticalScrollMetricsProvider = MockScrollMetricsProvider()
     horizontalScrollMetricsProvider = MockScrollMetricsProvider()
 
-    let initialBounds = CGRect(x: 0, y: 0, width: 320, height: 480)
+    let initialSize = CGSize(width: 320, height: 480)
 
     verticalScrollMetricsMutator = ScrollMetricsMutator(
       scrollMetricsProvider: verticalScrollMetricsProvider,
-      bounds: initialBounds,
       scrollAxis: .vertical)
     verticalScrollMetricsMutator.setUpInitialMetricsIfNeeded()
+    verticalScrollMetricsMutator.updateContentSizePerpendicularToScrollAxis(
+      viewportSize: initialSize)
 
     horizontalScrollMetricsMutator = ScrollMetricsMutator(
       scrollMetricsProvider: horizontalScrollMetricsProvider,
-      bounds: initialBounds,
       scrollAxis: .horizontal)
     horizontalScrollMetricsMutator.setUpInitialMetricsIfNeeded()
+    horizontalScrollMetricsMutator.updateContentSizePerpendicularToScrollAxis(
+      viewportSize: initialSize)
   }
 
   // MARK: Initial setup

--- a/Tests/VisibleItemsProviderTests.swift
+++ b/Tests/VisibleItemsProviderTests.swift
@@ -599,7 +599,9 @@ final class VisibleItemsProviderTests: XCTestCase {
       "Unexpected centermost layout item.")
 
     XCTAssert(details.minimumScrollOffset == nil, "Unexpected minimum scroll offset.")
-    XCTAssert(details.maximumScrollOffset == nil, "Unexpected maximum scroll offset.")
+    XCTAssert(
+      details.maximumScrollOffset?.alignedToPixel(forScreenWithScale: 2) == 3394.5,
+      "Unexpected maximum scroll offset.")
   }
 
   // MARK: Scrolled to content boundary tests


### PR DESCRIPTION
## Details

This PR fixes several issues with how the internal scroll view's state was handled. Overall, it simplifies the looping logic, and hardens the boundary-determining logic so that it's impossible to scroll fast enough that the calendar is put into a state where all visible items have been scrolled past (difficult to do, but if you scroll reallllyyy fast it's possible to skip right over a boundary-determining month).

- Simplify the `scrollMetricsMutator` (responsible for looping the content offset and setting the content inset to create boundaries). Instead of basing calculations on the current bounds / height, the `scrollMetricsMutator` now uses constants to determine its minimum offset, maximum offset, and looping region size.
- Fixes some bugs with inset handling
- Ensure that there's no way to scroll so fast that we skip right over a boundary month. This is done by looking for a boundary-determining month in the `extendedBounds`, rather than the visible bounds. The extended bounds always encapsulates the current scroll position and some item from the last frame, enabling us to be sure that we're never skipping over a large portion of content just because our scroll velocity was crazy fast.

Put all together, the changes in this PR fix https://github.com/airbnb/HorizonCalendar/issues/18 - now, things behave correctly when used with an expanding / collapsing nav bar.

| Before | After |
| ---- | ---- |
| ![ezgif-1-8e045c99086f](https://user-images.githubusercontent.com/746571/86231221-15246400-bb47-11ea-8495-dcc3db0295ce.gif) | ![ezgif-1-544e48721a67](https://user-images.githubusercontent.com/746571/86231297-31c09c00-bb47-11ea-9c4f-63c6da660f14.gif) |

## Related Issue

https://github.com/airbnb/HorizonCalendar/issues/18

## Motivation and Context

Cleaning up and simplifying this code was overdue. This also paves the way for supporting proper automatic content inset adjustment behavior and manual content inset preferences (for which there's also an open issue).

## How Has This Been Tested

Testing on my phone and in simulator.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
