### PR TITLE
Deprecate public scroll view delegate functions

### DIFF
--- a/Sources/Public/CalendarView.swift
+++ b/Sources/Public/CalendarView.swift
@@ -73,7 +73,7 @@ public final class CalendarView: UIView {
   /// A closure (that is retained) that is invoked inside `scrollViewDidEndDragging(_: willDecelerate:)`.
   public var didEndDragging: ((_ visibleDayRange: DayRange) -> Void)?
 
-  /// A closure that is retained that is invoked inside `scrollViewDidEndDecelerating(_:)`.
+  /// A closure (that is retained) that is invoked inside `scrollViewDidEndDecelerating(_:)`.
   public var didEndDecelerating: ((_ visibleDayRange: DayRange) -> Void)?
 
   /// Whether or not the calendar's scroll view is currently overscrolling, i.e, whether the rubber-banding or bouncing effect is in

--- a/Sources/Public/CalendarView.swift
+++ b/Sources/Public/CalendarView.swift
@@ -655,6 +655,10 @@ public final class CalendarView: UIView {
 
 extension CalendarView: UIScrollViewDelegate {
 
+  @available(
+    *,
+    deprecated,
+    message: "Do not invoke this function directly, as it is only intended to be called from the internal implementation of `CalendarView`. This will be removed in a future major release.")
   public func scrollViewDidScroll(_ scrollView: UIScrollView) {
     if let anchorLayoutItem = anchorLayoutItem {
       scrollView.performWithoutNotifyingDelegate {
@@ -682,6 +686,10 @@ extension CalendarView: UIScrollViewDelegate {
     setNeedsLayout()
   }
 
+  @available(
+    *,
+    deprecated,
+    message: "Do not invoke this function directly, as it is only intended to be called from the internal implementation of `CalendarView`. This will be removed in a future major release.")
   public func scrollViewDidEndDragging(
     _ scrollView: UIScrollView,
     willDecelerate decelerate: Bool)
@@ -690,6 +698,10 @@ extension CalendarView: UIScrollViewDelegate {
     didEndDecelerating?(visibleDayRange)
   }
 
+  @available(
+    *,
+    deprecated,
+    message: "Do not invoke this function directly, as it is only intended to be called from the internal implementation of `CalendarView`. This will be removed in a future major release.")
   public func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
     guard let visibleDayRange = visibleDayRange else { return }
     didEndDecelerating?(visibleDayRange)


### PR DESCRIPTION
## Details

This deprecates the public `UIScrollViewDelegate` functions on `CalendarView` - in `v2.0`, I'll hide this conformance in an internal type so that they won't even show up when users look at the autocomplete options after typing `calendarView.`.

## Related Issue

N/A

## Motivation and Context

Prepping for 2.0 release which will make several API changes, including removing these functions from the public interface.

## How Has This Been Tested

Tested using Xcode autocomplete.
![image](https://user-images.githubusercontent.com/746571/86884357-4e5d5680-c0a8-11ea-8d39-d4fbfd527ba1.png)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
