### PR TITLE
Make Day & Month inits public

### DIFF
--- a/Sources/Public/Day.swift
+++ b/Sources/Public/Day.swift
@@ -23,7 +23,7 @@ public struct Day {
 
   // MARK: Lifecycle
 
-  init(month: Month, day: Int) {
+  public init(month: Month, day: Int) {
     self.month = month
     self.day = day
   }

--- a/Sources/Public/Month.swift
+++ b/Sources/Public/Month.swift
@@ -23,7 +23,7 @@ public struct Month {
 
   // MARK: Lifecycle
 
-  init(era: Int, year: Int, month: Int, isInGregorianCalendar: Bool) {
+  public init(era: Int, year: Int, month: Int, isInGregorianCalendar: Bool) {
     self.era = era
     self.year = year
     self.month = month


### PR DESCRIPTION
## Details

Made `Day` and `Month` structs' initializers public.

## Related Issue

n/a

## Motivation and Context

Solves the case where the user wants to programmatically select a range of dates. To do so, there are two problems the user has to solve

1. Providing the right `Set<ClosedRange<Date>>` to the `DayRangeItemProvider`
2. Having the right `DayRangeItemProvider` enum to apply the appropriate selection style for start/end dates

The first problem can be easily solved by the user. However, the second one can not be solved as both `Day` and `Month` structs' initializers' levels are `internal` and are not accessible to the user.

## How Has This Been Tested

No significant changes have been made to the codebase. Therefore believe that no additional tests have to be written.

## Types of change
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
