### PR TITLE
Simplify Calendar Item Model creation by introducing `CalendarItemViewRepresentable`

### DIFF
--- a/HorizonCalendar.xcodeproj/project.pbxproj
+++ b/HorizonCalendar.xcodeproj/project.pbxproj
@@ -7,6 +7,11 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		93061FFE24F1AE1700177ECC /* CalendarViewContent+CalendarItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93061FFC24F1AE1700177ECC /* CalendarViewContent+CalendarItem.swift */; };
+		93061FFF24F1AE1700177ECC /* CalendarItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93061FFD24F1AE1700177ECC /* CalendarItem.swift */; };
+		938DA40F24BEEB1A008A3B47 /* CalendarItemViewRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 938DA40E24BEEB1A008A3B47 /* CalendarItemViewRepresentable.swift */; };
+		938DA41124BEFFCB008A3B47 /* AnyCalendarItemModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 938DA41024BEFFCB008A3B47 /* AnyCalendarItemModel.swift */; };
+		938DA41324BF0FFF008A3B47 /* DefaultItemProviders.swift in Sources */ = {isa = PBXBuildFile; fileRef = 938DA41224BF0FFF008A3B47 /* DefaultItemProviders.swift */; };
 		9396F3CC2483261B008AD306 /* HorizonCalendar.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9396F3C22483261B008AD306 /* HorizonCalendar.framework */; };
 		9396F3DD24832715008AD306 /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 9396F3DC24832715008AD306 /* README.md */; };
 		9396F3DF248327C2008AD306 /* LICENSE in Resources */ = {isa = PBXBuildFile; fileRef = 9396F3DE248327C2008AD306 /* LICENSE */; };
@@ -14,15 +19,15 @@
 		939E692524837E0300A8BCC7 /* LayoutItemTypeEnumerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 939E691824837E0200A8BCC7 /* LayoutItemTypeEnumerator.swift */; };
 		939E692624837E0300A8BCC7 /* ScrollMetricsMutator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 939E691924837E0200A8BCC7 /* ScrollMetricsMutator.swift */; };
 		939E692724837E0300A8BCC7 /* VisibleItemsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 939E691A24837E0200A8BCC7 /* VisibleItemsProvider.swift */; };
-		939E692824837E0300A8BCC7 /* CalendarItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 939E691B24837E0200A8BCC7 /* CalendarItemView.swift */; };
+		939E692824837E0300A8BCC7 /* ItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 939E691B24837E0200A8BCC7 /* ItemView.swift */; };
 		939E692924837E0300A8BCC7 /* VisibleCalendarItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 939E691C24837E0200A8BCC7 /* VisibleCalendarItem.swift */; };
-		939E692A24837E0300A8BCC7 /* CalendarItemViewReuseManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 939E691D24837E0200A8BCC7 /* CalendarItemViewReuseManager.swift */; };
+		939E692A24837E0300A8BCC7 /* ItemViewReuseManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 939E691D24837E0200A8BCC7 /* ItemViewReuseManager.swift */; };
 		939E692B24837E0300A8BCC7 /* Dictionary+MutatingValueForKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 939E691E24837E0200A8BCC7 /* Dictionary+MutatingValueForKey.swift */; };
 		939E692D24837E0300A8BCC7 /* LayoutItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 939E692024837E0300A8BCC7 /* LayoutItem.swift */; };
 		939E692E24837E0300A8BCC7 /* ScrollToItemContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 939E692124837E0300A8BCC7 /* ScrollToItemContext.swift */; };
 		939E692F24837E0300A8BCC7 /* OffScreenCalendarItemAccessibilityElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 939E692224837E0300A8BCC7 /* OffScreenCalendarItemAccessibilityElement.swift */; };
 		939E693024837E0300A8BCC7 /* FrameProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 939E692324837E0300A8BCC7 /* FrameProvider.swift */; };
-		939E693724837E8700A8BCC7 /* CalendarItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 939E693224837E8700A8BCC7 /* CalendarItem.swift */; };
+		939E693724837E8700A8BCC7 /* CalendarItemModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 939E693224837E8700A8BCC7 /* CalendarItemModel.swift */; };
 		939E693824837E8700A8BCC7 /* CalendarViewScrollPosition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 939E693324837E8700A8BCC7 /* CalendarViewScrollPosition.swift */; };
 		939E693924837E8700A8BCC7 /* MonthsLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 939E693424837E8700A8BCC7 /* MonthsLayout.swift */; };
 		939E693A24837E8700A8BCC7 /* CalendarViewContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 939E693524837E8700A8BCC7 /* CalendarViewContent.swift */; };
@@ -40,6 +45,7 @@
 		939E695C2484B22600A8BCC7 /* VisibleItemsProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 939E694D2484B14400A8BCC7 /* VisibleItemsProviderTests.swift */; };
 		939E695D2484B22A00A8BCC7 /* MonthTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 939E69492484B14400A8BCC7 /* MonthTests.swift */; };
 		93A361F4248332AE00E6544A /* ScreenPixelAlignment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93A361F3248332AE00E6544A /* ScreenPixelAlignment.swift */; };
+		93B6D99E24F0C6220027A60C /* InternalAnyCalendarItemModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93B6D99D24F0C6220027A60C /* InternalAnyCalendarItemModel.swift */; };
 		93E24A70249D915900B856F7 /* CONTRIBUTING.md in Resources */ = {isa = PBXBuildFile; fileRef = 93E24A56249D915900B856F7 /* CONTRIBUTING.md */; };
 		93E24A71249D915900B856F7 /* TECHNICAL_DETAILS.md in Resources */ = {isa = PBXBuildFile; fileRef = 93E24A57249D915900B856F7 /* TECHNICAL_DETAILS.md */; };
 		93FA64EC248CDD3E00A8B7B1 /* MonthHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93FA64EB248CDD3E00A8B7B1 /* MonthHelperTests.swift */; };
@@ -59,6 +65,11 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		93061FFC24F1AE1700177ECC /* CalendarViewContent+CalendarItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CalendarViewContent+CalendarItem.swift"; sourceTree = "<group>"; };
+		93061FFD24F1AE1700177ECC /* CalendarItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CalendarItem.swift; sourceTree = "<group>"; };
+		938DA40E24BEEB1A008A3B47 /* CalendarItemViewRepresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarItemViewRepresentable.swift; sourceTree = "<group>"; };
+		938DA41024BEFFCB008A3B47 /* AnyCalendarItemModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyCalendarItemModel.swift; sourceTree = "<group>"; };
+		938DA41224BF0FFF008A3B47 /* DefaultItemProviders.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultItemProviders.swift; sourceTree = "<group>"; };
 		9396F3C22483261B008AD306 /* HorizonCalendar.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = HorizonCalendar.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9396F3C62483261B008AD306 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		9396F3CB2483261B008AD306 /* HorizonCalendarTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = HorizonCalendarTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -69,15 +80,15 @@
 		939E691824837E0200A8BCC7 /* LayoutItemTypeEnumerator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LayoutItemTypeEnumerator.swift; sourceTree = "<group>"; };
 		939E691924837E0200A8BCC7 /* ScrollMetricsMutator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScrollMetricsMutator.swift; sourceTree = "<group>"; };
 		939E691A24837E0200A8BCC7 /* VisibleItemsProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VisibleItemsProvider.swift; sourceTree = "<group>"; };
-		939E691B24837E0200A8BCC7 /* CalendarItemView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CalendarItemView.swift; sourceTree = "<group>"; };
+		939E691B24837E0200A8BCC7 /* ItemView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ItemView.swift; sourceTree = "<group>"; };
 		939E691C24837E0200A8BCC7 /* VisibleCalendarItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VisibleCalendarItem.swift; sourceTree = "<group>"; };
-		939E691D24837E0200A8BCC7 /* CalendarItemViewReuseManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CalendarItemViewReuseManager.swift; sourceTree = "<group>"; };
+		939E691D24837E0200A8BCC7 /* ItemViewReuseManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ItemViewReuseManager.swift; sourceTree = "<group>"; };
 		939E691E24837E0200A8BCC7 /* Dictionary+MutatingValueForKey.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Dictionary+MutatingValueForKey.swift"; sourceTree = "<group>"; };
 		939E692024837E0300A8BCC7 /* LayoutItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LayoutItem.swift; sourceTree = "<group>"; };
 		939E692124837E0300A8BCC7 /* ScrollToItemContext.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScrollToItemContext.swift; sourceTree = "<group>"; };
 		939E692224837E0300A8BCC7 /* OffScreenCalendarItemAccessibilityElement.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OffScreenCalendarItemAccessibilityElement.swift; sourceTree = "<group>"; };
 		939E692324837E0300A8BCC7 /* FrameProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FrameProvider.swift; sourceTree = "<group>"; };
-		939E693224837E8700A8BCC7 /* CalendarItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CalendarItem.swift; sourceTree = "<group>"; };
+		939E693224837E8700A8BCC7 /* CalendarItemModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CalendarItemModel.swift; sourceTree = "<group>"; };
 		939E693324837E8700A8BCC7 /* CalendarViewScrollPosition.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CalendarViewScrollPosition.swift; sourceTree = "<group>"; };
 		939E693424837E8700A8BCC7 /* MonthsLayout.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MonthsLayout.swift; sourceTree = "<group>"; };
 		939E693524837E8700A8BCC7 /* CalendarViewContent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CalendarViewContent.swift; sourceTree = "<group>"; };
@@ -95,6 +106,7 @@
 		939E694E2484B14500A8BCC7 /* ScrollMetricsMutatorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScrollMetricsMutatorTests.swift; sourceTree = "<group>"; };
 		939E694F2484B14500A8BCC7 /* FrameProviderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FrameProviderTests.swift; sourceTree = "<group>"; };
 		93A361F3248332AE00E6544A /* ScreenPixelAlignment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScreenPixelAlignment.swift; sourceTree = "<group>"; };
+		93B6D99D24F0C6220027A60C /* InternalAnyCalendarItemModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InternalAnyCalendarItemModel.swift; sourceTree = "<group>"; };
 		93E24A56249D915900B856F7 /* CONTRIBUTING.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = CONTRIBUTING.md; sourceTree = "<group>"; };
 		93E24A57249D915900B856F7 /* TECHNICAL_DETAILS.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = TECHNICAL_DETAILS.md; sourceTree = "<group>"; };
 		93FA64EB248CDD3E00A8B7B1 /* MonthHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonthHelperTests.swift; sourceTree = "<group>"; };
@@ -122,6 +134,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		93061FFB24F1AE1700177ECC /* Legacy CalendarItem Support */ = {
+			isa = PBXGroup;
+			children = (
+				93061FFC24F1AE1700177ECC /* CalendarViewContent+CalendarItem.swift */,
+				93061FFD24F1AE1700177ECC /* CalendarItem.swift */,
+			);
+			path = "Legacy CalendarItem Support";
+			sourceTree = "<group>";
+		};
 		9396F3B82483261B008AD306 = {
 			isa = PBXGroup;
 			children = (
@@ -156,17 +177,17 @@
 		9396F3CF2483261B008AD306 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
-				93FA64EB248CDD3E00A8B7B1 /* MonthHelperTests.swift */,
-				939E694A2484B14400A8BCC7 /* CalendarItemViewReuseManagerTests.swift */,
 				93FA64ED248D7B0100A8B7B1 /* DayHelperTests.swift */,
 				93FA64EF248D84FE00A8B7B1 /* DayOfWeekPositionTests.swift */,
 				939E694F2484B14500A8BCC7 /* FrameProviderTests.swift */,
+				939E694A2484B14400A8BCC7 /* CalendarItemViewReuseManagerTests.swift */,
 				939E694C2484B14400A8BCC7 /* LayoutItemTypeEnumeratorTests.swift */,
-				939E694B2484B14400A8BCC7 /* ScreenPixelAlignmentTests.swift */,
 				939E694E2484B14500A8BCC7 /* ScrollMetricsMutatorTests.swift */,
-				939E694D2484B14400A8BCC7 /* VisibleItemsProviderTests.swift */,
-				939E69492484B14400A8BCC7 /* MonthTests.swift */,
+				939E694B2484B14400A8BCC7 /* ScreenPixelAlignmentTests.swift */,
+				93FA64EB248CDD3E00A8B7B1 /* MonthHelperTests.swift */,
 				93FA64F1248D93EA00A8B7B1 /* MonthRowTests.swift */,
+				939E69492484B14400A8BCC7 /* MonthTests.swift */,
+				939E694D2484B14400A8BCC7 /* VisibleItemsProviderTests.swift */,
 				9396F3D22483261B008AD306 /* Info.plist */,
 			);
 			path = Tests;
@@ -175,16 +196,19 @@
 		9396F3E024832857008AD306 /* Public */ = {
 			isa = PBXGroup;
 			children = (
+				938DA41024BEFFCB008A3B47 /* AnyCalendarItemModel.swift */,
+				939E693224837E8700A8BCC7 /* CalendarItemModel.swift */,
+				938DA40E24BEEB1A008A3B47 /* CalendarItemViewRepresentable.swift */,
 				939E691724837E0200A8BCC7 /* CalendarView.swift */,
-				939E693224837E8700A8BCC7 /* CalendarItem.swift */,
 				939E693524837E8700A8BCC7 /* CalendarViewContent.swift */,
 				939E693324837E8700A8BCC7 /* CalendarViewScrollPosition.swift */,
-				939E693424837E8700A8BCC7 /* MonthsLayout.swift */,
-				939E693B2483824600A8BCC7 /* MonthRange.swift */,
-				939E694124846EB400A8BCC7 /* DayRange.swift */,
-				939E693D24846A6600A8BCC7 /* Month.swift */,
 				939E693F24846A8C00A8BCC7 /* Day.swift */,
 				939E694524847BA300A8BCC7 /* DayOfWeekPosition.swift */,
+				939E694124846EB400A8BCC7 /* DayRange.swift */,
+				939E693D24846A6600A8BCC7 /* Month.swift */,
+				939E693424837E8700A8BCC7 /* MonthsLayout.swift */,
+				939E693B2483824600A8BCC7 /* MonthRange.swift */,
+				93061FFB24F1AE1700177ECC /* Legacy CalendarItem Support */,
 			);
 			path = Public;
 			sourceTree = "<group>";
@@ -192,19 +216,21 @@
 		9396F3E12483285D008AD306 /* Internal */ = {
 			isa = PBXGroup;
 			children = (
-				939E691B24837E0200A8BCC7 /* CalendarItemView.swift */,
-				939E691D24837E0200A8BCC7 /* CalendarItemViewReuseManager.swift */,
+				939E69432484784D00A8BCC7 /* Calendar+Helpers.swift */,
+				938DA41224BF0FFF008A3B47 /* DefaultItemProviders.swift */,
 				939E691E24837E0200A8BCC7 /* Dictionary+MutatingValueForKey.swift */,
 				939E692324837E0300A8BCC7 /* FrameProvider.swift */,
+				93B6D99D24F0C6220027A60C /* InternalAnyCalendarItemModel.swift */,
+				939E691B24837E0200A8BCC7 /* ItemView.swift */,
+				939E691D24837E0200A8BCC7 /* ItemViewReuseManager.swift */,
 				939E692024837E0300A8BCC7 /* LayoutItem.swift */,
 				939E691824837E0200A8BCC7 /* LayoutItemTypeEnumerator.swift */,
 				939E692224837E0300A8BCC7 /* OffScreenCalendarItemAccessibilityElement.swift */,
+				93A361F3248332AE00E6544A /* ScreenPixelAlignment.swift */,
 				939E691924837E0200A8BCC7 /* ScrollMetricsMutator.swift */,
 				939E692124837E0300A8BCC7 /* ScrollToItemContext.swift */,
 				939E691C24837E0200A8BCC7 /* VisibleCalendarItem.swift */,
 				939E691A24837E0200A8BCC7 /* VisibleItemsProvider.swift */,
-				93A361F3248332AE00E6544A /* ScreenPixelAlignment.swift */,
-				939E69432484784D00A8BCC7 /* Calendar+Helpers.swift */,
 			);
 			path = Internal;
 			sourceTree = "<group>";
@@ -331,14 +357,18 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				939E692A24837E0300A8BCC7 /* CalendarItemViewReuseManager.swift in Sources */,
+				939E692A24837E0300A8BCC7 /* ItemViewReuseManager.swift in Sources */,
 				939E692524837E0300A8BCC7 /* LayoutItemTypeEnumerator.swift in Sources */,
+				938DA41124BEFFCB008A3B47 /* AnyCalendarItemModel.swift in Sources */,
 				939E692724837E0300A8BCC7 /* VisibleItemsProvider.swift in Sources */,
+				93061FFF24F1AE1700177ECC /* CalendarItem.swift in Sources */,
 				939E693024837E0300A8BCC7 /* FrameProvider.swift in Sources */,
-				939E693724837E8700A8BCC7 /* CalendarItem.swift in Sources */,
+				939E693724837E8700A8BCC7 /* CalendarItemModel.swift in Sources */,
+				938DA40F24BEEB1A008A3B47 /* CalendarItemViewRepresentable.swift in Sources */,
 				939E692924837E0300A8BCC7 /* VisibleCalendarItem.swift in Sources */,
 				939E693C2483824600A8BCC7 /* MonthRange.swift in Sources */,
 				93A361F4248332AE00E6544A /* ScreenPixelAlignment.swift in Sources */,
+				93061FFE24F1AE1700177ECC /* CalendarViewContent+CalendarItem.swift in Sources */,
 				939E693E24846A6600A8BCC7 /* Month.swift in Sources */,
 				939E692E24837E0300A8BCC7 /* ScrollToItemContext.swift in Sources */,
 				939E693824837E8700A8BCC7 /* CalendarViewScrollPosition.swift in Sources */,
@@ -353,7 +383,9 @@
 				939E692624837E0300A8BCC7 /* ScrollMetricsMutator.swift in Sources */,
 				939E694224846EB400A8BCC7 /* DayRange.swift in Sources */,
 				939E69442484784D00A8BCC7 /* Calendar+Helpers.swift in Sources */,
-				939E692824837E0300A8BCC7 /* CalendarItemView.swift in Sources */,
+				939E692824837E0300A8BCC7 /* ItemView.swift in Sources */,
+				93B6D99E24F0C6220027A60C /* InternalAnyCalendarItemModel.swift in Sources */,
+				938DA41324BF0FFF008A3B47 /* DefaultItemProviders.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/Internal/DefaultItemProviders.swift
+++ b/Sources/Internal/DefaultItemProviders.swift
@@ -1,0 +1,149 @@
+// Created by Bryan Keller on 7/15/20.
+// Copyright © 2020 Airbnb Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import UIKit
+
+// MARK: - DefaultLabel
+
+struct DefaultLabelRepresenting: CalendarItemViewRepresentable {
+
+  struct InvariantViewProperties: Hashable {
+    let font: UIFont
+    let textAlignment: NSTextAlignment
+    let textColor: UIColor
+    let backgroundColor: UIColor
+    let isAccessibilityElement: Bool
+    let accessibilityTraits: UIAccessibilityTraits
+  }
+
+  struct ViewModel: Equatable {
+    let text: String
+    let accessibilityLabel: String?
+  }
+
+  // MARK: Internal
+
+  static func makeView(
+    withInvariantViewProperties invariantViewProperties: InvariantViewProperties)
+    -> UILabel
+  {
+    let label = UILabel()
+    label.font = invariantViewProperties.font
+    label.textAlignment = invariantViewProperties.textAlignment
+    label.textColor = invariantViewProperties.textColor
+    label.backgroundColor = invariantViewProperties.backgroundColor
+    label.isAccessibilityElement = invariantViewProperties.isAccessibilityElement
+    label.accessibilityTraits = invariantViewProperties.accessibilityTraits
+    return label
+  }
+
+  static func setViewModel(_ viewModel: ViewModel, on view: UILabel) {
+    view.text = viewModel.text
+    view.accessibilityLabel = viewModel.accessibilityLabel
+  }
+
+}
+
+// MARK: Default Item Providers
+
+extension CalendarViewContent {
+
+  // MARK: Internal
+
+  static func defaultMonthHeaderItemModelProvider(
+    for month: Month,
+    calendar: Calendar,
+    dateFormatter: DateFormatter)
+    -> AnyCalendarItemModel
+  {
+    let textColor: UIColor
+    if #available(iOS 13.0, *) {
+      textColor = .label
+    } else {
+      textColor = .black
+    }
+
+    let monthText = dateFormatter.string(from: calendar.firstDate(of: month))
+
+    return CalendarItemModel<DefaultLabelRepresenting>(
+      invariantViewProperties: .init(
+        font: UIFont.systemFont(ofSize: 22),
+        textAlignment: .natural,
+        textColor: textColor,
+        backgroundColor: .clear,
+        isAccessibilityElement: true,
+        accessibilityTraits: [.header]),
+      viewModel: .init(text: monthText, accessibilityLabel: monthText))
+  }
+
+  static func defaultDayOfWeekItemModelProvider(
+    forWeekdayIndex weekdayIndex: Int,
+    calendar: Calendar,
+    dateFormatter: DateFormatter)
+    -> AnyCalendarItemModel
+  {
+    let textColor: UIColor
+    let backgroundColor: UIColor
+    if #available(iOS 13.0, *) {
+      textColor = .secondaryLabel
+      backgroundColor = .systemBackground
+    } else {
+      textColor = .black
+      backgroundColor = .white
+    }
+
+    let dayOfWeekText = dateFormatter.veryShortStandaloneWeekdaySymbols[weekdayIndex]
+
+    return CalendarItemModel<DefaultLabelRepresenting>(
+      invariantViewProperties: .init(
+        font: UIFont.systemFont(ofSize: 16),
+        textAlignment: .center,
+        textColor: textColor,
+        backgroundColor: backgroundColor,
+        isAccessibilityElement: false,
+        accessibilityTraits: []),
+      viewModel: .init(text: dayOfWeekText, accessibilityLabel: nil))
+  }
+
+  static func defaultDayItemModelProvider(
+    for day: Day,
+    calendar: Calendar,
+    dateFormatter: DateFormatter)
+    -> AnyCalendarItemModel
+  {
+    let textColor: UIColor
+    if #available(iOS 13.0, *) {
+      textColor = .label
+    } else {
+      textColor = .black
+    }
+
+    let dayText = "\(day.day)"
+
+    let date = calendar.startDate(of: day)
+    let accessibilityLabel = dateFormatter.string(from: date)
+
+    return CalendarItemModel<DefaultLabelRepresenting>(
+      invariantViewProperties: .init(
+        font: UIFont.systemFont(ofSize: 18),
+        textAlignment: .center,
+        textColor: textColor,
+        backgroundColor: .clear,
+        isAccessibilityElement: true,
+        accessibilityTraits: []),
+      viewModel: .init(text: dayText, accessibilityLabel: accessibilityLabel))
+  }
+
+}

--- a/Sources/Internal/InternalAnyCalendarItemModel.swift
+++ b/Sources/Internal/InternalAnyCalendarItemModel.swift
@@ -1,0 +1,70 @@
+// Created by Bryan Keller on 8/21/20.
+// Copyright © 2020 Airbnb Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import UIKit
+
+enum InternalAnyCalendarItemModel {
+
+  case itemModel(AnyCalendarItemModel)
+  case legacy(AnyCalendarItem)
+
+  var itemViewDifferentiator: _CalendarItemViewDifferentiator {
+    switch self {
+    case .itemModel(let itemModel):
+      return itemModel._itemViewDifferentiator
+    case .legacy(let legacyItem):
+      return .legacyReuseIdentifier(legacyItem.reuseIdentifier)
+    }
+  }
+
+  var makeView: () -> UIView {
+    switch self {
+    case .itemModel(let itemModel):
+      return itemModel._makeView
+    case .legacy(let legacyItem):
+      return legacyItem.buildView
+    }
+  }
+
+  var setViewModelOnViewOfSameType: (UIView) -> Void {
+    switch self {
+    case .itemModel(let itemModel):
+      return itemModel._setViewModel(onViewOfSameType:)
+    case .legacy(let legacyItem):
+      return legacyItem.updateViewModel(view:)
+    }
+  }
+
+  var updateHighlightState: ((UIView, Bool) -> Void)? {
+    switch self {
+    case .itemModel:
+      return nil
+    case .legacy(let legacyItem):
+      return legacyItem.updateHighlightState(view:isHighlighted:)
+    }
+  }
+
+  func isViewModelEqualToViewModelOfOther(_ other: Self) -> Bool {
+    switch (self, other) {
+    case let (.itemModel(lhsItemModel), .itemModel(rhsItemModel)):
+      return lhsItemModel._isViewModel(equalToViewModelOf: rhsItemModel)
+    case let (.legacy(lhsLegacyItem), .legacy(rhsLegacyItem)):
+      return lhsLegacyItem.isViewModel(equalToViewModelOf: rhsLegacyItem)
+    default:
+      return false
+    }
+  }
+
+}

--- a/Sources/Internal/OffScreenCalendarItemAccessibilityElement.swift
+++ b/Sources/Internal/OffScreenCalendarItemAccessibilityElement.swift
@@ -23,8 +23,8 @@ final class OffScreenCalendarItemAccessibilityElement: UIAccessibilityElement {
   // MARK: Lifecycle
 
   init?(correspondingItem: VisibleCalendarItem, scrollViewContainer: UIScrollView) {
-    let view = correspondingItem.calendarItem.buildView()
-    correspondingItem.calendarItem.updateViewModel(view: view)
+    let view = correspondingItem.calendarItemModel.makeView()
+    correspondingItem.calendarItemModel.setViewModelOnViewOfSameType(view)
     guard view.isAccessibilityElement else { return nil }
 
     self.correspondingItem = correspondingItem

--- a/Sources/Internal/VisibleCalendarItem.swift
+++ b/Sources/Internal/VisibleCalendarItem.swift
@@ -28,20 +28,20 @@ final class VisibleCalendarItem {
 
   // MARK: Lifecycle
 
-  init(calendarItem: AnyCalendarItem, itemType: ItemType, frame: CGRect) {
-    self.calendarItem = calendarItem
+  init(calendarItemModel: InternalAnyCalendarItemModel, itemType: ItemType, frame: CGRect) {
+    self.calendarItemModel = calendarItemModel
     self.itemType = itemType
     self.frame = frame
 
     var hasher = Hasher()
-    hasher.combine(calendarItem.reuseIdentifier)
+    hasher.combine(calendarItemModel.itemViewDifferentiator)
     hasher.combine(itemType)
     cachedHashValue = hasher.finalize()
   }
 
   // MARK: Internal
 
-  let calendarItem: AnyCalendarItem
+  let calendarItemModel: InternalAnyCalendarItemModel
   let itemType: ItemType
   let frame: CGRect
 

--- a/Sources/Internal/VisibleItemsProvider.swift
+++ b/Sources/Internal/VisibleItemsProvider.swift
@@ -121,9 +121,9 @@ final class VisibleItemsProvider {
     var heightOfPinnedContent = CGFloat(0)
 
     // Default the initial capacity to 100, which is approximately enough room for 3 months worth of
-    // calendar items.
-    var calendarItemCache = Dictionary<VisibleCalendarItem.ItemType, AnyCalendarItem>(
-      minimumCapacity: previousCalendarItemCache?.capacity ?? 100)
+    // calendar item models.
+    var calendarItemModelCache = Dictionary<VisibleCalendarItem.ItemType, InternalAnyCalendarItemModel>(
+      minimumCapacity: previousCalendarItemModelCache?.capacity ?? 100)
 
     // `extendedBounds` is used to make sure that we're always laying out a continuous set of items,
     // even if the last anchor item is completely off screen.
@@ -172,7 +172,7 @@ final class VisibleItemsProvider {
           minimumScrollOffset: &minimumScrollOffset,
           maximumScrollOffset: &maximumScrollOffset,
           visibleItems: &visibleItems,
-          calendarItemCache: &calendarItemCache,
+          calendarItemModelCache: &calendarItemModelCache,
           originsForMonths: &originsForMonths,
           handledDayRanges: &handledDayRanges,
           shouldStop: &shouldStop)
@@ -199,7 +199,7 @@ final class VisibleItemsProvider {
           minimumScrollOffset: &minimumScrollOffset,
           maximumScrollOffset: &maximumScrollOffset,
           visibleItems: &visibleItems,
-          calendarItemCache: &calendarItemCache,
+          calendarItemModelCache: &calendarItemModelCache,
           originsForMonths: &originsForMonths,
           handledDayRanges: &handledDayRanges,
           shouldStop: &shouldStop)
@@ -209,7 +209,7 @@ final class VisibleItemsProvider {
     if case .vertical(let options) = content.monthsLayout, options.pinDaysOfWeekToTop {
       handlePinnedDaysOfWeekIfNeeded(
         yContentOffset: bounds.minY,
-        calendarItemCache: &calendarItemCache,
+        calendarItemModelCache: &calendarItemModelCache,
         visibleItems: &visibleItems,
         heightOfPinnedContent: &heightOfPinnedContent)
     }
@@ -235,7 +235,7 @@ final class VisibleItemsProvider {
       framesForVisibleDays: framesForVisibleDays,
       visibleItems: &visibleItems)
 
-    previousCalendarItemCache = calendarItemCache
+    previousCalendarItemModelCache = calendarItemModelCache
 
     return VisibleItemsDetails(
       visibleItems: visibleItems,
@@ -265,14 +265,14 @@ final class VisibleItemsProvider {
     let handleItem: (LayoutItem, Bool, inout Bool) -> Void =
     { layoutItem, isLookingBackwards, shouldStop in
       let month: Month
-      let calendarItem: AnyCalendarItem
+      let calendarItemModel: InternalAnyCalendarItemModel
       switch layoutItem.itemType {
       case .monthHeader(let _month):
         month = _month
-        calendarItem = self.content.monthHeaderItemProvider(month)
+        calendarItemModel = self.content.monthHeaderItemModelProvider(month)
       case .day(let day):
         month = day.month
-        calendarItem = self.content.dayItemProvider(day)
+        calendarItemModel = self.content.dayItemModelProvider(day)
       case .dayOfWeekInMonth:
         return
       }
@@ -283,7 +283,7 @@ final class VisibleItemsProvider {
       }
 
       let item = VisibleCalendarItem(
-        calendarItem: calendarItem,
+        calendarItemModel: calendarItemModel,
         itemType: .layoutItemType(layoutItem.itemType),
         frame: layoutItem.frame)
       if isLookingBackwards {
@@ -326,7 +326,9 @@ final class VisibleItemsProvider {
   private let layoutItemTypeEnumerator: LayoutItemTypeEnumerator
   private let frameProvider: FrameProvider
 
-  private var previousCalendarItemCache: [VisibleCalendarItem.ItemType: AnyCalendarItem]?
+  private var previousCalendarItemModelCache: [
+    VisibleCalendarItem.ItemType: InternalAnyCalendarItemModel
+  ]?
 
   private var calendar: Calendar {
     content.calendar
@@ -568,7 +570,7 @@ final class VisibleItemsProvider {
     minimumScrollOffset: inout CGFloat?,
     maximumScrollOffset: inout CGFloat?,
     visibleItems: inout Set<VisibleCalendarItem>,
-    calendarItemCache: inout [VisibleCalendarItem.ItemType: AnyCalendarItem],
+    calendarItemModelCache: inout [VisibleCalendarItem.ItemType: InternalAnyCalendarItemModel],
     originsForMonths: inout [Month: CGPoint],
     handledDayRanges: inout Set<DayRange>,
     shouldStop: inout Bool)
@@ -608,14 +610,14 @@ final class VisibleItemsProvider {
 
         let itemType = VisibleCalendarItem.ItemType.layoutItemType(layoutItem.itemType)
 
-        let calendarItem: AnyCalendarItem
+        let calendarItemModel: InternalAnyCalendarItemModel
         switch layoutItem.itemType {
         case .monthHeader(let month):
-          calendarItem = calendarItemCache.value(
+          calendarItemModel = calendarItemModelCache.value(
             for: itemType,
             missingValueProvider: {
-              previousCalendarItemCache?[itemType]
-                ?? content.monthHeaderItemProvider(month)
+              previousCalendarItemModelCache?[itemType]
+                ?? content.monthHeaderItemModelProvider(month)
             })
 
           // Create a visible item for the separator view, if needed.
@@ -624,24 +626,25 @@ final class VisibleItemsProvider {
             let separatorOptions = content.daysOfTheWeekRowSeparatorOptions
           {
             let separatorItemType = VisibleCalendarItem.ItemType.daysOfWeekRowSeparator(month)
-            let separatorCalendarItem = calendarItemCache.value(
+            let separatorCalendarItemModel = calendarItemModelCache.value(
               for: separatorItemType,
               missingValueProvider: {
-                previousCalendarItemCache?[separatorItemType] ??
-                  CalendarItem<UIView, Month>(
-                    viewModel: month,
-                    styleID: "DaysOfTheWeekRowSeparator",
-                    buildView: {
-                      let view = UIView()
-                      view.backgroundColor = separatorOptions.color
-                      return view
-                    },
-                    updateViewModel: { _, _ in })
+                previousCalendarItemModelCache?[separatorItemType] ??
+                  .legacy(
+                    CalendarItem<UIView, Month>(
+                      viewModel: month,
+                      styleID: "DaysOfTheWeekRowSeparator",
+                      buildView: {
+                        let view = UIView()
+                        view.backgroundColor = separatorOptions.color
+                        return view
+                      },
+                      updateViewModel: { _, _ in }))
               })
 
             visibleItems.insert(
               VisibleCalendarItem(
-                calendarItem: separatorCalendarItem,
+                calendarItemModel: separatorCalendarItemModel,
                 itemType: separatorItemType,
                 frame: frameProvider.frameOfDaysOfWeekRowSeparator(
                   inMonthWithOrigin: monthFrame.origin,
@@ -649,20 +652,19 @@ final class VisibleItemsProvider {
           }
 
         case let .dayOfWeekInMonth(dayOfWeekPosition, month):
-          calendarItem = calendarItemCache.value(
+          calendarItemModel = calendarItemModelCache.value(
             for: itemType,
             missingValueProvider: {
               let weekdayIndex = calendar.weekdayIndex(for: dayOfWeekPosition)
-              return previousCalendarItemCache?[itemType]
-                ?? content.dayOfWeekItemProvider(month, weekdayIndex)
+              return previousCalendarItemModelCache?[itemType]
+                ?? content.dayOfWeekItemModelProvider(month, weekdayIndex)
             })
 
         case .day(let day):
-          calendarItem = calendarItemCache.value(
+          calendarItemModel = calendarItemModelCache.value(
             for: itemType,
             missingValueProvider: {
-              previousCalendarItemCache?[itemType]
-                ?? content.dayItemProvider(day)
+              previousCalendarItemModelCache?[itemType] ?? content.dayItemModelProvider(day)
             })
 
           handleDayRangesContaining(
@@ -688,7 +690,7 @@ final class VisibleItemsProvider {
         }
 
         let visibleItem = VisibleCalendarItem(
-          calendarItem: calendarItem,
+          calendarItemModel: calendarItemModel,
           itemType: .layoutItemType(layoutItem.itemType),
           frame: layoutItem.frame)
         visibleItems.insert(visibleItem)
@@ -741,7 +743,7 @@ final class VisibleItemsProvider {
     originsForMonths: inout [Month: CGPoint])
   {
     // Handle day ranges that start or end with the current day.
-    for dayRange in content.dayRangesAndItemProvider?.dayRanges ?? [] {
+    for dayRange in content.dayRangesAndItemModelProvider?.dayRanges ?? [] {
       guard
         !handledDayRanges.contains(dayRange),
         dayRange.contains(day)
@@ -768,9 +770,12 @@ final class VisibleItemsProvider {
     inBounds bounds: CGRect,
     visibleItems: inout Set<VisibleCalendarItem>)
   {
-    guard let dayRangeItemProvider = content.dayRangesAndItemProvider?.dayRangeItemProvider else {
+    guard
+      let dayRangeItemModelProvider = content.dayRangesAndItemModelProvider?.dayRangeItemModelProvider
+    else
+    {
       preconditionFailure(
-        "`content.dayRangesAndItemProvider` cannot be nil when handling a day range.")
+        "`content.dayRangesAndItemModelProvider` cannot be nil when handling a day range.")
     }
 
     let frame = dayRangeLayoutContext.frame
@@ -780,14 +785,14 @@ final class VisibleItemsProvider {
 
     visibleItems.insert(
       VisibleCalendarItem(
-        calendarItem: dayRangeItemProvider(dayRangeLayoutContext) ,
+        calendarItemModel: dayRangeItemModelProvider(dayRangeLayoutContext),
         itemType: .dayRange(dayRange),
         frame: frame))
   }
 
   private func handlePinnedDaysOfWeekIfNeeded(
     yContentOffset: CGFloat,
-    calendarItemCache: inout [VisibleCalendarItem.ItemType: AnyCalendarItem],
+    calendarItemModelCache: inout [VisibleCalendarItem.ItemType: InternalAnyCalendarItemModel],
     visibleItems: inout Set<VisibleCalendarItem>,
     heightOfPinnedContent: inout CGFloat)
   {
@@ -800,12 +805,12 @@ final class VisibleItemsProvider {
         yContentOffset: yContentOffset)
       visibleItems.insert(
         VisibleCalendarItem(
-          calendarItem: calendarItemCache.value(
+          calendarItemModel: calendarItemModelCache.value(
             for: itemType,
             missingValueProvider: {
               let weekdayIndex = calendar.weekdayIndex(for: dayOfWeekPosition)
-              return previousCalendarItemCache?[itemType] ??
-                content.dayOfWeekItemProvider(nil, weekdayIndex)
+              return previousCalendarItemModelCache?[itemType] ??
+                content.dayOfWeekItemModelProvider(nil, weekdayIndex)
             }),
           itemType: itemType,
           frame: frame))
@@ -820,39 +825,41 @@ final class VisibleItemsProvider {
     // items as content is scrolled underneath.
     visibleItems.insert(
       VisibleCalendarItem(
-        calendarItem: CalendarItem<UIView, Int>.init(
-          viewModel: 0,
-          styleID: "PinnedDaysOfTheWeekRowBackground",
-          buildView: { [unowned self] in
-            let view = UIView()
-            view.backgroundColor = self.content.backgroundColor
-            return view
-          },
-          updateViewModel: { _, _ in }),
+        calendarItemModel: .legacy(
+          CalendarItem<UIView, Int>.init(
+            viewModel: 0,
+            styleID: "PinnedDaysOfTheWeekRowBackground",
+            buildView: { [unowned self] in
+              let view = UIView()
+              view.backgroundColor = self.content.backgroundColor
+              return view
+            },
+            updateViewModel: { _, _ in })),
         itemType: .pinnedDaysOfWeekRowBackground,
         frame: frameProvider.frameOfPinnedDaysOfWeekRowBackground(yContentOffset: yContentOffset)))
 
     // Create a visible item for the separator view, if needed.
     if let separatorOptions = content.daysOfTheWeekRowSeparatorOptions {
       let separatorItemType = VisibleCalendarItem.ItemType.pinnedDaysOfWeekRowSeparator
-      let separatorCalendarItem = calendarItemCache.value(
+      let separatorCalendarItemModel = calendarItemModelCache.value(
         for: separatorItemType,
         missingValueProvider: {
-          previousCalendarItemCache?[separatorItemType] ??
-            CalendarItem<UIView, Int>(
-              viewModel: 0,
-              styleID: "PinnedDaysOfTheWeekRowSeparator",
-              buildView: {
-                let view = UIView()
-                view.backgroundColor = separatorOptions.color
-                return view
-              },
-              updateViewModel: { _, _ in })
+          previousCalendarItemModelCache?[separatorItemType] ??
+            .legacy(
+              CalendarItem<UIView, Int>(
+                viewModel: 0,
+                styleID: "PinnedDaysOfTheWeekRowSeparator",
+                buildView: {
+                  let view = UIView()
+                  view.backgroundColor = separatorOptions.color
+                  return view
+                },
+                updateViewModel: { _, _ in }))
         })
 
       visibleItems.insert(
         VisibleCalendarItem(
-          calendarItem: separatorCalendarItem,
+          calendarItemModel: separatorCalendarItemModel,
           itemType: separatorItemType,
           frame: frameProvider.frameOfPinnedDaysOfWeekRowSeparator(
             yContentOffset: yContentOffset,
@@ -867,7 +874,7 @@ final class VisibleItemsProvider {
     visibleItems: inout Set<VisibleCalendarItem>)
   {
     guard
-      let (overlaidItemLocations, itemProvider) = content.overlaidItemLocationsAndItemProvider
+      let (overlaidItemLocations, itemModelProvider) = content.overlaidItemLocationsAndItemModelProvider
     else
     {
       return
@@ -887,7 +894,7 @@ final class VisibleItemsProvider {
 
       visibleItems.insert(
         VisibleCalendarItem(
-          calendarItem: itemProvider(layoutContext),
+          calendarItemModel: itemModelProvider(layoutContext),
           itemType: .overlayItem(overlaidItemLocation),
           frame: bounds))
     }

--- a/Sources/Public/AnyCalendarItemModel.swift
+++ b/Sources/Public/AnyCalendarItemModel.swift
@@ -1,0 +1,60 @@
+// Created by Bryan Keller on 7/15/20.
+// Copyright © 2020 Airbnb Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import UIKit
+
+// MARK: - AnyCalendarItemModel
+
+/// A type-erased calendar item model.
+///
+/// Useful for working with types conforming to `CalendarItemModel` without knowing the underlying concrete type.
+public protocol AnyCalendarItemModel {
+
+  /// A type that helps `ItemViewReuseManager` determine which views are compatible with one another and can therefore be
+  /// recycled / reused.
+  ///
+  /// - Note: There is no reason to access this property from your feature code; it should only be accessed internally.
+  var _itemViewDifferentiator: _CalendarItemViewDifferentiator { get }
+
+  /// Builds an instance of `ViewType` by invoking its initializer with `invariantViewProperties`.
+  ///
+  /// - Note: There is no reason to invoke this function from your feature code; it should only be invoked internally.
+  func _makeView() -> UIView
+
+  /// Updates the view model on an instance of `ViewType` by invoking `setViewModel`.
+  ///
+  /// - Note: There is no reason to invoke this function from your feature code; it should only be invoked internally.
+  func _setViewModel(onViewOfSameType view: UIView)
+
+  /// Compares the view models of two `CalendarItemModel`s for equality.
+  ///
+  /// - Note: There is no reason to invoke this function from your feature code; it should only be invoked internally.
+  func _isViewModel(equalToViewModelOf other: AnyCalendarItemModel) -> Bool
+
+}
+
+// MARK: - _CalendarItemViewDifferentiator
+
+/// A type that helps `ItemViewReuseManager` determine which views are compatible with one another and can therefore be
+/// recycled / reused.
+///
+/// - Note: There is no reason to create an instance of this enum from your feature code; it should only be invoked internally.
+public enum _CalendarItemViewDifferentiator: Hashable {
+  case viewRepresentable(
+    viewRepresentableTypeDescription: String,
+    viewTypeDescription: String,
+    invariantViewProperties: AnyHashable)
+  case legacyReuseIdentifier(String)
+}

--- a/Sources/Public/CalendarItemModel.swift
+++ b/Sources/Public/CalendarItemModel.swift
@@ -1,0 +1,87 @@
+// Created by Bryan Keller on 7/15/20.
+// Copyright © 2020 Airbnb Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import UIKit
+
+// MARK: - CalendarItemModel
+
+/// Represents a view that `CalendarView` will display at a particular location.
+///
+/// `CalendarItemModel`s are what are provided to `CalendarView` via `CalendarViewContent`, and are used to tell
+/// `CalendarView` what types of views to display for month headers, day-of-week items, day items, day-range items, and more.
+///
+/// `CalendarItemModel` is generic over a `ViewRepresentable`, a type that can create and update the represented view.
+/// See the documentation for `CalendarItemViewRepresentable` for more details.
+public struct CalendarItemModel<ViewRepresentable>: AnyCalendarItemModel where
+  ViewRepresentable: CalendarItemViewRepresentable
+{
+
+  // MARK: Lifecycle
+
+  /// Initializes a new `CalendarItemModel`.
+  ///
+  /// - Parameters:
+  ///   - invariantViewProperties: A type containing all of the immutable / view-model-independent properties necessary to
+  ///   initialize a `ViewType`. Use this to configure appearance options that do not change based on the data in the `viewModel`.
+  ///   For example, you might pass a type that contains properties to configure a `UILabel`'s `textAlignment`, `textColor`,
+  ///   and `font`, assuming none of those things change in response to `viewModel` updates.
+  ///   - viewModel: A type containing all of the variable data necessary to update an instance of`ViewType`. Use this to specify
+  ///   the dynamic, data-driven parts of the view.
+  public init(
+    invariantViewProperties: ViewRepresentable.InvariantViewProperties,
+    viewModel: ViewRepresentable.ViewModel)
+  {
+    _itemViewDifferentiator = .viewRepresentable(
+      viewRepresentableTypeDescription: String(reflecting: ViewRepresentable.self),
+      viewTypeDescription: String(reflecting: ViewRepresentable.ViewType.self),
+      invariantViewProperties: invariantViewProperties)
+
+    self.invariantViewProperties = invariantViewProperties
+    self.viewModel = viewModel
+  }
+
+  // MARK: Public
+
+  public let _itemViewDifferentiator: _CalendarItemViewDifferentiator
+
+  public func _makeView() -> UIView {
+    ViewRepresentable.makeView(withInvariantViewProperties: invariantViewProperties)
+  }
+
+  public func _setViewModel(onViewOfSameType view: UIView) {
+    guard let view = view as? ViewRepresentable.ViewType else {
+      let viewTypeDescription = String(reflecting: ViewRepresentable.ViewType.self)
+      preconditionFailure("Failed to convert the view to an instance of \(viewTypeDescription).")
+    }
+
+    ViewRepresentable.setViewModel(viewModel, on: view)
+  }
+
+  public func _isViewModel(equalToViewModelOf other: AnyCalendarItemModel) -> Bool {
+    guard let other = other as? Self else {
+      let selfTypeDescription = String(reflecting: Self.self)
+      preconditionFailure(
+        "Failed to convert the calendar item model to an instance of \(selfTypeDescription).")
+    }
+
+    return viewModel == other.viewModel
+  }
+
+  // MARK: Private
+
+  private let invariantViewProperties: ViewRepresentable.InvariantViewProperties
+  private let viewModel: ViewRepresentable.ViewModel
+
+}

--- a/Sources/Public/CalendarItemViewRepresentable.swift
+++ b/Sources/Public/CalendarItemViewRepresentable.swift
@@ -1,0 +1,55 @@
+// Created by Bryan Keller on 7/15/20.
+// Copyright © 2020 Airbnb Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import UIKit
+
+// MARK: - CalendarItemViewRepresentable
+
+/// A protocol to which types that can create and update views displayed in `CalendarView` must conform. By conforming to this
+/// protocol, `CalendarView` is able to treat each view it displays as a function of its `invariantViewProperties` and its
+/// `viewModel`, simplifying the initialization and state updating of views.
+public protocol CalendarItemViewRepresentable {
+
+  /// The type of view that this `CalendarItemViewRepresentable` can create and update.
+  associatedtype ViewType: UIView
+
+  /// A type containing all of the immutable / initial setup values necessary to initialize the view. Use this to configure appearance
+  /// options that do not change based on the data in the `viewModel`.
+  associatedtype InvariantViewProperties: Hashable
+
+  /// A type containing all of the variable data necessary to update the view. Use this to update the dynamic, data-driven parts of the
+  /// view.
+  associatedtype ViewModel: Equatable
+
+  /// Creates a view using a set of invariant view properties that contain all of the immutable / initial setup values necessary to
+  /// configure the view. All immutable / view-model-independent properties should be configured here. For example, you might set up
+  /// a `UILabel`'s `textAlignment`, `textColor`, and `font`, assuming none of those properties change in response to
+  /// `viewModel` updates.
+  ///
+  /// - Parameters:
+  ///   - invariantViewProperties: An instance containing all of the immutable / initial setup values necessary to initialize the
+  ///   view. Use this to configure appearance options that do not change based on the data in the `viewModel`.
+  static func makeView(
+    withInvariantViewProperties invariantViewProperties: InvariantViewProperties)
+    -> ViewType
+
+  /// Sets the view model on your view. `CalendarView` invokes this whenever a view's data is stale and needs to be updated to
+  /// reflect the data in a new view model.
+  ///
+  /// - Parameters:
+  ///   - viewModel: An instance containing all of the variable data necessary to update the view.
+  static func setViewModel(_ viewModel: ViewModel, on view: ViewType)
+
+}

--- a/Sources/Public/CalendarView.swift
+++ b/Sources/Public/CalendarView.swift
@@ -349,14 +349,14 @@ public final class CalendarView: UIView {
 
   // MARK: Private
 
-  private let reuseManager = CalendarItemViewReuseManager()
+  private let reuseManager = ItemViewReuseManager()
 
   private var content: CalendarViewContent
   private var anchorLayoutItem: LayoutItem?
   private var _scrollMetricsMutator: ScrollMetricsMutator?
   private var _visibleItemsProvider: VisibleItemsProvider?
   private var visibleItemsDetails: VisibleItemsDetails?
-  private var visibleViewsForVisibleItems = [VisibleCalendarItem: CalendarItemView]()
+  private var visibleViewsForVisibleItems = [VisibleCalendarItem: ItemView]()
   private weak var scrollToItemDisplayLink: CADisplayLink?
   private var scrollToItemAnimationStartTime: CFTimeInterval?
   private var cachedAccessibilityElements: [Any]?
@@ -509,9 +509,10 @@ public final class CalendarView: UIView {
     case .horizontal(let _monthWidth): monthWidth = _monthWidth
     }
 
-    let firstMonthHeaderItem = content.monthHeaderItemProvider(content.monthRange.lowerBound)
-    let firstMonthHeader = firstMonthHeaderItem.buildView()
-    firstMonthHeaderItem.updateViewModel(view: firstMonthHeader)
+    let firstMonthHeaderItemModel = content.monthHeaderItemModelProvider(
+      content.monthRange.lowerBound)
+    let firstMonthHeader = firstMonthHeaderItemModel.makeView()
+    firstMonthHeaderItemModel.setViewModelOnViewOfSameType(firstMonthHeader)
 
     let size = firstMonthHeader.systemLayoutSizeFitting(
       CGSize(width: monthWidth, height: 0),
@@ -551,9 +552,8 @@ public final class CalendarView: UIView {
     }
   }
 
-  private func configureView(_ view: CalendarItemView, with visibleItem: VisibleCalendarItem) {
-    let calendarItem = visibleItem.calendarItem
-    view.calendarItem = calendarItem
+  private func configureView(_ view: ItemView, with visibleItem: VisibleCalendarItem) {
+    view.calendarItemModel = visibleItem.calendarItemModel
 
     // Update the visibility
     view.frame = visibleItem.frame.alignedToPixels(forScreenWithScale: scale)

--- a/Sources/Public/Legacy CalendarItem Support/CalendarItem.swift
+++ b/Sources/Public/Legacy CalendarItem Support/CalendarItem.swift
@@ -18,9 +18,13 @@ import UIKit
 // MARK: - CalendarItemViewModelEquatable
 
 /// Facilitates the comparison of type-earased `AnyCalendarItem`s based on their concrete types' `viewModel`s.
+///
+/// - Note: This is a legacy protocol and will be removed in a future major release.
 public protocol CalendarItemViewModelEquatable {
 
   /// Compares the view models of two `CalendarItem`s for equality.
+  ///
+  /// - Note: There is no reason to invoke this function from your feature code; it should only be invoked internally.
   ///
   /// - Parameters:
   ///   - otherCalendarItem: The calendar item to compare to `self`.
@@ -35,13 +39,30 @@ public protocol CalendarItemViewModelEquatable {
 /// A type-erased calendar item.
 ///
 /// Useful for working with types conforming to `CalendarItem` without knowing the underlying concrete type.
+///
+/// - Note: This is a legacy protocol and will be removed in a future major release.
 public protocol AnyCalendarItem: CalendarItemViewModelEquatable {
 
   /// A reuse identifier used by `CalendarView` to differentiate between items based on their type and style.
+  ///
+  /// - Note: There is no reason to access this property from your feature code; it should only be invoked internally.
   var reuseIdentifier: String { get }
 
+  /// Builds an instance of `ViewType` by invoking the `buildView` closure from `CalendarItem`'s initializer.
+  ///
+  /// - Note: There is no reason to invoke this function from your feature code; it should only be invoked internally.
   func buildView() -> UIView
+
+  /// Updates the view model on an instance of `ViewType` by invoking the `updateViewModel` closure from
+  /// `CalendarItem`'s initializer.
+  ///
+  /// - Note: There is no reason to invoke this function from your feature code; it should only be invoked internally.
   func updateViewModel(view: UIView)
+
+  /// Updates the highlight state on an instance of `ViewType` by invoking the `updateHighlightState` closure from
+  /// `CalendarItem`'s initializer.
+  ///
+  /// - Note: There is no reason to invoke this function from your feature code; it should only be invoked internally.
   func updateHighlightState(view: UIView, isHighlighted: Bool)
 
 }
@@ -56,6 +77,8 @@ public protocol AnyCalendarItem: CalendarItemViewModelEquatable {
 /// `CalendarItem` is generic over a `ViewType` and a `ViewModel`.
 /// `ViewType` should be a `UIView` or `UIView` subclass, and is what will be displayed  by `CalendarView`.
 /// `ViewModel` should be a type that contains all of the data necessary to populate an instance of`ViewType` with data.
+///
+/// - Warning: This is a legacy type and will be removed in a future major release. Use `CalendarItemModel` instead.
 public struct CalendarItem<ViewType, ViewModel>: AnyCalendarItem where
   ViewType: UIView,
   ViewModel: Equatable
@@ -64,6 +87,8 @@ public struct CalendarItem<ViewType, ViewModel>: AnyCalendarItem where
   // MARK: Lifecycle
 
   /// Initializes a new `CalendarItem`.
+  ///
+  /// - Warning: This is a legacy type and will be removed in a future major release. Use `CalendarItemModel` instead.
   ///
   /// - Parameters:
   ///   - viewModel: The view model containing all of the data necessary to populate an instance of`ViewType`.
@@ -87,7 +112,7 @@ public struct CalendarItem<ViewType, ViewModel>: AnyCalendarItem where
     updateHighlightState: ((_ view: ViewType, _ isHighlighted: Bool) -> Void)? = nil)
   {
     self.viewModel = viewModel
-    reuseIdentifier = "ViewType: \(ViewType.self), styleID: \(styleID)"
+    reuseIdentifier = "ViewType: \(String(reflecting: ViewType.self)), styleID: \(styleID)"
     _buildView = buildView
     _updateViewModel = updateViewModel
     _updateHighlightState = updateHighlightState
@@ -101,16 +126,12 @@ public struct CalendarItem<ViewType, ViewModel>: AnyCalendarItem where
   /// `CalendarItem`s, even if those `CalendarItem`s render the same `ViewType`.
   public let viewModel: ViewModel
 
-  /// The reuse identifier used by `CalendarView` to differentiate between items based on their type and style.
   public let reuseIdentifier: String
 
-  /// Builds an instance of `ViewType` by invoking the `buildView` closure from `CalendarItem`'s initializer.
   public func buildView() -> UIView {
     _buildView()
   }
 
-  /// Updates the view model on an instance of `ViewType` by invoking the `updateViewModel` closure from
-  /// `CalendarItem`'s initializer.
   public func updateViewModel(view: UIView) {
     guard let view = view as? ViewType else {
       preconditionFailure("Failed to convert the UIView to the type-erased ViewType")
@@ -119,8 +140,6 @@ public struct CalendarItem<ViewType, ViewModel>: AnyCalendarItem where
     _updateViewModel(view, viewModel)
   }
 
-  /// Updates the highlight state on an instance of `ViewType` by invoking the `updateHighlightState` closure from
-  /// `CalendarItem`'s initializer.
   public func updateHighlightState(view: UIView, isHighlighted: Bool) {
     guard let view = view as? ViewType else {
       preconditionFailure("Failed to convert the UIView to the type-erased ViewType")
@@ -129,7 +148,6 @@ public struct CalendarItem<ViewType, ViewModel>: AnyCalendarItem where
     _updateHighlightState?(view, isHighlighted)
   }
 
-  /// Compares the view models of two `CalendarItem`s for equality.
   public func isViewModel(
     equalToViewModelOf otherCalendarItem: CalendarItemViewModelEquatable)
     -> Bool

--- a/Sources/Public/Legacy CalendarItem Support/CalendarViewContent+CalendarItem.swift
+++ b/Sources/Public/Legacy CalendarItem Support/CalendarViewContent+CalendarItem.swift
@@ -29,6 +29,10 @@ extension CalendarViewContent {
   ///   - monthHeaderItemProvider: A closure (that is retained) that returns a `CalendarItem` representing a month header.
   ///   - month: The `Month` for which to provide a month header item.
   /// - Returns: A mutated `CalendarViewContent` instance with a new month header item provider.
+  @available(
+    *,
+    deprecated,
+    message: "`CalendarItem` has been replaced with `CalendarItemModel`, a type that simplifies the creation of views displayed in `CalendarView`. Use `withMonthHeaderItemModelProvider` instead.")
   public func withMonthHeaderItemProvider(
     _ monthHeaderItemProvider: @escaping (_ month: Month) -> AnyCalendarItem)
     -> CalendarViewContent
@@ -51,6 +55,10 @@ extension CalendarViewContent {
   ///   the top of the calendar, since in that scenario, they don't belong to any particular month.
   ///   - weekdayIndex: The weekday index for which to provide a `CalendarItem`.
   /// - Returns: A mutated `CalendarViewContent` instance with a new day-of-week item provider.
+  @available(
+    *,
+    deprecated,
+    message: "`CalendarItem` has been replaced with `CalendarItemModel`, a type that simplifies the creation of views displayed in `CalendarView`. Use `withDayOfWeekItemModelProvider` instead.")
   public func withDayOfWeekItemProvider(
     _ dayOfWeekItemProvider: @escaping (_ month: Month?, _ weekdayIndex: Int) -> AnyCalendarItem)
     -> CalendarViewContent
@@ -73,6 +81,10 @@ extension CalendarViewContent {
   ///   calendar.
   ///   - day: The `Day` for which to provide a day item.
   /// - Returns: A mutated `CalendarViewContent` instance with a new day item provider.
+  @available(
+    *,
+    deprecated,
+    message: "`CalendarItem` has been replaced with `CalendarItemModel`, a type that simplifies the creation of views displayed in `CalendarView`. Use `withDayItemModelProvider` instead.")
   public func withDayItemProvider(
     _ dayItemProvider: @escaping (_ day: Day) -> AnyCalendarItem)
     -> CalendarViewContent
@@ -103,6 +115,10 @@ extension CalendarViewContent {
   ///   - dayRangeLayoutContext: The layout context for the day range containing information about the frames of days and
   ///   bounds in which your day range item will be displayed.
   /// - Returns: A mutated `CalendarViewContent` instance with a new day range item provider.
+  @available(
+    *,
+    deprecated,
+    message: "`CalendarItem` has been replaced with `CalendarItemModel`, a type that simplifies the creation of views displayed in `CalendarView`. Use `withDayRangeItemModelProvider` instead.")
   public func withDayRangeItemProvider(
     for dateRanges: Set<ClosedRange<Date>>,
     _ dayRangeItemProvider: @escaping (
@@ -130,6 +146,10 @@ extension CalendarViewContent {
   ///   - overlayLayoutContext: The layout context for the overlaid item location containing information about that location's
   ///   frame and the bounds in which your overlay item will be displayed.
   /// - Returns: A mutated `CalendarViewContent` instance with a new overlay item provider.
+  @available(
+    *,
+    deprecated,
+    message: "`CalendarItem` has been replaced with `CalendarItemModel`, a type that simplifies the creation of views displayed in `CalendarView`. Use `withOverlayItemModelProvider` instead.")
   public func withOverlayItemProvider(
     for overlaidItemLocations: Set<OverlaidItemLocation>,
     _ overlayItemProvider: @escaping (

--- a/Sources/Public/Legacy CalendarItem Support/CalendarViewContent+CalendarItem.swift
+++ b/Sources/Public/Legacy CalendarItem Support/CalendarViewContent+CalendarItem.swift
@@ -1,0 +1,146 @@
+// Created by Bryan Keller on 8/22/20.
+// Copyright © 2020 Airbnb Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+extension CalendarViewContent {
+
+  /// Configures the month header item provider.
+  ///
+  /// `CalendarView` invokes the provided `monthHeaderItemProvider` for each month in the range of months being
+  /// displayed. The `CalendarItem`s that you return will be used to create the views for each month header in `CalendarView`.
+  ///
+  /// If you don't configure your own month header item provider via this function, then a default month header item provider will be
+  /// used.
+  ///
+  /// - Parameters:
+  ///   - monthHeaderItemProvider: A closure (that is retained) that returns a `CalendarItem` representing a month header.
+  ///   - month: The `Month` for which to provide a month header item.
+  /// - Returns: A mutated `CalendarViewContent` instance with a new month header item provider.
+  public func withMonthHeaderItemProvider(
+    _ monthHeaderItemProvider: @escaping (_ month: Month) -> AnyCalendarItem)
+    -> CalendarViewContent
+  {
+    monthHeaderItemModelProvider = { .legacy(monthHeaderItemProvider($0)) }
+    return self
+  }
+
+  /// Configures the day-of-week item provider.
+  ///
+  /// `CalendarView` invokes the provided `dayOfWeekItemProvider` for each weekday index for the current calendar. For
+  /// example, for the en_US locale, 0 is Sunday, 1 is Monday, and 6 is Saturday. This will be different in some other locales. The
+  /// `CalendarItem`s that you return will be used to create the views for each day-of-week view in `CalendarView`.
+  ///
+  /// If you don't configure your own day-of-week item provider via this function, then a default day-of-week item provider will be used.
+  ///
+  /// - Parameters:
+  ///   - dayOfWeekItemProvider: A closure (that is retained) that returns a `CalendarItem` representing a day of the week.
+  ///   - month: The month in which the day-of-week item belongs. This parameter will be `nil` if days of the week are pinned to
+  ///   the top of the calendar, since in that scenario, they don't belong to any particular month.
+  ///   - weekdayIndex: The weekday index for which to provide a `CalendarItem`.
+  /// - Returns: A mutated `CalendarViewContent` instance with a new day-of-week item provider.
+  public func withDayOfWeekItemProvider(
+    _ dayOfWeekItemProvider: @escaping (_ month: Month?, _ weekdayIndex: Int) -> AnyCalendarItem)
+    -> CalendarViewContent
+  {
+    dayOfWeekItemModelProvider = { .legacy(dayOfWeekItemProvider($0, $1)) }
+    return self
+  }
+
+  /// Configures the day item provider.
+  ///
+  /// `CalendarView` invokes the provided `dayItemProvider` for each day being displayed. The `CalendarItem`s that you
+  /// return will be used to create the views for each day in `CalendarView`. In most cases, this view should be some kind of label
+  /// that tells the user the day number of the month. You can also add other decoration, like a badge or background, by including it in
+  /// the view that your `CalendarItem` creates.
+  ///
+  /// If you don't configure your own day item provider via this function, then a default day item provider will be used.
+  ///
+  /// - Parameters:
+  ///   - dayItemProvider: A closure (that is retained) that returns a `CalendarItem` representing a single day in the
+  ///   calendar.
+  ///   - day: The `Day` for which to provide a day item.
+  /// - Returns: A mutated `CalendarViewContent` instance with a new day item provider.
+  public func withDayItemProvider(
+    _ dayItemProvider: @escaping (_ day: Day) -> AnyCalendarItem)
+    -> CalendarViewContent
+  {
+    dayItemModelProvider = { .legacy(dayItemProvider($0)) }
+    return self
+  }
+
+  /// Configures the day range item provider.
+  ///
+  /// `CalendarView` invokes the provided `dayRangeItemProvider` for each day range in the `dateRanges` set. Date
+  /// ranges will be converted to day ranges by using the `calendar`passed into the `CalendarViewContent` initializer. The
+  /// `CalendarItem` that you return for each day range will be used to create a view that spans the entire frame encapsulating all
+  /// days in that day range. This behavior makes day range items useful for things like day range selection indicators that might have
+  /// specific styling requirements for different parts of the selected day range. For example, you might have a cross fade in your day
+  /// range selection indicator view when a day range spans multiple months, or you might have rounded end caps for the start and
+  /// end of a day range.
+  ///
+  /// The views created by the `CalendarItem`s provided by this function will be placed at a lower z-index than the layer of day
+  /// items. If you don't configure your own day range item provider via this function, then no day range view will be displayed.
+  ///
+  /// If you don't want to show any day range items, pass in an empty set for the `dateRanges` parameter.
+  ///
+  /// - Parameters:
+  ///   - dateRanges: The date ranges for which `CalendarView` will invoke your day range item provider closure.
+  ///   - dayRangeItemProvider: A closure (that is retained) that returns a `CalendarItem` representing a day range in the
+  ///   calendar.
+  ///   - dayRangeLayoutContext: The layout context for the day range containing information about the frames of days and
+  ///   bounds in which your day range item will be displayed.
+  /// - Returns: A mutated `CalendarViewContent` instance with a new day range item provider.
+  public func withDayRangeItemProvider(
+    for dateRanges: Set<ClosedRange<Date>>,
+    _ dayRangeItemProvider: @escaping (
+      _ dayRangeLayoutContext: DayRangeLayoutContext)
+      -> AnyCalendarItem)
+    -> CalendarViewContent
+  {
+    let dayRanges = Set(dateRanges.map { DayRange(containing: $0, in: calendar) })
+    dayRangesAndItemModelProvider = (dayRanges, { .legacy(dayRangeItemProvider($0)) })
+    return self
+  }
+
+  /// Configures the overlay item provider.
+  ///
+  /// `CalendarView` invokes the provided `overlayItemProvider` for each overlaid item location in the
+  /// `overlaidItemLocations` set. All of the layout information needed to create an overlay item is provided via the overlay
+  /// context passed into the `overlayItemProvider` closure. The `CalendarItem` that you return for each overlaid item
+  /// location will be used to create a view that spans the visible bounds of the calendar when that overlaid item's location is visible. This
+  /// behavior makes overlay items useful for things like tooltips.
+  ///
+  /// - Parameters:
+  ///   - overlaidItemLocations: The overlaid item locations for which `CalendarView` will invoke your overlay item
+  ///   provider closure.
+  ///   - overlayItemProvider: A closure (that is retained) that returns a `CalendarItem` representing an overlay.
+  ///   - overlayLayoutContext: The layout context for the overlaid item location containing information about that location's
+  ///   frame and the bounds in which your overlay item will be displayed.
+  /// - Returns: A mutated `CalendarViewContent` instance with a new overlay item provider.
+  public func withOverlayItemProvider(
+    for overlaidItemLocations: Set<OverlaidItemLocation>,
+    _ overlayItemProvider: @escaping (
+      _ overlayLayoutContext: OverlayLayoutContext)
+      -> AnyCalendarItem)
+    -> CalendarViewContent
+  {
+    overlaidItemLocationsAndItemModelProvider = (
+      overlaidItemLocations,
+      { .legacy(overlayItemProvider($0)) })
+    return self
+  }
+  
+}


### PR DESCRIPTION
## Details

This PR greatly simplifies the API for making calendar item models. With this change, API consumers will no longer need to:
- figure out what `styleID`s are / how to use them
- know that there's view recycling / reusing going on under the hood (related to `styleID`)
- understand what each of the `CalendarItem` closures does (there are no more closures 😄)

We're going from this:
```swift
.withDayItemProvider { day in
        let isSelected = day == selectedDay

        return CalendarItem<DayView, Day>(
          viewModel: day,
          styleID: isSelected ? "Selected" : "Default",
          buildView: { DayView(isSelectedStyle: isSelected) },
          updateViewModel: { [weak self] dayView, day in
            dayView.dayText = "\(day.day)"

            if let date = self?.calendar.date(from: day.components) {
              dayView.dayAccessibilityText = self?.dayDateFormatter.string(from: date)
            } else {
              dayView.dayAccessibilityText = nil
            }
          },
          updateHighlightState: { dayView, isHighlighted in
            dayView.isHighlighted = isHighlighted
          })
      }
```

to this:

```swift
.withDayItemModelProvider { [weak self] day in
        let dayAccessibilityText: String?
        if let date = self?.calendar.date(from: day.components) {
          dayAccessibilityText = self?.dayDateFormatter.string(from: date)
        } else {
          dayAccessibilityText = nil
        }

        return CalendarItemModel<DayView>(
          invariantViewProperties: .init(isSelectedStyle: day == selectedDay),
          viewModel: .init(dayText: "\(day.day)", dayAccessibilityText: dayAccessibilityText))
      }
```

The core idea behind this change is that API consumers create types conforming to `CalendarItemViewRepresentable` for each view they want to display in the  calendar. `CalendarItemViewRepresentable ` has a static function for making a view, and updating a view with a given view model. People can make existing view subclasses conform to `CalendarItemViewRepresentable`, or create separate types to handle implementing the protocol requirements.

I found a way to implement this in a backwards-compatible way. `CalendarItem`, the old item model type that required developers to figure out styleID and other complicated things, is now marked as deprecated. Similarly, any `CalendarViewContent` functions using `CalendarItem` are also marked as deprecated. `CalendarItemModel` is the new path forward.

Note the base branch of this is not `master` - there are a few more PRs coming but I wanted to divide up the code since this was getting a bit big.

## Related Issue

Inspired by this issue https://github.com/airbnb/HorizonCalendar/issues/29

## Motivation and Context

Simplifying the API and making it way harder for for tricky bugs to happen.

## How Has This Been Tested

Simulator. More to come.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
