### PR TITLE
Bk/improve voiceover support

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -13,12 +13,12 @@ jobs:
 
     strategy:
       matrix:
-        destination: ['platform=iOS Simulator,OS=11.0,name=iPhone 8', 'platform=iOS Simulator,OS=13.5,name=iPhone 11']
+        destination: ['platform=iOS Simulator,OS=11.0,name=iPhone 8', 'platform=iOS Simulator,OS=13.6,name=iPhone 11']
 
     steps:
     - uses: actions/checkout@v2
     - name: Build
       run: xcodebuild clean build -scheme HorizonCalendar
     - name: Run tests
-      run: xcodebuild clean test -project HorizonCalendar.xcodeproj -scheme HorizonCalendar -destination "name=iPhone 8,OS=13.5"
+      run: xcodebuild clean test -project HorizonCalendar.xcodeproj -scheme HorizonCalendar -destination "name=iPhone 8,OS=13.6"
 

--- a/HorizonCalendar.podspec
+++ b/HorizonCalendar.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name = "HorizonCalendar"
-  spec.version = "1.1.4"
+  spec.version = "1.1.5"
   spec.license = "Apache License, Version 2.0"
   spec.summary = "A declarative, performant, calendar UI component that supports use cases ranging from simple date pickers to fully-featured calendar apps."
 

--- a/HorizonCalendar.xcodeproj/project.pbxproj
+++ b/HorizonCalendar.xcodeproj/project.pbxproj
@@ -528,7 +528,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.4;
+				MARKETING_VERSION = 1.1.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.HorizonCalendar;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -562,7 +562,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.4;
+				MARKETING_VERSION = 1.1.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.HorizonCalendar;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Sources/Internal/VisibleItemsProvider.swift
+++ b/Sources/Internal/VisibleItemsProvider.swift
@@ -106,6 +106,8 @@ final class VisibleItemsProvider {
     var centermostLayoutItem = previouslyVisibleLayoutItem
     var firstVisibleDay: Day?
     var lastVisibleDay: Day?
+    var firstVisibleMonth: Month?
+    var lastVisibleMonth: Month?
     var framesForVisibleMonths = [Month: CGRect]()
     var framesForVisibleDays = [Day: CGRect]()
     var minimumScrollOffset: CGFloat?
@@ -160,6 +162,8 @@ final class VisibleItemsProvider {
           centermostLayoutItem: &centermostLayoutItem,
           firstVisibleDay: &firstVisibleDay,
           lastVisibleDay: &lastVisibleDay,
+          firstVisibleMonth: &firstVisibleMonth,
+          lastVisibleMonth: &lastVisibleMonth,
           framesForVisibleMonths: &framesForVisibleMonths,
           framesForVisibleDays: &framesForVisibleDays,
           minimumScrollOffset: &minimumScrollOffset,
@@ -186,6 +190,8 @@ final class VisibleItemsProvider {
           centermostLayoutItem: &centermostLayoutItem,
           firstVisibleDay: &firstVisibleDay,
           lastVisibleDay: &lastVisibleDay,
+          firstVisibleMonth: &firstVisibleMonth,
+          lastVisibleMonth: &lastVisibleMonth,
           framesForVisibleMonths: &framesForVisibleMonths,
           framesForVisibleDays: &framesForVisibleDays,
           minimumScrollOffset: &minimumScrollOffset,
@@ -213,6 +219,13 @@ final class VisibleItemsProvider {
       visibleDayRange = nil
     }
 
+    let visibleMonthRange: MonthRange?
+    if let firstVisibleMonth = firstVisibleMonth, let lastVisibleMonth = lastVisibleMonth {
+      visibleMonthRange = firstVisibleMonth...lastVisibleMonth
+    } else {
+      visibleMonthRange = nil
+    }
+
     // Handle overlay items
     handleOverlayItemsIfNeeded(
       bounds: bounds,
@@ -226,6 +239,7 @@ final class VisibleItemsProvider {
       visibleItems: visibleItems,
       centermostLayoutItem: centermostLayoutItem,
       visibleDayRange: visibleDayRange,
+      visibleMonthRange: visibleMonthRange,
       framesForVisibleMonths: framesForVisibleMonths,
       framesForVisibleDays: framesForVisibleDays,
       minimumScrollOffset: minimumScrollOffset,
@@ -240,6 +254,8 @@ final class VisibleItemsProvider {
   {
     var visibleItems = [VisibleCalendarItem]()
 
+    // Look behind / ahead by 1 month to ensure that users can navigate by heading, even if an
+    // adjacent month header is off-screen.
     let lowerBoundMonth = calendar.month(byAddingMonths: -1, to: visibleMonthRange.lowerBound)
     let upperBoundMonth = calendar.month(byAddingMonths: 1, to: visibleMonthRange.upperBound)
     let monthRange = lowerBoundMonth...upperBoundMonth
@@ -551,6 +567,8 @@ final class VisibleItemsProvider {
     centermostLayoutItem: inout LayoutItem,
     firstVisibleDay: inout Day?,
     lastVisibleDay: inout Day?,
+    firstVisibleMonth: inout Month?,
+    lastVisibleMonth: inout Month?,
     framesForVisibleMonths: inout [Month: CGRect],
     framesForVisibleDays: inout [Day: CGRect],
     minimumScrollOffset: inout CGFloat?,
@@ -565,6 +583,9 @@ final class VisibleItemsProvider {
       numberOfConsecutiveNonIntersectingItems = 0
 
       let month = layoutItem.itemType.month
+
+      firstVisibleMonth = min(firstVisibleMonth ?? month, month)
+      lastVisibleMonth = max(lastVisibleMonth ?? month, month)
 
       // Calculate and the current month frame if it's not cached; it will be used in other
       // calculations.
@@ -960,6 +981,7 @@ struct VisibleItemsDetails {
   let visibleItems: Set<VisibleCalendarItem>
   let centermostLayoutItem: LayoutItem
   let visibleDayRange: DayRange?
+  let visibleMonthRange: MonthRange?
   let framesForVisibleMonths: [Month: CGRect]
   let framesForVisibleDays: [Day: CGRect]
   let minimumScrollOffset: CGFloat?

--- a/Sources/Public/CalendarView.swift
+++ b/Sources/Public/CalendarView.swift
@@ -99,7 +99,7 @@ public final class CalendarView: UIView {
 
   /// The range of months that are partially of fully visible.
   public var visibleMonthRange: MonthRange? {
-    visibleDayRange.map { $0.lowerBound.month...$0.upperBound.month }
+    visibleItemsDetails?.visibleMonthRange
   }
 
   /// The range of days that are partially or fully visible.
@@ -723,7 +723,7 @@ extension CalendarView {
       }
       guard
         let visibleItemsDetails = visibleItemsDetails,
-        let visibleDayRange = visibleItemsDetails.visibleDayRange
+        let visibleMonthRange = visibleMonthRange
       else
       {
         return nil
@@ -731,10 +731,7 @@ extension CalendarView {
 
       let visibleItems = visibleItemsProvider.visibleItemsForAccessibilityElements(
         surroundingPreviouslyVisibleLayoutItem: visibleItemsDetails.centermostLayoutItem,
-        visibleMonthRange: MonthRange(
-          uncheckedBounds: (
-            lower: visibleDayRange.lowerBound.month,
-            upper: visibleDayRange.upperBound.month)))
+        visibleMonthRange: visibleMonthRange)
 
       var elements = [Any]()
       for visibleCalendarItem in visibleItems {

--- a/Sources/Public/CalendarView.swift
+++ b/Sources/Public/CalendarView.swift
@@ -204,8 +204,6 @@ public final class CalendarView: UIView {
       UIAccessibility.post(
         notification: .layoutChanged,
         argument: visibleViewsForVisibleItems[element.correspondingItem])
-    } else {
-      UIAccessibility.post(notification: .layoutChanged, argument: focusedAccessibilityElement)
     }
   }
 


### PR DESCRIPTION
## Details

Improves Voiceover behavior when navigating by month heading:
====

To fix navigating by heading, I had to add a proper `visibleMonthRange` implementation. The previous implementation just looked at the min / max of the `visibleDayRange`, which caused partially visible months that only had their month header visible (but no days) to be excluded from the `visibleMonthRange`. This resulted in a the infamous "Heading not found" voiceover bug since my one month lookahead/behind logic depended on the visibleMonthRange being accurate.

Reduces delay when a user selects a day using voiceover
====

I was unnecessarily triggering a `layoutChanged` voiceover notification whenever a user selected a day, which would cause the user's focus to be lost. That notification wasn't necessary, and was actually probably causing some minor confusion since the `layoutChanged` notification actually plays a short blip sound to indicate re-layout.

-------

![ezgif-2-1eca7222362b](https://user-images.githubusercontent.com/746571/88167651-06712000-cbce-11ea-9804-16b6e7c03213.gif)


## Related Issue

N/A

## Motivation and Context

Get Voiceover working great!

## How Has This Been Tested

Tested using Voiceover in the example app on a real device.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
