### PR TITLE
Bk/inset support

### DIFF
--- a/HorizonCalendar.podspec
+++ b/HorizonCalendar.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name = "HorizonCalendar"
-  spec.version = "1.1.5"
+  spec.version = "1.2.0"
   spec.license = "Apache License, Version 2.0"
   spec.summary = "A declarative, performant, calendar UI component that supports use cases ranging from simple date pickers to fully-featured calendar apps."
 

--- a/HorizonCalendar.xcodeproj/project.pbxproj
+++ b/HorizonCalendar.xcodeproj/project.pbxproj
@@ -528,7 +528,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.5;
+				MARKETING_VERSION = 1.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.HorizonCalendar;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -562,7 +562,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.5;
+				MARKETING_VERSION = 1.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.HorizonCalendar;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A declarative, performant, calendar UI component that supports use cases ranging
 Features:
 
 - Supports all calendars from `Foundation.Calendar` (Gregorian, Japanese, Hebrew, etc.)
-- Displaying months in a vertically-scrolling or horizontally-scrolling layout
+- Display months in a vertically-scrolling or horizontally-scrolling layout
 - Declarative API that enables unidirectional data flow for updating the content of the calendar
 - A custom layout system that enables virtually infinite date ranges without increasing memory usage
 - Specify custom views for individual days, month headers, and days of the week
@@ -23,9 +23,10 @@ Features:
 - A day selection handler to monitor when a day is tapped
 - Customizable layout metrics
 - Pinning days of the week to the top
-- Showing partial boundary months (exactly 2020-03-14 to 2020-04-20, for example)
-- Scrolling to arbitrary dates and months, with or without animation
+- Show partial boundary months (exactly 2020-03-14 to 2020-04-20, for example)
+- Scroll to arbitrary dates and months, with or without animation
 - Robust accessibility support
+- Inset the content without affecting the scrollable region using `UIView` layout margins
 
 `HorizonCalendar` serves as the foundation for the date pickers and calendars used in Airbnb's highest trafficked flows.
 

--- a/Sources/Internal/FrameProvider.swift
+++ b/Sources/Internal/FrameProvider.swift
@@ -13,8 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import CoreGraphics
-import Foundation
+import UIKit
 
 /// Provides frame and size information about all core layout items. The calendar is laid out lazily, starting with an initial known layout
 /// frame (like the frame of an initially visible month header). All subsequent layout calculations are done by laying out items adjacent to
@@ -26,17 +25,19 @@ final class FrameProvider {
   init(
     content: CalendarViewContent,
     size: CGSize,
+    layoutMargins: NSDirectionalEdgeInsets,
     scale: CGFloat,
     monthHeaderHeight: CGFloat)
   {
     self.content = content
     self.size = size
+    self.layoutMargins = layoutMargins
     self.scale = scale
     self.monthHeaderHeight = monthHeaderHeight
 
     switch content.monthsLayout {
     case .vertical:
-      monthWidth = size.width
+      monthWidth = size.width - layoutMargins.leading - layoutMargins.trailing
     case .horizontal(let _monthWidth):
       monthWidth = _monthWidth
     }
@@ -53,6 +54,7 @@ final class FrameProvider {
   // MARK: Internal
 
   let size: CGSize
+  let layoutMargins: NSDirectionalEdgeInsets
   let scale: CGFloat
   let daySize: CGSize
 

--- a/Sources/Internal/VisibleItemsProvider.swift
+++ b/Sources/Internal/VisibleItemsProvider.swift
@@ -26,6 +26,7 @@ final class VisibleItemsProvider {
     calendar: Calendar,
     content: CalendarViewContent,
     size: CGSize,
+    layoutMargins: NSDirectionalEdgeInsets,
     scale: CGFloat,
     monthHeaderHeight: CGFloat)
   {
@@ -38,6 +39,7 @@ final class VisibleItemsProvider {
     frameProvider = FrameProvider(
       content: content,
       size: size,
+      layoutMargins: layoutMargins,
       scale: scale,
       monthHeaderHeight: monthHeaderHeight)
   }
@@ -48,6 +50,10 @@ final class VisibleItemsProvider {
 
   var size: CGSize {
     frameProvider.size
+  }
+
+  var layoutMargins: NSDirectionalEdgeInsets {
+    frameProvider.layoutMargins
   }
 
   var scale: CGFloat {
@@ -701,18 +707,19 @@ final class VisibleItemsProvider {
       switch content.monthsLayout {
       case .vertical(let options):
         minimumScrollOffset = monthFrame.minY -
-          (options.pinDaysOfWeekToTop ? frameProvider.daySize.height : 0)
+          (options.pinDaysOfWeekToTop ? frameProvider.daySize.height : 0) -
+          layoutMargins.top
       case .horizontal:
-        minimumScrollOffset = monthFrame.minX
+        minimumScrollOffset = monthFrame.minX - layoutMargins.leading
       }
     }
 
     if month == content.dayRange.upperBound.month {
       switch content.monthsLayout {
       case .vertical:
-        maximumScrollOffset = monthFrame.maxY
+        maximumScrollOffset = monthFrame.maxY + layoutMargins.bottom
       case .horizontal:
-        maximumScrollOffset = monthFrame.maxX
+        maximumScrollOffset = monthFrame.maxX + layoutMargins.trailing
       }
     }
   }

--- a/Sources/Public/CalendarView.swift
+++ b/Sources/Public/CalendarView.swift
@@ -173,6 +173,7 @@ public final class CalendarView: UIView {
   }
 
   public override func layoutMarginsDidChange() {
+    super.layoutMarginsDidChange()
     setNeedsLayout()
   }
 

--- a/Sources/Public/CalendarView.swift
+++ b/Sources/Public/CalendarView.swift
@@ -142,12 +142,38 @@ public final class CalendarView: UIView {
     }
   }
 
+  /// `CalendarView` only supports positive values for `layoutMargins`. Negative values will be changed to `0`.
+  public override var layoutMargins: UIEdgeInsets {
+    didSet {
+      super.layoutMargins = UIEdgeInsets(
+        top: max(layoutMargins.top, 0),
+        left: max(layoutMargins.left, 0),
+        bottom: max(layoutMargins.bottom, 0),
+        right: max(layoutMargins.right, 0))
+    }
+  }
+
+  /// `CalendarView` only supports positive values for `directionalLayoutMargins`. Negative values will be changed to `0`.
+  public override var directionalLayoutMargins: NSDirectionalEdgeInsets {
+    didSet {
+      super.directionalLayoutMargins = NSDirectionalEdgeInsets(
+        top: max(directionalLayoutMargins.top, 0),
+        leading: max(directionalLayoutMargins.leading, 0),
+        bottom: max(directionalLayoutMargins.bottom, 0),
+        trailing: max(directionalLayoutMargins.trailing, 0))
+    }
+  }
+
   public override func didMoveToWindow() {
     super.didMoveToWindow()
 
     if window == nil {
       scrollToItemDisplayLink?.invalidate()
     }
+  }
+
+  public override func layoutMarginsDidChange() {
+    setNeedsLayout()
   }
 
   public override func layoutSubviews() {
@@ -388,6 +414,7 @@ public final class CalendarView: UIView {
     if
       let existingVisibleItemsProvider = _visibleItemsProvider,
       existingVisibleItemsProvider.size == bounds.size,
+      existingVisibleItemsProvider.layoutMargins == directionalLayoutMargins,
       existingVisibleItemsProvider.scale == scale
     {
       return existingVisibleItemsProvider
@@ -396,6 +423,7 @@ public final class CalendarView: UIView {
         calendar: calendar,
         content: content,
         size: bounds.size,
+        layoutMargins: directionalLayoutMargins,
         scale: scale,
         monthHeaderHeight: monthHeaderHeight())
       _visibleItemsProvider = visibleItemsProvider
@@ -404,9 +432,12 @@ public final class CalendarView: UIView {
   }
 
   private var initialMonthHeaderAnchorLayoutItem: LayoutItem {
-    visibleItemsProvider.anchorMonthHeaderItem(
+    let offset = CGPoint(
+      x: scrollView.contentOffset.x + directionalLayoutMargins.leading,
+      y: scrollView.contentOffset.y + directionalLayoutMargins.top)
+    return visibleItemsProvider.anchorMonthHeaderItem(
       for: content.monthRange.lowerBound,
-      offset: scrollView.contentOffset,
+      offset: offset,
       scrollPosition: .firstFullyVisiblePosition)
   }
 

--- a/Sources/Public/CalendarViewContent.swift
+++ b/Sources/Public/CalendarViewContent.swift
@@ -94,18 +94,30 @@ public final class CalendarViewContent {
 
   /// Configures the background color of `CalendarView`. The default value is `.systemBackground` on iOS 13+, and
   /// `.white` on earlier iOS versions.
+  ///
+  /// - Parameters:
+  ///   - backgroundColor: The backround color of the calendar.
+  /// - Returns: A mutated `CalendarViewContent` instance with a new background color.
   public func withBackgroundColor(_ backgroundColor: UIColor) -> CalendarViewContent {
     self.backgroundColor = backgroundColor
     return self
   }
 
   /// Configures the amount of spacing, in points, between months. The default value is `0`.
+  ///
+  /// - Parameters:
+  ///   - interMonthSpacing: The amount of spacing, in points, between months.
+  /// - Returns: A mutated `CalendarViewContent` instance with a new inter-month-spacing value.
   public func withInterMonthSpacing(_ interMonthSpacing: CGFloat) -> CalendarViewContent {
     self.interMonthSpacing = interMonthSpacing
     return self
   }
 
   /// Configures the amount to inset days and day-of-week items from the edges of a month. The default value is `.zero`.
+  ///
+  /// - Parameters:
+  ///   - monthDayInsets: The amount to inset days and day-of-week items from the edges of a month.
+  /// - Returns: A mutated `CalendarViewContent` instance with a new month-day-insets value.
   public func withMonthDayInsets(_ monthDayInsets: UIEdgeInsets) -> CalendarViewContent {
     self.monthDayInsets = monthDayInsets
     return self
@@ -114,8 +126,12 @@ public final class CalendarViewContent {
   /// Configures the amount of space between two day frames vertically.
   ///
   /// If `verticalDayMargin` and `horizontalDayMargin` are the same, then each day will appear to
-  /// have a 1:1 (square) aspect ratio. If `verticalDayMargin` and `horizontalDayMargin` are
-  //  different, then days can appear wider or taller.
+  /// have a 1:1 (square) aspect ratio. If `verticalDayMargin` and `horizontalDayMargin` are different, then days can
+  /// appear wider or taller.
+  ///
+  /// - Parameters:
+  ///   - verticalDayMargin: The amount of space between two day frames along the vertical axis.
+  /// - Returns: A mutated `CalendarViewContent` instance with a new vertical day margin value.
   public func withVerticalDayMargin(_ verticalDayMargin: CGFloat) -> CalendarViewContent {
     self.verticalDayMargin = verticalDayMargin
     return self
@@ -126,6 +142,10 @@ public final class CalendarViewContent {
   /// If `verticalDayMargin` and `horizontalDayMargin` are the same, then each day will appear to
   /// have a 1:1 (square) aspect ratio. If `verticalDayMargin` and `horizontalDayMargin` are
   /// different, then days can appear wider or taller.
+  ///
+  /// - Parameters:
+  ///   - horizontalDayMargin: The amount of space between two day frames along the horizontal axis.
+  /// - Returns: A mutated `CalendarViewContent` instance with a new horizontal day margin value.
   public func withHorizontalDayMargin(_ horizontalDayMargin: CGFloat) -> CalendarViewContent {
     self.horizontalDayMargin = horizontalDayMargin
     return self

--- a/Tests/FrameProviderTests.swift
+++ b/Tests/FrameProviderTests.swift
@@ -39,6 +39,7 @@ final class FrameProviderTests: XCTestCase {
         .withVerticalDayMargin(20)
         .withHorizontalDayMargin(10),
       size: size,
+      layoutMargins: .zero,
       scale: 3,
       monthHeaderHeight: monthHeaderHeight)
     verticalPinnedDaysOfWeekFrameProvider = FrameProvider(
@@ -51,6 +52,7 @@ final class FrameProviderTests: XCTestCase {
         .withVerticalDayMargin(20)
         .withHorizontalDayMargin(10),
       size: size,
+      layoutMargins: .zero,
       scale: 3,
       monthHeaderHeight: monthHeaderHeight)
     verticalPartialMonthFrameProvider = FrameProvider(
@@ -64,6 +66,7 @@ final class FrameProviderTests: XCTestCase {
         .withVerticalDayMargin(20)
         .withHorizontalDayMargin(10),
       size: size,
+      layoutMargins: .zero,
       scale: 3,
       monthHeaderHeight: monthHeaderHeight)
     horizontalFrameProvider = FrameProvider(
@@ -76,6 +79,7 @@ final class FrameProviderTests: XCTestCase {
         .withVerticalDayMargin(20)
         .withHorizontalDayMargin(10),
       size: size,
+      layoutMargins: .zero,
       scale: 3,
       monthHeaderHeight: monthHeaderHeight)
   }

--- a/Tests/VisibleItemsProviderTests.swift
+++ b/Tests/VisibleItemsProviderTests.swift
@@ -1535,6 +1535,7 @@ final class VisibleItemsProviderTests: XCTestCase {
         visibleDateRange: dateRange,
         monthsLayout: .vertical(options: VerticalMonthsLayoutOptions()))),
     size: size,
+    layoutMargins: .zero,
     scale: 2,
     monthHeaderHeight: 50)
 
@@ -1546,6 +1547,7 @@ final class VisibleItemsProviderTests: XCTestCase {
         visibleDateRange: dateRange,
         monthsLayout: .vertical(options: VerticalMonthsLayoutOptions(pinDaysOfWeekToTop: true)))),
     size: size,
+    layoutMargins: .zero,
     scale: 2,
     monthHeaderHeight: 50)
 
@@ -1558,6 +1560,7 @@ final class VisibleItemsProviderTests: XCTestCase {
         monthsLayout: .vertical(
           options: VerticalMonthsLayoutOptions(alwaysShowCompleteBoundaryMonths: false)))),
     size: size,
+    layoutMargins: .zero,
     scale: 2,
     monthHeaderHeight: 50)
 
@@ -1569,6 +1572,7 @@ final class VisibleItemsProviderTests: XCTestCase {
         visibleDateRange: dateRange,
         monthsLayout: .horizontal(monthWidth: 300))),
     size: size,
+    layoutMargins: .zero,
     scale: 2,
     monthHeaderHeight: 50)
 


### PR DESCRIPTION
## Details

This adds support for insetting the content without affecting the scrollable / user-interact-able region using the `layoutMargins` and `directionalLayoutMargins` properties on `CalendarView.swift`

The approach of using layout margins seems to work pretty well - one nice thing we get for free is automatic safe area inset respecting (which can be turned off via the flag on `UIView`). The one quirk is that we don't support negative layout margins, since this causes really weird scrolling / layout logic. I can't really think of a valid reason to use negative values either, but hopefully I'm not missing something obvious.

One other caveat - For horizontal layout calendars, the current sizing logic doesn't take into account the vertical dimension of the frame. Instead, it's determined by the `monthWidth` that's passed into `CalendarViewContent`. In hindsight, this probably isn't how the horizontal layout should work - instead, the horizontal layout should determine its month width by looking at the available height. Because of this shortcoming with how the horizontal layout works, there's not a great way to make layout margins work perfectly in the vertical dimension, since the available space in the vertical dimension isn't taken into account. I don't think this is a showstopper, as the leading / trailing / top margins all work well. It's only when you use both a top and bottom margin that the latter is basically just ignored. As part of the 2.0 release of HorizonCalendar, I'll change this API / behavior so that it works in a more predictable way, which will have the consequence of making the layout margins work correctly for top / bottom when using a horizontal layout.

| Vertical | Horizontal (just leading / trailing margins) |
| ---- | ---- |
| ![ezgif-6-41b58e78f50a](https://user-images.githubusercontent.com/746571/88641215-bb468980-d073-11ea-9528-cab6e9470622.gif) | ![ezgif-6-eaf73940399e](https://user-images.githubusercontent.com/746571/88641272-d1544a00-d073-11ea-8dce-7067a9632ccd.gif) |

## Related Issue

https://github.com/airbnb/HorizonCalendar/issues/19

## Motivation and Context

It's common for people to want to inset their calendar's content without adjusting the frame or scrollable region. For example, this could be useful when displaying a vertically scrolling calendar on iPad, where the content would look way too big if it went edge-to-edge horizontally. By setting layout margins, the content of the calendar can be inset while still allowing scroll gestures all the way to the edge of the screen.

## How Has This Been Tested

Tested on simulator and device.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
