### PR TITLE
Bk/remove unnecessary layout margins

### DIFF
--- a/HorizonCalendar.podspec
+++ b/HorizonCalendar.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name = "HorizonCalendar"
-  spec.version = "1.2.0"
+  spec.version = "1.2.1"
   spec.license = "Apache License, Version 2.0"
   spec.summary = "A declarative, performant, calendar UI component that supports use cases ranging from simple date pickers to fully-featured calendar apps."
 

--- a/HorizonCalendar.xcodeproj/project.pbxproj
+++ b/HorizonCalendar.xcodeproj/project.pbxproj
@@ -528,7 +528,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.0;
+				MARKETING_VERSION = 1.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.HorizonCalendar;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -562,7 +562,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.0;
+				MARKETING_VERSION = 1.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.HorizonCalendar;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Sources/Public/CalendarView.swift
+++ b/Sources/Public/CalendarView.swift
@@ -506,7 +506,6 @@ public final class CalendarView: UIView {
 
     let firstMonthHeaderItem = content.monthHeaderItemProvider(content.monthRange.lowerBound)
     let firstMonthHeader = firstMonthHeaderItem.buildView()
-    configureHorizontalInsets(for: firstMonthHeader)
     firstMonthHeaderItem.updateViewModel(view: firstMonthHeader)
 
     let size = firstMonthHeader.systemLayoutSizeFitting(
@@ -573,16 +572,6 @@ public final class CalendarView: UIView {
     } else {
       view.isUserInteractionEnabled = false
     }
-
-    // Update the horizontal layout margins for month headers since they're displayed edge-to-edge.
-    if case .layoutItemType(.monthHeader) = visibleItem.itemType {
-      configureHorizontalInsets(for: view.contentView)
-    }
-  }
-
-  private func configureHorizontalInsets(for contentView: UIView) {
-    contentView.layoutMargins.left = content.monthDayInsets.left
-    contentView.layoutMargins.right = content.monthDayInsets.right
   }
 
   private func startScrollingTowardTargetItem() {


### PR DESCRIPTION
## Details

This removes some legacy behavior that overwrote the month header's layout margins with the left/right values from `monthDateInsets`.

## Related Issue

N/A

## Motivation and Context

API consumers should be free to set whatever layout margins they want on their month headers, without being overwritten by the calendar.

## How Has This Been Tested

Tested in the Airbnb app and in the demo project. Confirmed that layout margins are not reset / overwritten.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
