### PR TITLE
Bk/days of the week row background

### DIFF
--- a/HorizonCalendar.podspec
+++ b/HorizonCalendar.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name = "HorizonCalendar"
-  spec.version = "1.2.1"
+  spec.version = "1.2.2"
   spec.license = "Apache License, Version 2.0"
   spec.summary = "A declarative, performant, calendar UI component that supports use cases ranging from simple date pickers to fully-featured calendar apps."
 

--- a/HorizonCalendar.xcodeproj/project.pbxproj
+++ b/HorizonCalendar.xcodeproj/project.pbxproj
@@ -528,7 +528,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.1;
+				MARKETING_VERSION = 1.2.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.HorizonCalendar;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -562,7 +562,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.1;
+				MARKETING_VERSION = 1.2.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.HorizonCalendar;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Sources/Internal/FrameProvider.swift
+++ b/Sources/Internal/FrameProvider.swift
@@ -217,13 +217,13 @@ final class FrameProvider {
     yContentOffset: CGFloat)
     -> CGRect
   {
-    let x = content.monthDayInsets.left +
+    let x = layoutMargins.leading + content.monthDayInsets.left +
       (CGFloat(dayOfWeekPosition.rawValue - 1) * (daySize.width + content.horizontalDayMargin))
     return CGRect(origin: CGPoint(x: x, y: yContentOffset), size: daySize)
   }
 
   func frameOfPinnedDayOfWeekBackground(yContentOffset: CGFloat) -> CGRect {
-    CGRect(x: 0, y: yContentOffset, width: monthWidth, height: daySize.height)
+    CGRect(x: layoutMargins.leading, y: yContentOffset, width: monthWidth, height: daySize.height)
   }
 
   // MARK: Private

--- a/Sources/Internal/VisibleCalendarItem.swift
+++ b/Sources/Internal/VisibleCalendarItem.swift
@@ -80,6 +80,7 @@ extension VisibleCalendarItem {
   enum ItemType: Equatable, Hashable {
     case layoutItemType(LayoutItem.ItemType)
     case pinnedDayOfWeek(DayOfWeekPosition)
+    case pinnedDaysOfWeekRowBackground
     case dayRange(DayRange)
     case overlayItem(CalendarViewContent.OverlaidItemLocation)
 
@@ -87,6 +88,7 @@ extension VisibleCalendarItem {
       switch self {
       case .layoutItemType: return 500
       case .pinnedDayOfWeek: return 1000
+      case .pinnedDaysOfWeekRowBackground: return 999
       case .dayRange: return 250
       case .overlayItem: return 750
       }

--- a/Sources/Internal/VisibleItemsProvider.swift
+++ b/Sources/Internal/VisibleItemsProvider.swift
@@ -809,6 +809,22 @@ final class VisibleItemsProvider {
         hasUpdatesHeightOfPinnedContent = true
       }
     }
+
+    // The pinned days-of-the-week row needs a background view to prevent gaps between individual
+    // items as content is scrolled underneath.
+    visibleItems.insert(
+      VisibleCalendarItem(
+        calendarItem: CalendarItem<UIView, Int>.init(
+          viewModel: 0,
+          styleID: "PinnedDaysOfTheWeekRowBackground",
+          buildView: { [unowned self] in
+            let view = UIView()
+            view.backgroundColor = self.content.backgroundColor
+            return view
+          },
+          updateViewModel: { _, _ in }),
+        itemType: .pinnedDaysOfWeekRowBackground,
+        frame: frameProvider.frameOfPinnedDayOfWeekBackground(yContentOffset: yContentOffset)))
   }
 
   private func handleOverlayItemsIfNeeded(

--- a/Tests/VisibleItemsProviderTests.swift
+++ b/Tests/VisibleItemsProviderTests.swift
@@ -405,6 +405,7 @@ final class VisibleItemsProviderTests: XCTestCase {
       "[itemType: .layoutItemType(.day(2020-06-04)), frame: (188.0, 530.0, 35.5, 35.5)]",
       "[itemType: .layoutItemType(.day(2020-06-13)), frame: (279.5, 585.5, 35.5, 36.0)]",
       "[itemType: .layoutItemType(.monthHeader(2020-06)), frame: (0.0, 450.0, 320.0, 50.0)]",
+      "[itemType: .pinnedDaysOfWeekRowBackground, frame: (0.0, 450.0, 320.0, 35.5)]",
     ]
 
     XCTAssert(
@@ -719,6 +720,7 @@ final class VisibleItemsProviderTests: XCTestCase {
       "[itemType: .layoutItemType(.day(2020-01-17)), frame: (233.5, 236.5, 36.0, 35.5)]",
       "[itemType: .layoutItemType(.monthHeader(2020-01)), frame: (0.0, 45.0, 320.0, 50.0)]",
       "[itemType: .layoutItemType(.day(2020-01-12)), frame: (5.0, 236.5, 35.5, 35.5)]",
+      "[itemType: .pinnedDaysOfWeekRowBackground, frame: (0.0, 50.0, 320.0, 35.5)]",
     ]
 
     XCTAssert(
@@ -1630,6 +1632,8 @@ extension VisibleCalendarItem: CustomStringConvertible {
       itemTypeText = layoutItemType.description
     case .pinnedDayOfWeek(let position):
       itemTypeText = ".pinnedDayOfWeek(\(position))"
+    case .pinnedDaysOfWeekRowBackground:
+      itemTypeText = ".pinnedDaysOfWeekRowBackground"
     case .dayRange(let dayRange):
       itemTypeText = ".dayRange(\(dayRange.lowerBound), \(dayRange.upperBound))"
     case .overlayItem(let overlaidItemLocation):


### PR DESCRIPTION
## Details

This PR fixes 2 bugs
- Pinned days of the week are not inset by the view's layout margins
- Pinned days of the week show content scrolling underneath them if there's a `horizontalDayMargin >= 0` configured

Video demonstrating the second issue:
![ezgif-6-fbd5fffb86c4](https://user-images.githubusercontent.com/746571/89111944-0d3f3480-d411-11ea-8f1a-2ba462795439.gif)


## Related Issue

N/A

## Motivation and Context

Bug fixes

## How Has This Been Tested

iOS simulator

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
