### PR TITLE
Bk/fix horizontal layout clipping

### DIFF
--- a/HorizonCalendar.podspec
+++ b/HorizonCalendar.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name = "HorizonCalendar"
-  spec.version = "1.2.2"
+  spec.version = "1.2.3"
   spec.license = "Apache License, Version 2.0"
   spec.summary = "A declarative, performant, calendar UI component that supports use cases ranging from simple date pickers to fully-featured calendar apps."
 

--- a/HorizonCalendar.xcodeproj/project.pbxproj
+++ b/HorizonCalendar.xcodeproj/project.pbxproj
@@ -528,7 +528,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.2;
+				MARKETING_VERSION = 1.2.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.HorizonCalendar;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -562,7 +562,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.2;
+				MARKETING_VERSION = 1.2.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.HorizonCalendar;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Sources/Internal/VisibleItemsProvider.swift
+++ b/Sources/Internal/VisibleItemsProvider.swift
@@ -575,8 +575,7 @@ final class VisibleItemsProvider {
   {
     let month = layoutItem.itemType.month
 
-    // Calculate and the current month frame if it's not cached; it will be used in other
-    // calculations.
+    // Calculate the current month frame if it's not cached; it will be used in other calculations.
     let monthFrame: CGRect
     if let cachedMonthFrame = framesForVisibleMonths[month] {
       monthFrame = cachedMonthFrame

--- a/Sources/Public/MonthsLayout.swift
+++ b/Sources/Public/MonthsLayout.swift
@@ -33,6 +33,13 @@ public enum MonthsLayout {
 
   // MARK: Internal
 
+  var isHorizontal: Bool {
+    switch self {
+    case .vertical: return false
+    case .horizontal: return true
+    }
+  }
+
   var pinDaysOfWeekToTop: Bool {
     switch self {
     case .vertical(let options): return options.pinDaysOfWeekToTop

--- a/Tests/VisibleItemsProviderTests.swift
+++ b/Tests/VisibleItemsProviderTests.swift
@@ -605,6 +605,59 @@ final class VisibleItemsProviderTests: XCTestCase {
       "Unexpected maximum scroll offset.")
   }
 
+  func testHorizontalLeadingMonthPartiallyClipped() {
+    let details = horizontalVisibleItemsProvider.detailsForVisibleItems(
+      surroundingPreviouslyVisibleLayoutItem: LayoutItem(
+        itemType: .monthHeader(Month(era: 1, year: 2020, month: 2, isInGregorianCalendar: true)),
+        frame: CGRect(x: 315, y: 0, width: 300, height: 50)),
+      offset: CGPoint(x: 295, y: 0))
+
+    let expectedVisibleItemDescriptions: Set<String> = [
+      "[itemType: .layoutItemType(.day(2020-02-18)), frame: (405.5, 291.5, 33.0, 33.0)]",
+      "[itemType: .layoutItemType(.dayOfWeekInMonth(.last, 2020-02)), frame: (577.0, 80.0, 33.0, 33.0)]",
+      "[itemType: .layoutItemType(.day(2020-02-23)), frame: (320.0, 344.5, 33.0, 32.5)]",
+      "[itemType: .layoutItemType(.day(2020-02-05)), frame: (448.5, 185.5, 33.0, 33.0)]",
+      "[itemType: .layoutItemType(.day(2020-02-10)), frame: (363.0, 238.5, 32.5, 33.0)]",
+      "[itemType: .layoutItemType(.day(2020-02-20)), frame: (491.5, 291.5, 33.0, 33.0)]",
+      "[itemType: .layoutItemType(.day(2020-02-22)), frame: (577.0, 291.5, 33.0, 33.0)]",
+      "[itemType: .layoutItemType(.dayOfWeekInMonth(.fifth, 2020-02)), frame: (491.5, 80.0, 33.0, 33.0)]",
+      "[itemType: .layoutItemType(.dayOfWeekInMonth(.fourth, 2020-02)), frame: (448.5, 80.0, 33.0, 33.0)]",
+      "[itemType: .layoutItemType(.day(2020-02-15)), frame: (577.0, 238.5, 33.0, 33.0)]",
+      "[itemType: .layoutItemType(.day(2020-02-03)), frame: (363.0, 185.5, 32.5, 33.0)]",
+      "[itemType: .layoutItemType(.day(2020-02-27)), frame: (491.5, 344.5, 33.0, 32.5)]",
+      "[itemType: .layoutItemType(.day(2020-02-01)), frame: (577.0, 133.0, 33.0, 32.5)]",
+      "[itemType: .layoutItemType(.day(2020-02-29)), frame: (577.0, 344.5, 33.0, 32.5)]",
+      "[itemType: .layoutItemType(.day(2020-02-26)), frame: (448.5, 344.5, 33.0, 32.5)]",
+      "[itemType: .layoutItemType(.day(2020-02-09)), frame: (320.0, 238.5, 33.0, 33.0)]",
+      "[itemType: .layoutItemType(.day(2020-02-16)), frame: (320.0, 291.5, 33.0, 33.0)]",
+      "[itemType: .layoutItemType(.day(2020-02-13)), frame: (491.5, 238.5, 33.0, 33.0)]",
+      "[itemType: .layoutItemType(.day(2020-02-06)), frame: (491.5, 185.5, 33.0, 33.0)]",
+      "[itemType: .layoutItemType(.dayOfWeekInMonth(.second, 2020-02)), frame: (363.0, 80.0, 32.5, 33.0)]",
+      "[itemType: .layoutItemType(.day(2020-02-08)), frame: (577.0, 185.5, 33.0, 33.0)]",
+      "[itemType: .layoutItemType(.day(2020-02-21)), frame: (534.5, 291.5, 32.5, 33.0)]",
+      "[itemType: .layoutItemType(.dayOfWeekInMonth(.first, 2020-02)), frame: (320.0, 80.0, 33.0, 33.0)]",
+      "[itemType: .layoutItemType(.day(2020-02-17)), frame: (363.0, 291.5, 32.5, 33.0)]",
+      "[itemType: .layoutItemType(.day(2020-02-11)), frame: (405.5, 238.5, 33.0, 33.0)]",
+      "[itemType: .layoutItemType(.day(2020-02-14)), frame: (534.5, 238.5, 32.5, 33.0)]",
+      "[itemType: .layoutItemType(.dayOfWeekInMonth(.third, 2020-02)), frame: (405.5, 80.0, 33.0, 33.0)]",
+      "[itemType: .layoutItemType(.day(2020-02-04)), frame: (405.5, 185.5, 33.0, 33.0)]",
+      "[itemType: .layoutItemType(.day(2020-02-12)), frame: (448.5, 238.5, 33.0, 33.0)]",
+      "[itemType: .layoutItemType(.day(2020-02-19)), frame: (448.5, 291.5, 33.0, 33.0)]",
+      "[itemType: .layoutItemType(.day(2020-02-24)), frame: (363.0, 344.5, 32.5, 32.5)]",
+      "[itemType: .layoutItemType(.day(2020-02-25)), frame: (405.5, 344.5, 33.0, 32.5)]",
+      "[itemType: .layoutItemType(.day(2020-02-02)), frame: (320.0, 185.5, 33.0, 33.0)]",
+      "[itemType: .layoutItemType(.day(2020-02-28)), frame: (534.5, 344.5, 32.5, 32.5)]",
+      "[itemType: .layoutItemType(.dayOfWeekInMonth(.sixth, 2020-02)), frame: (534.5, 80.0, 32.5, 33.0)]",
+      "[itemType: .layoutItemType(.monthHeader(2020-02)), frame: (315.0, 0.0, 300.0, 50.0)]",
+      "[itemType: .layoutItemType(.day(2020-02-07)), frame: (534.5, 185.5, 32.5, 33.0)]",
+      "[itemType: .layoutItemType(.monthHeader(2020-01)), frame: (0.0, 0.0, 300.0, 50.0)]",
+    ]
+
+    XCTAssert(
+      Set(details.visibleItems.map { $0.description }) == expectedVisibleItemDescriptions,
+      "Unexpected visible items.")
+  }
+
   // MARK: Scrolled to content boundary tests
 
   func testBoundaryVerticalVisibleItemsContext() {


### PR DESCRIPTION
## Details

I noticed an issue where month headers were getting clipped too soon when figuring out which items are visible / not visible in a horizontal layout calendar. The root issue is that my heuristic for figuring out what intersects the visible rect was wrong for horizontal layouts.

| Before | After |
| ---- | ---- |
| ![ezgif-4-ed9a537cf4de](https://user-images.githubusercontent.com/746571/89245066-e1f94880-d5bc-11ea-9ca7-00c36cc38d06.gif) | ![ezgif-4-e3ec00150639](https://user-images.githubusercontent.com/746571/89245048-db6ad100-d5bc-11ea-9a3c-1ac965d5450b.gif) |

## Related Issue

N/A

## Motivation and Context

Bug fix.

## How Has This Been Tested

iOS sim, unit test.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
