### PR TITLE
Bk/days of the week row separator

### DIFF
--- a/HorizonCalendar.podspec
+++ b/HorizonCalendar.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name = "HorizonCalendar"
-  spec.version = "1.2.3"
+  spec.version = "1.3.0"
   spec.license = "Apache License, Version 2.0"
   spec.summary = "A declarative, performant, calendar UI component that supports use cases ranging from simple date pickers to fully-featured calendar apps."
 

--- a/HorizonCalendar.xcodeproj/project.pbxproj
+++ b/HorizonCalendar.xcodeproj/project.pbxproj
@@ -528,7 +528,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.3;
+				MARKETING_VERSION = 1.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.HorizonCalendar;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -562,7 +562,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.3;
+				MARKETING_VERSION = 1.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.HorizonCalendar;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/README.md
+++ b/README.md
@@ -22,11 +22,12 @@ Features:
 - Specify custom views to overlay parts of the calendar, enabling features like tooltips
 - A day selection handler to monitor when a day is tapped
 - Customizable layout metrics
-- Pinning days of the week to the top
+- Pin the days-of-the-week row to the top
 - Show partial boundary months (exactly 2020-03-14 to 2020-04-20, for example)
 - Scroll to arbitrary dates and months, with or without animation
 - Robust accessibility support
 - Inset the content without affecting the scrollable region using `UIView` layout margins
+- Separator below the days-of-the-week row
 
 `HorizonCalendar` serves as the foundation for the date pickers and calendars used in Airbnb's highest trafficked flows.
 

--- a/Sources/Internal/FrameProvider.swift
+++ b/Sources/Internal/FrameProvider.swift
@@ -138,11 +138,6 @@ final class FrameProvider {
     return CGRect(origin: CGPoint(x: x, y: y), size: daySize)
   }
 
-  func frameOfDayOfWeekBackground(inMonthWithOrigin monthOrigin: CGPoint) -> CGRect {
-    let y = monthOrigin.y + monthHeaderHeight + content.monthDayInsets.top
-    return CGRect(x: monthOrigin.x, y: y, width: monthWidth, height: daySize.height)
-  }
-
   func frameOfDay(_ day: Day, inMonthWithOrigin monthOrigin: CGPoint) -> CGRect {
     let date = calendar.startDate(of: day)
     let dayOfWeekPosition = calendar.dayOfWeekPosition(for: date)
@@ -222,8 +217,32 @@ final class FrameProvider {
     return CGRect(origin: CGPoint(x: x, y: yContentOffset), size: daySize)
   }
 
-  func frameOfPinnedDayOfWeekBackground(yContentOffset: CGFloat) -> CGRect {
+  func frameOfPinnedDaysOfWeekRowBackground(yContentOffset: CGFloat) -> CGRect {
     CGRect(x: layoutMargins.leading, y: yContentOffset, width: monthWidth, height: daySize.height)
+  }
+
+  func frameOfPinnedDaysOfWeekRowSeparator(
+    yContentOffset: CGFloat,
+    separatorHeight: CGFloat)
+    -> CGRect
+  {
+    CGRect(
+      x: layoutMargins.leading,
+      y: yContentOffset + daySize.height - separatorHeight,
+      width: monthWidth,
+      height: separatorHeight)
+  }
+
+  func frameOfDaysOfWeekRowSeparator(
+    inMonthWithOrigin monthOrigin: CGPoint,
+    separatorHeight: CGFloat) -> CGRect
+  {
+    CGRect(
+      x: monthOrigin.x,
+      y: monthOrigin.y + monthHeaderHeight + content.monthDayInsets.top + daySize.height -
+        separatorHeight,
+      width: monthWidth,
+      height: separatorHeight)
   }
 
   // MARK: Private

--- a/Sources/Internal/VisibleCalendarItem.swift
+++ b/Sources/Internal/VisibleCalendarItem.swift
@@ -81,6 +81,8 @@ extension VisibleCalendarItem {
     case layoutItemType(LayoutItem.ItemType)
     case pinnedDayOfWeek(DayOfWeekPosition)
     case pinnedDaysOfWeekRowBackground
+    case pinnedDaysOfWeekRowSeparator
+    case daysOfWeekRowSeparator(Month)
     case dayRange(DayRange)
     case overlayItem(CalendarViewContent.OverlaidItemLocation)
 
@@ -89,6 +91,8 @@ extension VisibleCalendarItem {
       case .layoutItemType: return 500
       case .pinnedDayOfWeek: return 1000
       case .pinnedDaysOfWeekRowBackground: return 999
+      case .pinnedDaysOfWeekRowSeparator: return 1001
+      case .daysOfWeekRowSeparator: return 501
       case .dayRange: return 250
       case .overlayItem: return 750
       }

--- a/Sources/Internal/VisibleItemsProvider.swift
+++ b/Sources/Internal/VisibleItemsProvider.swift
@@ -618,6 +618,36 @@ final class VisibleItemsProvider {
                 ?? content.monthHeaderItemProvider(month)
             })
 
+          // Create a visible item for the separator view, if needed.
+          if
+            !content.monthsLayout.pinDaysOfWeekToTop,
+            let separatorOptions = content.daysOfTheWeekRowSeparatorOptions
+          {
+            let separatorItemType = VisibleCalendarItem.ItemType.daysOfWeekRowSeparator(month)
+            let separatorCalendarItem = calendarItemCache.value(
+              for: separatorItemType,
+              missingValueProvider: {
+                previousCalendarItemCache?[separatorItemType] ??
+                  CalendarItem<UIView, Month>(
+                    viewModel: month,
+                    styleID: "DaysOfTheWeekRowSeparator",
+                    buildView: {
+                      let view = UIView()
+                      view.backgroundColor = separatorOptions.color
+                      return view
+                    },
+                    updateViewModel: { _, _ in })
+              })
+
+            visibleItems.insert(
+              VisibleCalendarItem(
+                calendarItem: separatorCalendarItem,
+                itemType: separatorItemType,
+                frame: frameProvider.frameOfDaysOfWeekRowSeparator(
+                  inMonthWithOrigin: monthFrame.origin,
+                  separatorHeight: separatorOptions.height)))
+          }
+
         case let .dayOfWeekInMonth(dayOfWeekPosition, month):
           calendarItem = calendarItemCache.value(
             for: itemType,
@@ -800,7 +830,34 @@ final class VisibleItemsProvider {
           },
           updateViewModel: { _, _ in }),
         itemType: .pinnedDaysOfWeekRowBackground,
-        frame: frameProvider.frameOfPinnedDayOfWeekBackground(yContentOffset: yContentOffset)))
+        frame: frameProvider.frameOfPinnedDaysOfWeekRowBackground(yContentOffset: yContentOffset)))
+
+    // Create a visible item for the separator view, if needed.
+    if let separatorOptions = content.daysOfTheWeekRowSeparatorOptions {
+      let separatorItemType = VisibleCalendarItem.ItemType.pinnedDaysOfWeekRowSeparator
+      let separatorCalendarItem = calendarItemCache.value(
+        for: separatorItemType,
+        missingValueProvider: {
+          previousCalendarItemCache?[separatorItemType] ??
+            CalendarItem<UIView, Int>(
+              viewModel: 0,
+              styleID: "PinnedDaysOfTheWeekRowSeparator",
+              buildView: {
+                let view = UIView()
+                view.backgroundColor = separatorOptions.color
+                return view
+              },
+              updateViewModel: { _, _ in })
+        })
+
+      visibleItems.insert(
+        VisibleCalendarItem(
+          calendarItem: separatorCalendarItem,
+          itemType: separatorItemType,
+          frame: frameProvider.frameOfPinnedDaysOfWeekRowSeparator(
+            yContentOffset: yContentOffset,
+            separatorHeight: separatorOptions.height)))
+    }
   }
 
   private func handleOverlayItemsIfNeeded(

--- a/Sources/Public/CalendarViewContent.swift
+++ b/Sources/Public/CalendarViewContent.swift
@@ -151,6 +151,19 @@ public final class CalendarViewContent {
     return self
   }
 
+  /// Configures the days-of-the-week row's separator options. The separator appears below the days-of-the-week row.
+  ///
+  /// - Parameters:
+  ///   - options: An instance that has properties to control various aspects of the separator's design.
+  /// - Returns: A mutated `CalendarViewContent` instance with a days-of-the-week row separator configured.
+  public func withDaysOfTheWeekRowSeparator(
+    options: DaysOfTheWeekRowSeparatorOptions)
+    -> CalendarViewContent
+  {
+    daysOfTheWeekRowSeparatorOptions = options
+    return self
+  }
+
   /// Configures the month header item provider.
   ///
   /// `CalendarView` invokes the provided `monthHeaderItemProvider` for each month in the range of months being
@@ -293,6 +306,7 @@ public final class CalendarViewContent {
   private(set) var monthDayInsets: UIEdgeInsets = .zero
   private(set) var verticalDayMargin: CGFloat = 0
   private(set) var horizontalDayMargin: CGFloat = 0
+  private(set) var daysOfTheWeekRowSeparatorOptions: DaysOfTheWeekRowSeparatorOptions?
 
   private(set) var monthHeaderItemProvider: (Month) -> AnyCalendarItem
   private(set) var dayOfWeekItemProvider: (_ month: Month?, _ weekdayIndex: Int) -> AnyCalendarItem
@@ -372,6 +386,41 @@ extension CalendarViewContent {
     /// available bounds.
     public let availableBounds: CGRect
 
+  }
+
+}
+
+// MARK: - CalendarViewContent.DaysOfTheWeekRowSeparatorOptions
+
+extension CalendarViewContent {
+
+  /// Used to configure the days-of-the-week row's separator.
+  public struct DaysOfTheWeekRowSeparatorOptions {
+
+    // MARK: Lifecycle
+
+    /// Initialized a new `DaysOfTheWeekRowSeparatorOptions`.
+    ///
+    /// - Parameters:
+    ///   - height: The height of the separator in points.
+    ///   - color: The color of the separator.
+    public init(height: CGFloat = 1, color: UIColor = .lightGray) {
+      self.height = height
+      self.color = color
+    }
+
+    // MARK: public
+
+    @available(iOS 13.0, *)
+    public static var systemStyleSeparator = DaysOfTheWeekRowSeparatorOptions(
+      height: 1,
+      color: .separator)
+
+    /// The height of the separator in points.
+    public var height: CGFloat
+
+    /// The color of the separator.
+    public var color: UIColor
   }
 
 }

--- a/Sources/Public/CalendarViewContent.swift
+++ b/Sources/Public/CalendarViewContent.swift
@@ -409,7 +409,7 @@ extension CalendarViewContent {
       self.color = color
     }
 
-    // MARK: public
+    // MARK: Public
 
     @available(iOS 13.0, *)
     public static var systemStyleSeparator = DaysOfTheWeekRowSeparatorOptions(

--- a/Tests/FrameProviderTests.swift
+++ b/Tests/FrameProviderTests.swift
@@ -347,29 +347,6 @@ final class FrameProviderTests: XCTestCase {
     XCTAssert(frame3 == expectedFrame3, "Incorrect frame for day of week.")
   }
 
-  func testDayOfWeekBackgroundFrame() {
-    let frame1 = verticalFrameProvider.frameOfDayOfWeekBackground(
-      inMonthWithOrigin: CGPoint(x: 0, y: 200))
-      .alignedToPixels(forScreenWithScale: 3)
-    let expectedFrame1 = CGRect(x: 0, y: 255, width: 320, height: 34.857142857142854)
-      .alignedToPixels(forScreenWithScale: 3)
-    XCTAssert(frame1 == expectedFrame1, "Incorrect frame for day of week background.")
-
-    let frame2 = verticalPinnedDaysOfWeekFrameProvider.frameOfDayOfWeekBackground(
-      inMonthWithOrigin: CGPoint(x: 0, y: 150))
-      .alignedToPixels(forScreenWithScale: 3)
-    let expectedFrame2 = CGRect(x: 0, y: 205, width: 320, height: 34.857142857142854)
-      .alignedToPixels(forScreenWithScale: 3)
-    XCTAssert(frame2 == expectedFrame2, "Incorrect frame for day of week background.")
-
-    let frame3 = horizontalFrameProvider.frameOfDayOfWeekBackground(
-      inMonthWithOrigin: CGPoint(x: 200, y: 0))
-      .alignedToPixels(forScreenWithScale: 3)
-    let expectedFrame3 = CGRect(x: 200, y: 55, width: 300, height: 32)
-      .alignedToPixels(forScreenWithScale: 3)
-    XCTAssert(frame3 == expectedFrame3, "Incorrect frame for day of week background.")
-  }
-
   func testDayFrameInMonth() {
     let frame1 = verticalFrameProvider.frameOfDay(
       Day(month: Month(era: 1, year: 2020, month: 04, isInGregorianCalendar: true), day: 20),
@@ -539,13 +516,33 @@ final class FrameProviderTests: XCTestCase {
     XCTAssert(frame1 == expectedFrame1, "Incorrect frame for pinned day of week.")
   }
 
-  func testPinnedDayOfWeekBackgroundFrame() {
-    let frame1 = verticalPinnedDaysOfWeekFrameProvider.frameOfPinnedDayOfWeekBackground(
+  func testPinnedDaysOfWeekBackgroundFrame() {
+    let frame1 = verticalPinnedDaysOfWeekFrameProvider.frameOfPinnedDaysOfWeekRowBackground(
       yContentOffset: 140)
       .alignedToPixels(forScreenWithScale: 3)
     let expectedFrame1 = CGRect(x: 0, y: 140, width: 320, height: 34.857142857142854)
       .alignedToPixels(forScreenWithScale: 3)
-    XCTAssert(frame1 == expectedFrame1, "Incorrect frame for pinned day of week background.")
+    XCTAssert(frame1 == expectedFrame1, "Incorrect frame for pinned days-of-week row background.")
+  }
+
+  func testPinnedDaysOfWeekSeparatorFrame() {
+    let frame1 = verticalPinnedDaysOfWeekFrameProvider.frameOfPinnedDaysOfWeekRowSeparator(
+      yContentOffset: 120,
+      separatorHeight: 2)
+    let expectedFrame1 = CGRect(x: 0, y: 152.85714285714286, width: 320, height: 2)
+    XCTAssert(frame1 == expectedFrame1, "Incorrect frame for pinned day-of-week row separator.")
+
+    let frame2 = verticalFrameProvider.frameOfDaysOfWeekRowSeparator(
+      inMonthWithOrigin: CGPoint(x: 0, y: 120),
+      separatorHeight: 1)
+    let expectedFrame2 = CGRect(x: 0, y: 208.85714285714286, width: 320, height: 1)
+    XCTAssert(frame2 == expectedFrame2, "Incorrect frame for day-of-week row separator.")
+
+    let frame3 = horizontalFrameProvider.frameOfDaysOfWeekRowSeparator(
+      inMonthWithOrigin: CGPoint(x: 421, y: 0),
+      separatorHeight: 10)
+    let expectedFrame3 = CGRect(x: 421, y: 77, width: 300, height: 10)
+    XCTAssert(frame3 == expectedFrame3, "Incorrect frame for day-of-week row separator.")
   }
 
   // MARK: Private

--- a/Tests/VisibleItemsProviderTests.swift
+++ b/Tests/VisibleItemsProviderTests.swift
@@ -340,6 +340,8 @@ final class VisibleItemsProviderTests: XCTestCase {
       "[itemType: .layoutItemType(.day(2020-03-24)), frame: (96.5, 503.0, 35.5, 35.5)]",
       "[itemType: .layoutItemType(.dayOfWeekInMonth(.third, 2020-03)), frame: (96.5, 280.0, 35.5, 35.5)]",
       "[itemType: .layoutItemType(.day(2020-03-04)), frame: (142.0, 335.5, 36.0, 36.0)]",
+      "[itemType: .daysOfWeekRowSeparator(2020-4), frame: (0.0, 724.0, 320.0, 1.0)]",
+      "[itemType: .daysOfWeekRowSeparator(2020-3), frame: (0.0, 314.5, 320.0, 1.0)]",
     ]
 
     XCTAssert(
@@ -406,6 +408,7 @@ final class VisibleItemsProviderTests: XCTestCase {
       "[itemType: .layoutItemType(.day(2020-06-13)), frame: (279.5, 585.5, 35.5, 36.0)]",
       "[itemType: .layoutItemType(.monthHeader(2020-06)), frame: (0.0, 450.0, 320.0, 50.0)]",
       "[itemType: .pinnedDaysOfWeekRowBackground, frame: (0.0, 450.0, 320.0, 35.5)]",
+      "[itemType: .pinnedDaysOfWeekRowSeparator, frame: (0.0, 484.5, 320.0, 1.0)]",
     ]
 
     XCTAssert(
@@ -452,6 +455,8 @@ final class VisibleItemsProviderTests: XCTestCase {
       "[itemType: .layoutItemType(.day(2020-01-30)), frame: (188.0, 391.5, 35.5, 35.5)]",
       "[itemType: .layoutItemType(.day(2020-01-29)), frame: (142.0, 391.5, 36.0, 35.5)]",
       "[itemType: .layoutItemType(.day(2020-02-01)), frame: (279.5, 578.0, 35.5, 35.5)]",
+      "[itemType: .daysOfWeekRowSeparator(2020-2), frame: (0.0, 557.0, 320.0, 1.0)]",
+      "[itemType: .daysOfWeekRowSeparator(2020-1), frame: (0.0, 314.5, 320.0, 1.0)]",
     ]
 
     XCTAssert(
@@ -521,6 +526,8 @@ final class VisibleItemsProviderTests: XCTestCase {
       "[itemType: .layoutItemType(.monthHeader(2020-05)), frame: (250.0, 0.0, 300.0, 50.0)]",
       "[itemType: .layoutItemType(.day(2020-04-15)), frame: (68.5, 238.5, 33.0, 33.0)]",
       "[itemType: .layoutItemType(.day(2020-04-18)), frame: (197.0, 238.5, 33.0, 33.0)]",
+      "[itemType: .daysOfWeekRowSeparator(2020-5), frame: (250.0, 112.0, 300.0, 1.0)]",
+      "[itemType: .daysOfWeekRowSeparator(2020-4), frame: (-65.0, 112.0, 300.0, 1.0)]",
     ]
 
     XCTAssert(
@@ -589,6 +596,7 @@ final class VisibleItemsProviderTests: XCTestCase {
       "[itemType: .layoutItemType(.day(2020-05-29)), frame: (233.5, 382.0, 36.0, 36.0)]",
       "[itemType: .layoutItemType(.day(2020-05-15)), frame: (233.5, 270.5, 36.0, 36.0)]",
       "[itemType: .layoutItemType(.day(2020-05-19)), frame: (96.5, 326.5, 35.5, 35.5)]",
+      "[itemType: .daysOfWeekRowSeparator(2020-6), frame: (0.0, 603.5, 320.0, 1.0)]",
     ]
 
     XCTAssert(
@@ -651,6 +659,8 @@ final class VisibleItemsProviderTests: XCTestCase {
       "[itemType: .layoutItemType(.monthHeader(2020-02)), frame: (315.0, 0.0, 300.0, 50.0)]",
       "[itemType: .layoutItemType(.day(2020-02-07)), frame: (534.5, 185.5, 32.5, 33.0)]",
       "[itemType: .layoutItemType(.monthHeader(2020-01)), frame: (0.0, 0.0, 300.0, 50.0)]",
+      "[itemType: .daysOfWeekRowSeparator(2020-1), frame: (0.0, 112.0, 300.0, 1.0)]",
+      "[itemType: .daysOfWeekRowSeparator(2020-2), frame: (315.0, 112.0, 300.0, 1.0)]",
     ]
 
     XCTAssert(
@@ -709,6 +719,8 @@ final class VisibleItemsProviderTests: XCTestCase {
       "[itemType: .layoutItemType(.day(2020-01-13)), frame: (50.5, 247.0, 36.0, 36.0)]",
       "[itemType: .layoutItemType(.day(2020-01-22)), frame: (142.0, 303.0, 36.0, 35.5)]",
       "[itemType: .layoutItemType(.dayOfWeekInMonth(.fifth, 2020-01)), frame: (188.0, 80.0, 35.5, 35.5)]",
+      "[itemType: .daysOfWeekRowSeparator(2020-1), frame: (0.0, 114.5, 320.0, 1.0)]",
+      "[itemType: .daysOfWeekRowSeparator(2020-2), frame: (0.0, 524.0, 320.0, 1.0)]",
     ]
 
     XCTAssert(
@@ -774,6 +786,7 @@ final class VisibleItemsProviderTests: XCTestCase {
       "[itemType: .layoutItemType(.monthHeader(2020-01)), frame: (0.0, 45.0, 320.0, 50.0)]",
       "[itemType: .layoutItemType(.day(2020-01-12)), frame: (5.0, 236.5, 35.5, 35.5)]",
       "[itemType: .pinnedDaysOfWeekRowBackground, frame: (0.0, 50.0, 320.0, 35.5)]",
+      "[itemType: .pinnedDaysOfWeekRowSeparator, frame: (0.0, 84.5, 320.0, 1.0)]",
     ]
 
     XCTAssert(
@@ -807,6 +820,7 @@ final class VisibleItemsProviderTests: XCTestCase {
       "[itemType: .layoutItemType(.dayOfWeekInMonth(.second, 2020-12)), frame: (50.5, 770.0, 36.0, 35.5)]",
       "[itemType: .layoutItemType(.dayOfWeekInMonth(.sixth, 2020-12)), frame: (233.5, 770.0, 36.0, 35.5)]",
       "[itemType: .layoutItemType(.day(2020-12-01)), frame: (96.5, 825.5, 35.5, 36.0)]",
+      "[itemType: .daysOfWeekRowSeparator(2020-12), frame: (0.0, 804.5, 320.0, 1.0)]",
     ]
 
     XCTAssert(
@@ -875,6 +889,8 @@ final class VisibleItemsProviderTests: XCTestCase {
       "[itemType: .layoutItemType(.dayOfWeekInMonth(.second, 2020-12)), frame: (1248.0, 80.0, 32.5, 33.0)]",
       "[itemType: .layoutItemType(.day(2020-12-07)), frame: (1248.0, 185.5, 32.5, 33.0)]",
       "[itemType: .layoutItemType(.day(2020-12-27)), frame: (1205.0, 344.5, 33.0, 32.5)]",
+      "[itemType: .daysOfWeekRowSeparator(2020-11), frame: (885.0, 112.0, 300.0, 1.0)]",
+      "[itemType: .daysOfWeekRowSeparator(2020-12), frame: (1200.0, 112.0, 300.0, 1.0)]",
     ]
 
     XCTAssert(
@@ -1648,6 +1664,7 @@ final class VisibleItemsProviderTests: XCTestCase {
       .withInterMonthSpacing(15)
       .withVerticalDayMargin(20)
       .withHorizontalDayMargin(10)
+      .withDaysOfTheWeekRowSeparator(options: .init(height: 1, color: .gray))
       .withMonthHeaderItemProvider  { _ in mockCalendarItem }
       .withDayOfWeekItemProvider { _, _ in mockCalendarItem }
       .withDayItemProvider { _ in mockCalendarItem }
@@ -1687,6 +1704,10 @@ extension VisibleCalendarItem: CustomStringConvertible {
       itemTypeText = ".pinnedDayOfWeek(\(position))"
     case .pinnedDaysOfWeekRowBackground:
       itemTypeText = ".pinnedDaysOfWeekRowBackground"
+    case .pinnedDaysOfWeekRowSeparator:
+      itemTypeText = ".pinnedDaysOfWeekRowSeparator"
+    case .daysOfWeekRowSeparator(let month):
+      itemTypeText = ".daysOfWeekRowSeparator(\(month.year)-\(month.month))"
     case .dayRange(let dayRange):
       itemTypeText = ".dayRange(\(dayRange.lowerBound), \(dayRange.upperBound))"
     case .overlayItem(let overlaidItemLocation):


### PR DESCRIPTION
## Details

This adds the ability to configure a separator view below the days-of-the-week row - whether it's a pinned row or a row that appears separately in each month.

| Pr-month Vertical | Per-month Horizontal | Pinned |
| ---- | ---- | ---- |
| ![Simulator Screen Shot - iPhone 8 - 2020-08-03 at 13 42 26](https://user-images.githubusercontent.com/746571/89248465-a95d6d00-d5c4-11ea-9bba-0c104d9b3493.png) | ![Simulator Screen Shot - iPhone 8 - 2020-08-03 at 13 54 59](https://user-images.githubusercontent.com/746571/89248473-b0847b00-d5c4-11ea-89f8-d01e11285604.png) | ![Simulator Screen Shot - iPhone 8 - 2020-08-03 at 13 56 42](https://user-images.githubusercontent.com/746571/89248484-b9754c80-d5c4-11ea-9273-8b251e6653cd.png) |

## Related Issue

N/A

## Motivation and Context

This adds back a key piece of functionality that used to exist in pre-release versions but was removed from the public 1.0 release.

## How Has This Been Tested

iOS simulator, unit tests.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
