### PR TITLE
Bk/horizon calendar 1.4.0/convert example project

### DIFF
--- a/Example/HorizonCalendarExample/HorizonCalendarExample/DayRangeIndicatorView.swift
+++ b/Example/HorizonCalendarExample/HorizonCalendarExample/DayRangeIndicatorView.swift
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import HorizonCalendar
 import UIKit
 
 // MARK: - DayRangeIndicatorView
@@ -21,8 +22,11 @@ final class DayRangeIndicatorView: UIView {
 
   // MARK: Lifecycle
 
-  init() {
+  init(indicatorColor: UIColor) {
+    self.indicatorColor = indicatorColor
+
     super.init(frame: .zero)
+
     backgroundColor = .clear
   }
 
@@ -41,7 +45,7 @@ final class DayRangeIndicatorView: UIView {
 
   override func draw(_ rect: CGRect) {
     let context = UIGraphicsGetCurrentContext()
-    context?.setFillColor(UIColor.blue.withAlphaComponent(0.15).cgColor)
+    context?.setFillColor(indicatorColor.cgColor)
 
     // Get frames of day rows in the range
     var dayRowFrames = [CGRect]()
@@ -63,6 +67,35 @@ final class DayRangeIndicatorView: UIView {
       context?.addPath(roundedRectanglePath.cgPath)
       context?.fillPath()
     }
+  }
+
+  // MARK: Private
+
+  private let indicatorColor: UIColor
+
+}
+
+// MARK: CalendarItemViewRepresentable
+
+extension DayRangeIndicatorView: CalendarItemViewRepresentable {
+
+  struct InvariantViewProperties: Hashable {
+    var indicatorColor = UIColor.blue.withAlphaComponent(0.15)
+  }
+
+  struct ViewModel: Equatable {
+    let framesOfDaysToHighlight: [CGRect]
+  }
+
+  static func makeView(
+    withInvariantViewProperties invariantViewProperties: InvariantViewProperties)
+    -> DayRangeIndicatorView
+  {
+    DayRangeIndicatorView(indicatorColor: invariantViewProperties.indicatorColor)
+  }
+
+  static func setViewModel(_ viewModel: ViewModel, on view: DayRangeIndicatorView) {
+    view.framesOfDaysToHighlight = viewModel.framesOfDaysToHighlight
   }
 
 }

--- a/Example/HorizonCalendarExample/HorizonCalendarExample/DayView.swift
+++ b/Example/HorizonCalendarExample/HorizonCalendarExample/DayView.swift
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import HorizonCalendar
 import UIKit
 
 // MARK: - DayView
@@ -21,13 +22,18 @@ final class DayView: UIView {
 
   // MARK: Lifecycle
 
-  init(isSelectedStyle: Bool) {
+  init(invariantViewProperties: InvariantViewProperties) {
+    dayLabel = UILabel()
+    dayLabel.font = invariantViewProperties.font
+    dayLabel.textAlignment = invariantViewProperties.textAlignment
+    dayLabel.textColor = invariantViewProperties.textColor
+
     super.init(frame: .zero)
 
     addSubview(dayLabel)
 
-    layer.borderColor = UIColor.blue.cgColor
-    layer.borderWidth = isSelectedStyle ? 2 : 0
+    layer.borderColor = invariantViewProperties.selectedColor.cgColor
+    layer.borderWidth = invariantViewProperties.isSelectedStyle ? 2 : 0
   }
 
   required init?(coder: NSCoder) {
@@ -57,17 +63,7 @@ final class DayView: UIView {
 
   // MARK: Private
 
-  private lazy var dayLabel: UILabel = {
-    let label = UILabel()
-    label.textAlignment = .center
-    label.font = UIFont.systemFont(ofSize: 18)
-    if #available(iOS 13.0, *) {
-      label.textColor = .label
-    } else {
-      label.textColor = .black
-    }
-    return label
-  }()
+  private let dayLabel: UILabel
 
   private func updateHighlightIndicator() {
     backgroundColor = isHighlighted ? UIColor.black.withAlphaComponent(0.1) : .clear
@@ -87,6 +83,37 @@ extension DayView {
   override var accessibilityLabel: String? {
     get { dayAccessibilityText ?? dayText }
     set { }
+  }
+
+}
+
+// MARK: CalendarItemViewRepresentable
+
+extension DayView: CalendarItemViewRepresentable {
+
+  struct InvariantViewProperties: Hashable {
+    var font = UIFont.systemFont(ofSize: 18)
+    var textAlignment = NSTextAlignment.center
+    var textColor: UIColor
+    var isSelectedStyle: Bool
+    var selectedColor = UIColor.blue
+  }
+
+  struct ViewModel: Equatable {
+    let dayText: String
+    let dayAccessibilityText: String?
+  }
+
+  static func makeView(
+    withInvariantViewProperties invariantViewProperties: InvariantViewProperties)
+    -> DayView
+  {
+    DayView(invariantViewProperties: invariantViewProperties)
+  }
+
+  static func setViewModel(_ viewModel: ViewModel, on view: DayView) {
+    view.dayText = viewModel.dayText
+    view.dayAccessibilityText = viewModel.dayAccessibilityText
   }
 
 }

--- a/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/PartialMonthVisibilityDemoViewController.swift
+++ b/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/PartialMonthVisibilityDemoViewController.swift
@@ -96,25 +96,24 @@ final class PartialMonthVisibilityDemoViewController: UIViewController, DemoView
       .withVerticalDayMargin(8)
       .withHorizontalDayMargin(8)
 
-      .withDayItemProvider { day in
-        let isSelected = day == selectedDay
+      .withDayItemModelProvider { [weak self] day in
+        let textColor: UIColor
+        if #available(iOS 13.0, *) {
+          textColor = .label
+        } else {
+          textColor = .black
+        }
 
-        return CalendarItem<DayView, Day>(
-          viewModel: day,
-          styleID: isSelected ? "Selected" : "Default",
-          buildView: { DayView(isSelectedStyle: isSelected) },
-          updateViewModel: { [weak self] dayView, day in
-            dayView.dayText = "\(day.day)"
+        let dayAccessibilityText: String?
+        if let date = self?.calendar.date(from: day.components) {
+          dayAccessibilityText = self?.dayDateFormatter.string(from: date)
+        } else {
+          dayAccessibilityText = nil
+        }
 
-            if let date = self?.calendar.date(from: day.components) {
-              dayView.dayAccessibilityText = self?.dayDateFormatter.string(from: date)
-            } else {
-              dayView.dayAccessibilityText = nil
-            }
-          },
-          updateHighlightState: { dayView, isHighlighted in
-            dayView.isHighlighted = isHighlighted
-          })
+        return CalendarItemModel<DayView>(
+          invariantViewProperties: .init(textColor: textColor, isSelectedStyle: day == selectedDay),
+          viewModel: .init(dayText: "\(day.day)", dayAccessibilityText: dayAccessibilityText))
       }
   }
 

--- a/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/SelectedDayTooltipDemoViewController.swift
+++ b/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/SelectedDayTooltipDemoViewController.swift
@@ -115,35 +115,32 @@ final class SelectedDayTooltipDemoViewController: UIViewController, DemoViewCont
 
       .withInterMonthSpacing(24)
 
-      .withDayItemProvider { day in
-        let isSelected = day == selectedDay
+      .withDayItemModelProvider { [weak self] day in
+        let textColor: UIColor
+        if #available(iOS 13.0, *) {
+          textColor = .label
+        } else {
+          textColor = .black
+        }
 
-        return CalendarItem<DayView, Day>(
-          viewModel: day,
-          styleID: isSelected ? "Selected" : "Default",
-          buildView: { DayView(isSelectedStyle: isSelected) },
-          updateViewModel: { [weak self] dayView, day in
-            dayView.dayText = "\(day.day)"
+        let dayAccessibilityText: String?
+        if let date = self?.calendar.date(from: day.components) {
+          dayAccessibilityText = self?.dayDateFormatter.string(from: date)
+        } else {
+          dayAccessibilityText = nil
+        }
 
-            if let date = self?.calendar.date(from: day.components) {
-              dayView.dayAccessibilityText = self?.dayDateFormatter.string(from: date)
-            } else {
-              dayView.dayAccessibilityText = nil
-            }
-          },
-          updateHighlightState: { dayView, isHighlighted in
-            dayView.isHighlighted = isHighlighted
-          })
+        return CalendarItemModel<DayView>(
+          invariantViewProperties: .init(textColor: textColor, isSelectedStyle: day == selectedDay),
+          viewModel: .init(dayText: "\(day.day)", dayAccessibilityText: dayAccessibilityText))
       }
 
-      .withOverlayItemProvider(for: overlaidItemLocations) { overlayLayoutContext in
-        CalendarItem<TooltipView, CGRect>(
-          viewModel: overlayLayoutContext.overlaidItemFrame,
-          styleID: "DayTooltip",
-          buildView: { TooltipView(text: "Selected Day") },
-          updateViewModel: { view, frameOfItemToOverlay in
-            view.frameOfTooltippedItem = frameOfItemToOverlay
-          })
+      .withOverlayItemModelProvider(for: overlaidItemLocations) { overlayLayoutContext in
+        CalendarItemModel<TooltipView>(
+          invariantViewProperties: .init(),
+          viewModel: .init(
+            frameOfTooltippedItem: overlayLayoutContext.overlaidItemFrame,
+            text: "Selected Day"))
       }
   }
 

--- a/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/SingleDaySelectionDemoViewController.swift
+++ b/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/SingleDaySelectionDemoViewController.swift
@@ -108,25 +108,24 @@ final class SingleDaySelectionDemoViewController: UIViewController, DemoViewCont
       .withVerticalDayMargin(8)
       .withHorizontalDayMargin(8)
 
-      .withDayItemProvider { day in
-        let isSelected = day == selectedDay
+      .withDayItemModelProvider { [weak self] day in
+        let textColor: UIColor
+        if #available(iOS 13.0, *) {
+          textColor = .label
+        } else {
+          textColor = .black
+        }
 
-        return CalendarItem<DayView, Day>(
-          viewModel: day,
-          styleID: isSelected ? "Selected" : "Default",
-          buildView: { DayView(isSelectedStyle: isSelected) },
-          updateViewModel: { [weak self] dayView, day in
-            dayView.dayText = "\(day.day)"
+        let dayAccessibilityText: String?
+        if let date = self?.calendar.date(from: day.components) {
+          dayAccessibilityText = self?.dayDateFormatter.string(from: date)
+        } else {
+          dayAccessibilityText = nil
+        }
 
-            if let date = self?.calendar.date(from: day.components) {
-              dayView.dayAccessibilityText = self?.dayDateFormatter.string(from: date)
-            } else {
-              dayView.dayAccessibilityText = nil
-            }
-          },
-          updateHighlightState: { dayView, isHighlighted in
-            dayView.isHighlighted = isHighlighted
-          })
+        return CalendarItemModel<DayView>(
+          invariantViewProperties: .init(textColor: textColor, isSelectedStyle: day == selectedDay),
+          viewModel: .init(dayText: "\(day.day)", dayAccessibilityText: dayAccessibilityText))
       }
   }
 

--- a/Example/HorizonCalendarExample/HorizonCalendarExample/TooltipView.swift
+++ b/Example/HorizonCalendarExample/HorizonCalendarExample/TooltipView.swift
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import HorizonCalendar
 import UIKit
 
 // MARK: - TooltipView
@@ -21,12 +22,22 @@ final class TooltipView: UIView {
 
   // MARK: Lifecycle
 
-  init(text: String) {
+  init(invariantViewProperties: InvariantViewProperties) {
+    backgroundView = UIView()
+    backgroundView.backgroundColor = invariantViewProperties.backgroundColor
+    backgroundView.layer.borderColor = invariantViewProperties.borderColor.cgColor
+    backgroundView.layer.borderWidth = 1
+    backgroundView.layer.cornerRadius = 6
+
+    label = UILabel()
+    label.font = invariantViewProperties.font
+    label.textAlignment = invariantViewProperties.textAlignment
+    label.lineBreakMode = .byTruncatingTail
+    label.textColor = invariantViewProperties.textColor
+
     super.init(frame: .zero)
 
     addSubview(backgroundView)
-
-    label.text = text
     addSubview(label)
   }
 
@@ -41,6 +52,11 @@ final class TooltipView: UIView {
       guard frameOfTooltippedItem != oldValue else { return }
       setNeedsLayout()
     }
+  }
+
+  var text: String {
+    get { label.text ?? "" }
+    set { label.text = newValue }
   }
 
   override func layoutSubviews() {
@@ -76,22 +92,38 @@ final class TooltipView: UIView {
 
   // MARK: Private
 
-  private lazy var backgroundView: UIView = {
-    let view = UIView()
-    view.backgroundColor = .white
-    view.layer.borderColor = UIColor.black.cgColor
-    view.layer.borderWidth = 1
-    view.layer.cornerRadius = 6
-    return view
-  }()
+  private let backgroundView: UIView
+  private let label: UILabel
 
-  private lazy var label: UILabel = {
-    let label = UILabel()
-    label.font = UIFont.systemFont(ofSize: 16)
-    label.textAlignment = .center
-    label.lineBreakMode = .byTruncatingTail
-    label.textColor = .black
-    return label
-  }()
+}
+
+// MARK: CalendarItemViewRepresentable
+
+extension TooltipView: CalendarItemViewRepresentable {
+
+  struct InvariantViewProperties: Hashable {
+    var backgroundColor = UIColor.white
+    var borderColor = UIColor.black
+    var font = UIFont.systemFont(ofSize: 16)
+    var textAlignment = NSTextAlignment.center
+    var textColor = UIColor.black
+  }
+
+  struct ViewModel: Equatable {
+    let frameOfTooltippedItem: CGRect?
+    let text: String
+  }
+
+  static func makeView(
+    withInvariantViewProperties invariantViewProperties: InvariantViewProperties)
+    -> TooltipView
+  {
+    TooltipView(invariantViewProperties: invariantViewProperties)
+  }
+
+  static func setViewModel(_ viewModel: ViewModel, on view: TooltipView) {
+    view.frameOfTooltippedItem = viewModel.frameOfTooltippedItem
+    view.text = viewModel.text
+  }
 
 }

--- a/Sources/Internal/VisibleItemsProvider.swift
+++ b/Sources/Internal/VisibleItemsProvider.swift
@@ -826,7 +826,7 @@ final class VisibleItemsProvider {
     visibleItems.insert(
       VisibleCalendarItem(
         calendarItemModel: .legacy(
-          CalendarItem<UIView, Int>.init(
+          CalendarItem<UIView, Int>(
             viewModel: 0,
             styleID: "PinnedDaysOfTheWeekRowBackground",
             buildView: { [unowned self] in


### PR DESCRIPTION
## Details

This is a follow-up to https://github.com/airbnb/HorizonCalendar/pull/30. This PR migrates the example project to use the new `CalendarItemModel` APIs rather than the deprecated `CalendarItem` APIs.

## Related Issue

N/A

## Motivation and Context

N/A

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
