### PR TITLE
Use iOS 13.7 on GitHub Actions to fix CI

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -13,12 +13,12 @@ jobs:
 
     strategy:
       matrix:
-        destination: ['platform=iOS Simulator,OS=11.0,name=iPhone 8', 'platform=iOS Simulator,OS=13.6,name=iPhone 11']
+        destination: ['platform=iOS Simulator,OS=11.0,name=iPhone 8', 'platform=iOS Simulator,OS=13.7,name=iPhone 11']
 
     steps:
     - uses: actions/checkout@v2
     - name: Build
       run: xcodebuild clean build -scheme HorizonCalendar
     - name: Run tests
-      run: xcodebuild clean test -project HorizonCalendar.xcodeproj -scheme HorizonCalendar -destination "name=iPhone 8,OS=13.6"
+      run: xcodebuild clean test -project HorizonCalendar.xcodeproj -scheme HorizonCalendar -destination "name=iPhone 8,OS=13.7"
 


### PR DESCRIPTION
## Details

Xcode 11.7 is now the default on GitHub Actions.

## Related Issue

N/A

## Motivation and Context

CI is currently failing after Xcode 11.7 became the default on GitHub Actions.

## How Has This Been Tested

Verified that the CI command succeeds with Xcode 11.7.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
