### PR TITLE
Bk/fix user interaction bug

### DIFF
--- a/HorizonCalendar.podspec
+++ b/HorizonCalendar.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name = "HorizonCalendar"
-  spec.version = "1.4.2"
+  spec.version = "1.4.3"
   spec.license = "Apache License, Version 2.0"
   spec.summary = "A declarative, performant, calendar UI component that supports use cases ranging from simple date pickers to fully-featured calendar apps."
 

--- a/HorizonCalendar.xcodeproj/project.pbxproj
+++ b/HorizonCalendar.xcodeproj/project.pbxproj
@@ -564,7 +564,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.4.2;
+				MARKETING_VERSION = 1.4.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.HorizonCalendar;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -598,7 +598,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.4.2;
+				MARKETING_VERSION = 1.4.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.HorizonCalendar;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Sources/Internal/VisibleCalendarItem.swift
+++ b/Sources/Internal/VisibleCalendarItem.swift
@@ -97,6 +97,18 @@ extension VisibleCalendarItem {
       case .overlayItem: return 750
       }
     }
+
+    var isUserInteractionEnabled: Bool {
+      switch self {
+      case .layoutItemType: return true
+      case .pinnedDayOfWeek: return true
+      case .pinnedDaysOfWeekRowBackground: return true
+      case .pinnedDaysOfWeekRowSeparator: return false
+      case .daysOfWeekRowSeparator: return false
+      case .dayRange: return false
+      case .overlayItem: return false
+      }
+    }
   }
 
 }

--- a/Sources/Public/CalendarView.swift
+++ b/Sources/Public/CalendarView.swift
@@ -559,6 +559,8 @@ public final class CalendarView: UIView {
     view.frame = visibleItem.frame.alignedToPixels(forScreenWithScale: scale)
     view.layer.zPosition = visibleItem.itemType.zPosition
 
+    view.isUserInteractionEnabled = visibleItem.itemType.isUserInteractionEnabled
+
     // Set up the selection handler
     if case .layoutItemType(.day(let day)) = visibleItem.itemType {
       view.selectionHandler = { [weak self] in


### PR DESCRIPTION
## Details

This PR fixes a regression introduced here https://github.com/airbnb/HorizonCalendar/pull/59 - since I enabled user interaction for all item views, I ended up making it so that day range items, which span and cover day items in the background, prevent touches from ever reaching day views. This makes it difficult to interact with the calendar.

 I'm pretty sure I introduced this bug in the OG calendar implementation at the end of 2019. If only I remembered that a few days ago before reintroducing it 😛 

![ezgif-7-68a514ab5a53](https://user-images.githubusercontent.com/746571/93662648-7eb16180-fa16-11ea-8654-8ac47fae3971.gif)


## Related Issue

N/A

## Motivation and Context

Fixing a regression and centralizing the logic for which item types should be interactive or not.

## How Has This Been Tested

Simulator / example app

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
