### PR TITLE
Fix incorrect inset

### DIFF
--- a/Sources/Public/CalendarView.swift
+++ b/Sources/Public/CalendarView.swift
@@ -455,16 +455,20 @@ public final class CalendarView: UIView {
   }
 
   private func targetAnchorLayoutItem(for scrollToItemContext: ScrollToItemContext) -> LayoutItem {
+    let offset = CGPoint(
+      x: scrollView.contentOffset.x + directionalLayoutMargins.leading,
+      y: scrollView.contentOffset.y + directionalLayoutMargins.top)
+
     switch scrollToItemContext.targetItem {
     case .month(let month):
       return visibleItemsProvider.anchorMonthHeaderItem(
         for: month,
-        offset: scrollView.contentOffset,
+        offset: offset,
         scrollPosition: scrollToItemContext.scrollPosition)
     case .day(let day):
       return visibleItemsProvider.anchorDayItem(
         for: day,
-        offset: scrollView.contentOffset,
+        offset: offset,
         scrollPosition: scrollToItemContext.scrollPosition)
     }
   }


### PR DESCRIPTION
## Details

This fixes a bug that causes the layout margins to get ignored after programmatically scrolling to an item.

## Related Issue

https://github.com/airbnb/HorizonCalendar/issues/52

## Motivation and Context

Fix minor layout bug.

## How Has This Been Tested

Simulator

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
