### PR TITLE
Bk/simplify month width api

### DIFF
--- a/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/DayRangeSelectionDemoViewController.swift
+++ b/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/DayRangeSelectionDemoViewController.swift
@@ -16,20 +16,7 @@
 import HorizonCalendar
 import UIKit
 
-// MARK: - DayRangeSelectionDemoViewController
-
-final class DayRangeSelectionDemoViewController: UIViewController, DemoViewController {
-
-  // MARK: Lifecycle
-
-  init(monthsLayout: MonthsLayout) {
-    self.monthsLayout = monthsLayout
-    super.init(nibName: nil, bundle: nil)
-  }
-
-  required init?(coder: NSCoder) {
-    fatalError("init(coder:) has not been implemented")
-  }
+final class DayRangeSelectionDemoViewController: DemoViewController {
 
   // MARK: Internal
 
@@ -37,12 +24,6 @@ final class DayRangeSelectionDemoViewController: UIViewController, DemoViewContr
     super.viewDidLoad()
 
     title = "Day Range Selection"
-
-    if #available(iOS 13.0, *) {
-      view.backgroundColor = .systemBackground
-    } else {
-      view.backgroundColor = .white
-    }
 
     calendarView.daySelectionHandler = { [weak self] day in
       guard let self = self else { return }
@@ -60,54 +41,9 @@ final class DayRangeSelectionDemoViewController: UIViewController, DemoViewContr
 
       self.calendarView.setContent(self.makeContent())
     }
-    view.addSubview(calendarView)
-
-    calendarView.translatesAutoresizingMaskIntoConstraints = false
-    switch monthsLayout {
-    case .vertical:
-      NSLayoutConstraint.activate([
-        calendarView.topAnchor.constraint(equalTo: view.layoutMarginsGuide.topAnchor),
-        calendarView.bottomAnchor.constraint(equalTo: view.layoutMarginsGuide.bottomAnchor),
-        calendarView.leadingAnchor.constraint(
-          greaterThanOrEqualTo: view.layoutMarginsGuide.leadingAnchor),
-        calendarView.trailingAnchor.constraint(
-          lessThanOrEqualTo: view.layoutMarginsGuide.trailingAnchor),
-        calendarView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-        calendarView.widthAnchor.constraint(lessThanOrEqualToConstant: 375)
-      ])
-    case .horizontal(let monthWidth):
-      NSLayoutConstraint.activate([
-        calendarView.centerYAnchor.constraint(equalTo: view.layoutMarginsGuide.centerYAnchor),
-        calendarView.heightAnchor.constraint(equalToConstant: monthWidth * 1.1),
-        calendarView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-        calendarView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-      ])
-    }
   }
 
-  // MARK: Private
-
-  private let monthsLayout: MonthsLayout
-
-  private lazy var calendarView = CalendarView(initialContent: makeContent())
-  private lazy var calendar = Calendar(identifier: .gregorian)
-  private lazy var dayDateFormatter: DateFormatter = {
-    let dateFormatter = DateFormatter()
-    dateFormatter.calendar = calendar
-    dateFormatter.dateFormat = DateFormatter.dateFormat(
-      fromTemplate: "EEEE, MMM d, yyyy",
-      options: 0,
-      locale: calendar.locale ?? Locale.current)
-    return dateFormatter
-  }()
-
-  private enum CalendarSelection {
-    case singleDay(Day)
-    case dayRange(DayRange)
-  }
-  private var calendarSelection: CalendarSelection?
-
-  private func makeContent() -> CalendarViewContent {
+  override func makeContent() -> CalendarViewContent {
     let startDate = calendar.date(from: DateComponents(year: 2020, month: 01, day: 01))!
     let endDate = calendar.date(from: DateComponents(year: 2021, month: 12, day: 31))!
 
@@ -169,5 +105,13 @@ final class DayRangeSelectionDemoViewController: UIViewController, DemoViewContr
             framesOfDaysToHighlight: dayRangeLayoutContext.daysAndFrames.map { $0.frame }))
       }
   }
+
+  // MARK: Private
+
+  private enum CalendarSelection {
+    case singleDay(Day)
+    case dayRange(DayRange)
+  }
+  private var calendarSelection: CalendarSelection?
 
 }

--- a/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/DemoViewController.swift
+++ b/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/DemoViewController.swift
@@ -4,8 +4,76 @@
 import HorizonCalendar
 import UIKit
 
-protocol DemoViewController: UIViewController {
+class DemoViewController: UIViewController {
 
-  init(monthsLayout: MonthsLayout)
+  // MARK: Lifecycle
+
+  required init(monthsLayout: MonthsLayout) {
+    self.monthsLayout = monthsLayout
+
+    super.init(nibName: nil, bundle: nil)
+  }
+
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  // MARK: Internal
+
+  let monthsLayout: MonthsLayout
+
+  lazy var calendarView = CalendarView(initialContent: makeContent())
+  lazy var calendar = Calendar(identifier: .gregorian)
+  lazy var dayDateFormatter: DateFormatter = {
+    let dateFormatter = DateFormatter()
+    dateFormatter.calendar = calendar
+    dateFormatter.dateFormat = DateFormatter.dateFormat(
+      fromTemplate: "EEEE, MMM d, yyyy",
+      options: 0,
+      locale: calendar.locale ?? Locale.current)
+    return dateFormatter
+  }()
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+
+    if #available(iOS 13.0, *) {
+      view.backgroundColor = .systemBackground
+    } else {
+      view.backgroundColor = .white
+    }
+
+    view.addSubview(calendarView)
+
+    calendarView.translatesAutoresizingMaskIntoConstraints = false
+    switch monthsLayout {
+    case .vertical:
+      NSLayoutConstraint.activate([
+        calendarView.topAnchor.constraint(equalTo: view.layoutMarginsGuide.topAnchor),
+        calendarView.bottomAnchor.constraint(equalTo: view.layoutMarginsGuide.bottomAnchor),
+        calendarView.leadingAnchor.constraint(
+          greaterThanOrEqualTo: view.layoutMarginsGuide.leadingAnchor),
+        calendarView.trailingAnchor.constraint(
+          lessThanOrEqualTo: view.layoutMarginsGuide.trailingAnchor),
+        calendarView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+        calendarView.widthAnchor.constraint(lessThanOrEqualToConstant: 375)
+      ])
+    case .horizontal:
+      NSLayoutConstraint.activate([
+        calendarView.centerYAnchor.constraint(equalTo: view.layoutMarginsGuide.centerYAnchor),
+        calendarView.heightAnchor.constraint(equalToConstant: 275),
+        calendarView.leadingAnchor.constraint(
+          greaterThanOrEqualTo: view.leadingAnchor),
+        calendarView.trailingAnchor.constraint(
+          lessThanOrEqualTo: view.trailingAnchor),
+        calendarView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+        calendarView.widthAnchor.constraint(lessThanOrEqualToConstant: 375)
+      ])
+    }
+  }
+
+  func makeContent() -> CalendarViewContent {
+    fatalError("Must be implemented by a subclass.")
+  }
 
 }

--- a/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/LargeDayRangeDemoViewController.swift
+++ b/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/LargeDayRangeDemoViewController.swift
@@ -16,20 +16,7 @@
 import HorizonCalendar
 import UIKit
 
-// MARK: - LargeDayRangeDemoViewController
-
-final class LargeDayRangeDemoViewController: UIViewController, DemoViewController {
-
-  // MARK: Lifecycle
-
-  init(monthsLayout: MonthsLayout) {
-    self.monthsLayout = monthsLayout
-    super.init(nibName: nil, bundle: nil)
-  }
-
-  required init?(coder: NSCoder) {
-    fatalError("init(coder:) has not been implemented")
-  }
+final class LargeDayRangeDemoViewController: DemoViewController {
 
   // MARK: Internal
 
@@ -38,36 +25,6 @@ final class LargeDayRangeDemoViewController: UIViewController, DemoViewControlle
 
     title = "Large Day Range"
 
-    if #available(iOS 13.0, *) {
-      view.backgroundColor = .systemBackground
-    } else {
-      view.backgroundColor = .white
-    }
-
-    view.addSubview(calendarView)
-
-    calendarView.translatesAutoresizingMaskIntoConstraints = false
-    switch monthsLayout {
-    case .vertical:
-      NSLayoutConstraint.activate([
-        calendarView.topAnchor.constraint(equalTo: view.layoutMarginsGuide.topAnchor),
-        calendarView.bottomAnchor.constraint(equalTo: view.layoutMarginsGuide.bottomAnchor),
-        calendarView.leadingAnchor.constraint(
-          greaterThanOrEqualTo: view.layoutMarginsGuide.leadingAnchor),
-        calendarView.trailingAnchor.constraint(
-          lessThanOrEqualTo: view.layoutMarginsGuide.trailingAnchor),
-        calendarView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-        calendarView.widthAnchor.constraint(lessThanOrEqualToConstant: 375)
-      ])
-    case .horizontal(let monthWidth):
-      NSLayoutConstraint.activate([
-        calendarView.centerYAnchor.constraint(equalTo: view.layoutMarginsGuide.centerYAnchor),
-        calendarView.heightAnchor.constraint(equalToConstant: monthWidth * 1.1),
-        calendarView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-        calendarView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-      ])
-    }
-
     let january1500CE = calendar.date(from: DateComponents(era: 1, year: 1500, month: 01, day: 01))!
     calendarView.scroll(
       toMonthContaining: january1500CE,
@@ -75,14 +32,7 @@ final class LargeDayRangeDemoViewController: UIViewController, DemoViewControlle
       animated: false)
   }
 
-  // MARK: Private
-
-  private let monthsLayout: MonthsLayout
-
-  private lazy var calendarView = CalendarView(initialContent: makeContent())
-  private lazy var calendar = Calendar(identifier: .gregorian)
-
-  private func makeContent() -> CalendarViewContent {
+  override func makeContent() -> CalendarViewContent {
     let startDate = calendar.date(from: DateComponents(era: 0, year: 0100, month: 01, day: 01))!
     let endDate = calendar.date(from: DateComponents(era: 1, year: 2000, month: 12, day: 31))!
 

--- a/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/PartialMonthVisibilityDemoViewController.swift
+++ b/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/PartialMonthVisibilityDemoViewController.swift
@@ -4,20 +4,7 @@
 import HorizonCalendar
 import UIKit
 
-// MARK: - PartialMonthVisibilityDemoViewController
-
-final class PartialMonthVisibilityDemoViewController: UIViewController, DemoViewController {
-
-  // MARK: Lifecycle
-
-  init(monthsLayout: MonthsLayout) {
-    self.monthsLayout = monthsLayout
-    super.init(nibName: nil, bundle: nil)
-  }
-
-  required init?(coder: NSCoder) {
-    fatalError("init(coder:) has not been implemented")
-  }
+final class PartialMonthVisibilityDemoViewController: DemoViewController {
 
   // MARK: Internal
 
@@ -26,62 +13,15 @@ final class PartialMonthVisibilityDemoViewController: UIViewController, DemoView
 
     title = "Partial Month Visibility"
 
-    if #available(iOS 13.0, *) {
-      view.backgroundColor = .systemBackground
-    } else {
-      view.backgroundColor = .white
-    }
-
     calendarView.daySelectionHandler = { [weak self] day in
       guard let self = self else { return }
 
       self.selectedDay = day
       self.calendarView.setContent(self.makeContent())
     }
-    view.addSubview(calendarView)
-
-    calendarView.translatesAutoresizingMaskIntoConstraints = false
-    switch monthsLayout {
-    case .vertical:
-      NSLayoutConstraint.activate([
-        calendarView.topAnchor.constraint(equalTo: view.layoutMarginsGuide.topAnchor),
-        calendarView.bottomAnchor.constraint(equalTo: view.layoutMarginsGuide.bottomAnchor),
-        calendarView.leadingAnchor.constraint(
-          greaterThanOrEqualTo: view.layoutMarginsGuide.leadingAnchor),
-        calendarView.trailingAnchor.constraint(
-          lessThanOrEqualTo: view.layoutMarginsGuide.trailingAnchor),
-        calendarView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-        calendarView.widthAnchor.constraint(lessThanOrEqualToConstant: 375)
-      ])
-    case .horizontal(let monthWidth):
-      NSLayoutConstraint.activate([
-        calendarView.centerYAnchor.constraint(equalTo: view.layoutMarginsGuide.centerYAnchor),
-        calendarView.heightAnchor.constraint(equalToConstant: monthWidth * 1.1),
-        calendarView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-        calendarView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-      ])
-    }
   }
 
-  // MARK: Private
-
-  private let monthsLayout: MonthsLayout
-
-  private lazy var calendarView = CalendarView(initialContent: makeContent())
-  private lazy var calendar = Calendar(identifier: .gregorian)
-  private lazy var dayDateFormatter: DateFormatter = {
-    let dateFormatter = DateFormatter()
-    dateFormatter.calendar = calendar
-    dateFormatter.dateFormat = DateFormatter.dateFormat(
-      fromTemplate: "EEEE, MMM d, yyyy",
-      options: 0,
-      locale: calendar.locale ?? Locale.current)
-    return dateFormatter
-  }()
-
-  private var selectedDay: Day?
-
-  private func makeContent() -> CalendarViewContent {
+  override func makeContent() -> CalendarViewContent {
     let startDate = calendar.date(from: DateComponents(year: 2020, month: 01, day: 16))!
     let endDate = calendar.date(from: DateComponents(year: 2020, month: 12, day: 05))!
 
@@ -116,6 +56,10 @@ final class PartialMonthVisibilityDemoViewController: UIViewController, DemoView
           viewModel: .init(dayText: "\(day.day)", dayAccessibilityText: dayAccessibilityText))
       }
   }
+
+  // MARK: Private
+
+  private var selectedDay: Day?
 
 }
 

--- a/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/ScrollToDayWithAnimationDemoViewController.swift
+++ b/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/ScrollToDayWithAnimationDemoViewController.swift
@@ -16,57 +16,12 @@
 import HorizonCalendar
 import UIKit
 
-// MARK: - ScrollToDayWithAnimationDemoViewController
-
-final class ScrollToDayWithAnimationDemoViewController: UIViewController, DemoViewController {
-
-  // MARK: Lifecycle
-
-  init(monthsLayout: MonthsLayout) {
-    self.monthsLayout = monthsLayout
-    super.init(nibName: nil, bundle: nil)
-  }
-
-  required init?(coder: NSCoder) {
-    fatalError("init(coder:) has not been implemented")
-  }
-
-  // MARK: Internal
+final class ScrollToDayWithAnimationDemoViewController: DemoViewController {
 
   override func viewDidLoad() {
     super.viewDidLoad()
 
     title = "Scroll to Day with Animation"
-
-    if #available(iOS 13.0, *) {
-      view.backgroundColor = .systemBackground
-    } else {
-      view.backgroundColor = .white
-    }
-
-    view.addSubview(calendarView)
-
-    calendarView.translatesAutoresizingMaskIntoConstraints = false
-    switch monthsLayout {
-    case .vertical:
-      NSLayoutConstraint.activate([
-        calendarView.topAnchor.constraint(equalTo: view.layoutMarginsGuide.topAnchor),
-        calendarView.bottomAnchor.constraint(equalTo: view.layoutMarginsGuide.bottomAnchor),
-        calendarView.leadingAnchor.constraint(
-          greaterThanOrEqualTo: view.layoutMarginsGuide.leadingAnchor),
-        calendarView.trailingAnchor.constraint(
-          lessThanOrEqualTo: view.layoutMarginsGuide.trailingAnchor),
-        calendarView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-        calendarView.widthAnchor.constraint(lessThanOrEqualToConstant: 375)
-      ])
-    case .horizontal(let monthWidth):
-      NSLayoutConstraint.activate([
-        calendarView.centerYAnchor.constraint(equalTo: view.layoutMarginsGuide.centerYAnchor),
-        calendarView.heightAnchor.constraint(equalToConstant: monthWidth * 1.1),
-        calendarView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-        calendarView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-      ])
-    }
   }
 
   override func viewDidAppear(_ animated: Bool) {
@@ -79,14 +34,7 @@ final class ScrollToDayWithAnimationDemoViewController: UIViewController, DemoVi
       animated: true)
   }
 
-  // MARK: Private
-
-  private let monthsLayout: MonthsLayout
-
-  private lazy var calendarView = CalendarView(initialContent: makeContent())
-  private lazy var calendar = Calendar(identifier: .gregorian)
-
-  private func makeContent() -> CalendarViewContent {
+  override func makeContent() -> CalendarViewContent {
     let startDate = calendar.date(from: DateComponents(year: 2016, month: 07, day: 01))!
     let endDate = calendar.date(from: DateComponents(year: 2020, month: 12, day: 31))!
 

--- a/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/SelectedDayTooltipDemoViewController.swift
+++ b/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/SelectedDayTooltipDemoViewController.swift
@@ -16,20 +16,7 @@
 import HorizonCalendar
 import UIKit
 
-// MARK: - SelectedDayTooltipDemoViewController
-
-final class SelectedDayTooltipDemoViewController: UIViewController, DemoViewController {
-
-  // MARK: Lifecycle
-
-  init(monthsLayout: MonthsLayout) {
-    self.monthsLayout = monthsLayout
-    super.init(nibName: nil, bundle: nil)
-  }
-
-  required init?(coder: NSCoder) {
-    fatalError("init(coder:) has not been implemented")
-  }
+final class SelectedDayTooltipDemoViewController: DemoViewController {
 
   // MARK: Internal
 
@@ -38,63 +25,15 @@ final class SelectedDayTooltipDemoViewController: UIViewController, DemoViewCont
 
     title = "Selected Day Tooltip"
 
-    if #available(iOS 13.0, *) {
-      view.backgroundColor = .systemBackground
-    } else {
-      view.backgroundColor = .white
-    }
-
     calendarView.daySelectionHandler = { [weak self] day in
       guard let self = self else { return }
 
       self.selectedDay = day
       self.calendarView.setContent(self.makeContent())
     }
-    
-    view.addSubview(calendarView)
-
-    calendarView.translatesAutoresizingMaskIntoConstraints = false
-    switch monthsLayout {
-    case .vertical:
-      NSLayoutConstraint.activate([
-        calendarView.topAnchor.constraint(equalTo: view.layoutMarginsGuide.topAnchor),
-        calendarView.bottomAnchor.constraint(equalTo: view.layoutMarginsGuide.bottomAnchor),
-        calendarView.leadingAnchor.constraint(
-          greaterThanOrEqualTo: view.layoutMarginsGuide.leadingAnchor),
-        calendarView.trailingAnchor.constraint(
-          lessThanOrEqualTo: view.layoutMarginsGuide.trailingAnchor),
-        calendarView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-        calendarView.widthAnchor.constraint(lessThanOrEqualToConstant: 375)
-      ])
-    case .horizontal(let monthWidth):
-      NSLayoutConstraint.activate([
-        calendarView.centerYAnchor.constraint(equalTo: view.layoutMarginsGuide.centerYAnchor),
-        calendarView.heightAnchor.constraint(equalToConstant: monthWidth * 1.1),
-        calendarView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-        calendarView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-      ])
-    }
   }
 
-  // MARK: Private
-
-  private let monthsLayout: MonthsLayout
-
-  private lazy var calendarView = CalendarView(initialContent: makeContent())
-  private lazy var calendar = Calendar(identifier: .gregorian)
-  private lazy var dayDateFormatter: DateFormatter = {
-    let dateFormatter = DateFormatter()
-    dateFormatter.calendar = calendar
-    dateFormatter.dateFormat = DateFormatter.dateFormat(
-      fromTemplate: "EEEE, MMM d, yyyy",
-      options: 0,
-      locale: calendar.locale ?? Locale.current)
-    return dateFormatter
-  }()
-
-  private var selectedDay: Day?
-
-  private func makeContent() -> CalendarViewContent {
+  override func makeContent() -> CalendarViewContent {
     let startDate = calendar.date(from: DateComponents(year: 2020, month: 01, day: 01))!
     let endDate = calendar.date(from: DateComponents(year: 2021, month: 12, day: 31))!
 
@@ -143,5 +82,9 @@ final class SelectedDayTooltipDemoViewController: UIViewController, DemoViewCont
             text: "Selected Day"))
       }
   }
+
+  // MARK: Private
+
+  private var selectedDay: Day?
 
 }

--- a/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/SingleDaySelectionDemoViewController.swift
+++ b/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/SingleDaySelectionDemoViewController.swift
@@ -16,20 +16,7 @@
 import HorizonCalendar
 import UIKit
 
-// MARK: - SingleDaySelectionDemoViewController
-
-final class SingleDaySelectionDemoViewController: UIViewController, DemoViewController {
-
-  // MARK: Lifecycle
-
-  init(monthsLayout: MonthsLayout) {
-    self.monthsLayout = monthsLayout
-    super.init(nibName: nil, bundle: nil)
-  }
-
-  required init?(coder: NSCoder) {
-    fatalError("init(coder:) has not been implemented")
-  }
+final class SingleDaySelectionDemoViewController: DemoViewController {
 
   // MARK: Internal
 
@@ -38,62 +25,15 @@ final class SingleDaySelectionDemoViewController: UIViewController, DemoViewCont
 
     title = "Single Day Selection"
 
-    if #available(iOS 13.0, *) {
-      view.backgroundColor = .systemBackground
-    } else {
-      view.backgroundColor = .white
-    }
-
     calendarView.daySelectionHandler = { [weak self] day in
       guard let self = self else { return }
 
       self.selectedDay = day
       self.calendarView.setContent(self.makeContent())
     }
-    view.addSubview(calendarView)
-
-    calendarView.translatesAutoresizingMaskIntoConstraints = false
-    switch monthsLayout {
-    case .vertical:
-      NSLayoutConstraint.activate([
-        calendarView.topAnchor.constraint(equalTo: view.layoutMarginsGuide.topAnchor),
-        calendarView.bottomAnchor.constraint(equalTo: view.layoutMarginsGuide.bottomAnchor),
-        calendarView.leadingAnchor.constraint(
-          greaterThanOrEqualTo: view.layoutMarginsGuide.leadingAnchor),
-        calendarView.trailingAnchor.constraint(
-          lessThanOrEqualTo: view.layoutMarginsGuide.trailingAnchor),
-        calendarView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-        calendarView.widthAnchor.constraint(lessThanOrEqualToConstant: 375)
-      ])
-    case .horizontal(let monthWidth):
-      NSLayoutConstraint.activate([
-        calendarView.centerYAnchor.constraint(equalTo: view.layoutMarginsGuide.centerYAnchor),
-        calendarView.heightAnchor.constraint(equalToConstant: monthWidth * 1.1),
-        calendarView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-        calendarView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-      ])
-    }
   }
 
-  // MARK: Private
-
-  private let monthsLayout: MonthsLayout
-
-  private lazy var calendarView = CalendarView(initialContent: makeContent())
-  private lazy var calendar = Calendar(identifier: .gregorian)
-  private lazy var dayDateFormatter: DateFormatter = {
-    let dateFormatter = DateFormatter()
-    dateFormatter.calendar = calendar
-    dateFormatter.dateFormat = DateFormatter.dateFormat(
-      fromTemplate: "EEEE, MMM d, yyyy",
-      options: 0,
-      locale: calendar.locale ?? Locale.current)
-    return dateFormatter
-  }()
-
-  private var selectedDay: Day?
-
-  private func makeContent() -> CalendarViewContent {
+  override func makeContent() -> CalendarViewContent {
     let startDate = calendar.date(from: DateComponents(year: 2020, month: 01, day: 01))!
     let endDate = calendar.date(from: DateComponents(year: 2021, month: 12, day: 31))!
 
@@ -128,5 +68,9 @@ final class SingleDaySelectionDemoViewController: UIViewController, DemoViewCont
           viewModel: .init(dayText: "\(day.day)", dayAccessibilityText: dayAccessibilityText))
       }
   }
+
+  // MARK: Private
+
+  private var selectedDay: Day?
 
 }

--- a/Example/HorizonCalendarExample/HorizonCalendarExample/DemoPickerViewController.swift
+++ b/Example/HorizonCalendarExample/HorizonCalendarExample/DemoPickerViewController.swift
@@ -142,7 +142,7 @@ extension DemoPickerViewController: UITableViewDelegate {
             pinDaysOfWeekToTop: false,
             alwaysShowCompleteBoundaryMonths: false))
         : .horizontal(
-          options: HorizontalMonthsLayoutOptions(numberOfFullyVisibleMonths: 1.5)))
+          options: HorizontalMonthsLayoutOptions(maximumFullyVisibleMonths: 1.5)))
 
     navigationController?.pushViewController(demoViewController, animated: true)
   }

--- a/Example/HorizonCalendarExample/HorizonCalendarExample/DemoPickerViewController.swift
+++ b/Example/HorizonCalendarExample/HorizonCalendarExample/DemoPickerViewController.swift
@@ -141,7 +141,8 @@ extension DemoPickerViewController: UITableViewDelegate {
           options: VerticalMonthsLayoutOptions(
             pinDaysOfWeekToTop: false,
             alwaysShowCompleteBoundaryMonths: false))
-        : .horizontal(monthWidth: min(min(view.bounds.width, view.bounds.height) - 64, 512)))
+        : .horizontal(
+          options: HorizontalMonthsLayoutOptions(numberOfFullyVisibleMonths: 1.5)))
 
     navigationController?.pushViewController(demoViewController, animated: true)
   }

--- a/HorizonCalendar.xcodeproj/project.pbxproj
+++ b/HorizonCalendar.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		93061FFE24F1AE1700177ECC /* CalendarViewContent+CalendarItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93061FFC24F1AE1700177ECC /* CalendarViewContent+CalendarItem.swift */; };
 		93061FFF24F1AE1700177ECC /* CalendarItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93061FFD24F1AE1700177ECC /* CalendarItem.swift */; };
+		932E24142558DF6E001648D2 /* HorizontalMonthsLayoutOptionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 932E24132558DF6E001648D2 /* HorizontalMonthsLayoutOptionsTests.swift */; };
 		938DA40F24BEEB1A008A3B47 /* CalendarItemViewRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 938DA40E24BEEB1A008A3B47 /* CalendarItemViewRepresentable.swift */; };
 		938DA41124BEFFCB008A3B47 /* AnyCalendarItemModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 938DA41024BEFFCB008A3B47 /* AnyCalendarItemModel.swift */; };
 		938DA41324BF0FFF008A3B47 /* DefaultItemProviders.swift in Sources */ = {isa = PBXBuildFile; fileRef = 938DA41224BF0FFF008A3B47 /* DefaultItemProviders.swift */; };
@@ -68,6 +69,7 @@
 /* Begin PBXFileReference section */
 		93061FFC24F1AE1700177ECC /* CalendarViewContent+CalendarItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CalendarViewContent+CalendarItem.swift"; sourceTree = "<group>"; };
 		93061FFD24F1AE1700177ECC /* CalendarItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CalendarItem.swift; sourceTree = "<group>"; };
+		932E24132558DF6E001648D2 /* HorizontalMonthsLayoutOptionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HorizontalMonthsLayoutOptionsTests.swift; sourceTree = "<group>"; };
 		938DA40E24BEEB1A008A3B47 /* CalendarItemViewRepresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarItemViewRepresentable.swift; sourceTree = "<group>"; };
 		938DA41024BEFFCB008A3B47 /* AnyCalendarItemModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyCalendarItemModel.swift; sourceTree = "<group>"; };
 		938DA41224BF0FFF008A3B47 /* DefaultItemProviders.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultItemProviders.swift; sourceTree = "<group>"; };
@@ -182,6 +184,7 @@
 				93FA64ED248D7B0100A8B7B1 /* DayHelperTests.swift */,
 				93FA64EF248D84FE00A8B7B1 /* DayOfWeekPositionTests.swift */,
 				939E694F2484B14500A8BCC7 /* FrameProviderTests.swift */,
+				932E24132558DF6E001648D2 /* HorizontalMonthsLayoutOptionsTests.swift */,
 				93A0062B24F206BE00F667A3 /* ItemViewReuseManagerTests.swift */,
 				939E694C2484B14400A8BCC7 /* LayoutItemTypeEnumeratorTests.swift */,
 				93A0062824F2068000F667A3 /* LegacyItemViewReuseManagerTests.swift */,
@@ -408,6 +411,7 @@
 				93A0062C24F206BE00F667A3 /* ItemViewReuseManagerTests.swift in Sources */,
 				939E69592484B21700A8BCC7 /* LayoutItemTypeEnumeratorTests.swift in Sources */,
 				93FA64F2248D93EA00A8B7B1 /* MonthRowTests.swift in Sources */,
+				932E24142558DF6E001648D2 /* HorizontalMonthsLayoutOptionsTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/Internal/FrameProvider.swift
+++ b/Sources/Internal/FrameProvider.swift
@@ -38,8 +38,10 @@ final class FrameProvider {
     switch content.monthsLayout {
     case .vertical:
       monthWidth = size.width - layoutMargins.leading - layoutMargins.trailing
-    case .horizontal(let _monthWidth):
-      monthWidth = _monthWidth
+    case .horizontal(let options):
+      monthWidth = options.monthWidth(
+        calendarWidth: size.width,
+        interMonthSpacing: content.interMonthSpacing)
     }
 
     let insetWidth = monthWidth - content.monthDayInsets.left - content.monthDayInsets.right

--- a/Sources/Public/CalendarView.swift
+++ b/Sources/Public/CalendarView.swift
@@ -530,8 +530,12 @@ public final class CalendarView: UIView {
   private func monthHeaderHeight() -> CGFloat {
     let monthWidth: CGFloat
     switch content.monthsLayout {
-    case .vertical: monthWidth = bounds.width
-    case .horizontal(let _monthWidth): monthWidth = _monthWidth
+    case .vertical:
+      monthWidth = bounds.width
+    case .horizontal(let options):
+      monthWidth = options.monthWidth(
+        calendarWidth: bounds.width,
+        interMonthSpacing: content.interMonthSpacing)
     }
 
     let firstMonthHeaderItemModel = content.monthHeaderItemModelProvider(

--- a/Sources/Public/MonthsLayout.swift
+++ b/Sources/Public/MonthsLayout.swift
@@ -139,17 +139,17 @@ public struct HorizontalMonthsLayoutOptions: Equatable {
   /// Initializes a new instance of `HorizontalMonthsLayoutOptions`.
   ///
   /// - Parameters:
-  ///   - numberOfFullyVisibleMonths: The maximum number off fully visible months for any scroll offset. The default value is
+  ///   - maximumFullyVisibleMonths: The maximum number of fully visible months for any scroll offset. The default value is
   ///   `1`.
-  public init(numberOfFullyVisibleMonths: Double = 1) {
-    assert(numberOfFullyVisibleMonths >= 1, "`numberOfFullyVisibleMonths` must be greater than 1.")
-    self.numberOfFullyVisibleMonths = numberOfFullyVisibleMonths
+  public init(maximumFullyVisibleMonths: Double = 1) {
+    assert(maximumFullyVisibleMonths >= 1, "`maximumFullyVisibleMonths` must be greater than 1.")
+    self.maximumFullyVisibleMonths = maximumFullyVisibleMonths
   }
 
   // MARK: Public
 
-  /// The maximum number off fully visible months for any scroll offset.
-  public let numberOfFullyVisibleMonths: Double
+  /// The maximum number of fully visible months for any scroll offset.
+  public let maximumFullyVisibleMonths: Double
 
   // MARK: Internal
 
@@ -161,8 +161,8 @@ public struct HorizontalMonthsLayoutOptions: Equatable {
       return monthWidth
     }
 
-    let visibleInterMonthSpacing = CGFloat(numberOfFullyVisibleMonths) * interMonthSpacing
-    return (calendarWidth - visibleInterMonthSpacing) / CGFloat(numberOfFullyVisibleMonths)
+    let visibleInterMonthSpacing = CGFloat(maximumFullyVisibleMonths) * interMonthSpacing
+    return (calendarWidth - visibleInterMonthSpacing) / CGFloat(maximumFullyVisibleMonths)
   }
 
 }

--- a/Sources/Public/MonthsLayout.swift
+++ b/Sources/Public/MonthsLayout.swift
@@ -27,9 +27,8 @@ public enum MonthsLayout {
 
   /// Calendar months will be arranged in a single row, and scroll on the horizontal axis.
   ///
-  /// - `monthWidth`: Whether the days of the week will appear once, pinned at the top, or separately for each
-  /// month.
-  case horizontal(monthWidth: CGFloat)
+  /// - `options`: Additional options to adjust the layout of the horizontally-scrolling calendar.
+  case horizontal(options: HorizontalMonthsLayoutOptions)
 
   // MARK: Internal
 
@@ -71,6 +70,19 @@ extension MonthsLayout {
     return .vertical(options: options)
   }
 
+  /// Calendar months will be arranged in a single row, and scroll on the horizontal axis.
+  ///
+  /// - `monthWidth`: The width of each month.
+  @available(
+    *,
+    deprecated,
+    message: "Use .horizontal(options: HorizontalMonthsLayoutOptions) instead. This will be removed in a future major release.")
+  public static func horizontal(monthWidth: CGFloat) -> Self {
+    var options = HorizontalMonthsLayoutOptions()
+    options.monthWidth = monthWidth
+    return .horizontal(options: options)
+  }
+
 }
 
 // MARK: Equatable
@@ -80,7 +92,7 @@ extension MonthsLayout: Equatable {
   public static func == (lhs: MonthsLayout, rhs: MonthsLayout) -> Bool {
     switch (lhs, rhs)  {
     case (.vertical(let lhsOptions), .vertical(let rhsOptions)): return lhsOptions == rhsOptions
-    case (.horizontal, .horizontal): return true
+    case (.horizontal(let lhsOptions), .horizontal(let rhsOptions)): return lhsOptions == rhsOptions
     default: return false
     }
   }
@@ -94,7 +106,7 @@ public struct VerticalMonthsLayoutOptions: Equatable {
 
   // MARK: Lifecycle
 
-  /// Initialized a new instance of `VerticalMonthsLayoutOptions`.
+  /// Initializes a new instance of `VerticalMonthsLayoutOptions`.
   ///
   /// - Parameters:
   ///   - pinDaysOfWeekToTop: Whether the days of the week will appear once, pinned at the top, or repeatedly in each month.
@@ -114,5 +126,43 @@ public struct VerticalMonthsLayoutOptions: Equatable {
   /// Whether the calendar will always show complete months at the calendar's boundaries, even if the visible date range does not start
   /// on the first date or end on the last date of a month.
   public let alwaysShowCompleteBoundaryMonths: Bool
+
+}
+
+// MARK: - HorizontalMonthsLayoutOptions
+
+/// Layout options for a horizontally-scrolling calendar.
+public struct HorizontalMonthsLayoutOptions: Equatable {
+
+  // MARK: Lifecycle
+
+  /// Initializes a new instance of `HorizontalMonthsLayoutOptions`.
+  ///
+  /// - Parameters:
+  ///   - numberOfFullyVisibleMonths: The maximum number off fully visible months for any scroll offset. The default value is
+  ///   `1`.
+  public init(numberOfFullyVisibleMonths: Double = 1) {
+    assert(numberOfFullyVisibleMonths >= 1, "`numberOfFullyVisibleMonths` must be greater than 1.")
+    self.numberOfFullyVisibleMonths = numberOfFullyVisibleMonths
+  }
+
+  // MARK: Public
+
+  /// The maximum number off fully visible months for any scroll offset.
+  public let numberOfFullyVisibleMonths: Double
+
+  // MARK: Internal
+
+  /// This property exists only to support `MonthsLayout.horizontal(monthWidth: CGFloat)`, which is deprecated.
+  var monthWidth: CGFloat?
+
+  func monthWidth(calendarWidth: CGFloat, interMonthSpacing: CGFloat) -> CGFloat {
+    if let monthWidth = monthWidth {
+      return monthWidth
+    }
+
+    let visibleInterMonthSpacing = CGFloat(numberOfFullyVisibleMonths) * interMonthSpacing
+    return (calendarWidth - visibleInterMonthSpacing) / CGFloat(numberOfFullyVisibleMonths)
+  }
 
 }

--- a/Tests/FrameProviderTests.swift
+++ b/Tests/FrameProviderTests.swift
@@ -73,7 +73,8 @@ final class FrameProviderTests: XCTestCase {
       content: CalendarViewContent(
         calendar: calendar,
         visibleDateRange: Date.distantPast...Date.distantFuture,
-        monthsLayout: .horizontal(monthWidth: 300))
+        monthsLayout: .horizontal(
+          options: HorizontalMonthsLayoutOptions(numberOfFullyVisibleMonths: 1)))
         .withMonthDayInsets(UIEdgeInsets(top: 5, left: 8, bottom: 5, right: 8))
         .withInterMonthSpacing(20)
         .withVerticalDayMargin(20)

--- a/Tests/FrameProviderTests.swift
+++ b/Tests/FrameProviderTests.swift
@@ -74,7 +74,7 @@ final class FrameProviderTests: XCTestCase {
         calendar: calendar,
         visibleDateRange: Date.distantPast...Date.distantFuture,
         monthsLayout: .horizontal(
-          options: HorizontalMonthsLayoutOptions(numberOfFullyVisibleMonths: 1)))
+          options: HorizontalMonthsLayoutOptions(maximumFullyVisibleMonths: 1)))
         .withMonthDayInsets(UIEdgeInsets(top: 5, left: 8, bottom: 5, right: 8))
         .withInterMonthSpacing(20)
         .withVerticalDayMargin(20)

--- a/Tests/HorizontalMonthsLayoutOptionsTests.swift
+++ b/Tests/HorizontalMonthsLayoutOptionsTests.swift
@@ -19,7 +19,7 @@ import XCTest
 final class HorizontalMonthsLayoutOptionsTests: XCTestCase {
   
   func testMonthWidthOneVisibleMonth() {
-    let options = HorizontalMonthsLayoutOptions(numberOfFullyVisibleMonths: 1)
+    let options = HorizontalMonthsLayoutOptions(maximumFullyVisibleMonths: 1)
 
     XCTAssert(
       options.monthWidth(calendarWidth: 100, interMonthSpacing: 0) == 100,
@@ -30,8 +30,8 @@ final class HorizontalMonthsLayoutOptionsTests: XCTestCase {
       "Incorrect month width")
   }
 
-  func testMonthWidthOneAndAHalfVisibleMonth() {
-    let options = HorizontalMonthsLayoutOptions(numberOfFullyVisibleMonths: 1.5)
+  func testMonthWidthOneAndAHalfVisibleMonths() {
+    let options = HorizontalMonthsLayoutOptions(maximumFullyVisibleMonths: 1.5)
 
     XCTAssert(
       options.monthWidth(calendarWidth: 120, interMonthSpacing: 0) == 80,
@@ -42,8 +42,8 @@ final class HorizontalMonthsLayoutOptionsTests: XCTestCase {
       "Incorrect month width")
   }
 
-  func testMonthWidthFourVisibleMonth() {
-    let options = HorizontalMonthsLayoutOptions(numberOfFullyVisibleMonths: 4)
+  func testMonthWidthFourVisibleMonths() {
+    let options = HorizontalMonthsLayoutOptions(maximumFullyVisibleMonths: 4)
 
     XCTAssert(
       options.monthWidth(calendarWidth: 100, interMonthSpacing: 0) == 25,

--- a/Tests/HorizontalMonthsLayoutOptionsTests.swift
+++ b/Tests/HorizontalMonthsLayoutOptionsTests.swift
@@ -1,0 +1,57 @@
+// Created by Bryan Keller on 11/8/20.
+// Copyright © 2020 Airbnb Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import XCTest
+@testable import HorizonCalendar
+
+final class HorizontalMonthsLayoutOptionsTests: XCTestCase {
+  
+  func testMonthWidthOneVisibleMonth() {
+    let options = HorizontalMonthsLayoutOptions(numberOfFullyVisibleMonths: 1)
+
+    XCTAssert(
+      options.monthWidth(calendarWidth: 100, interMonthSpacing: 0) == 100,
+      "Incorrect month width")
+
+    XCTAssert(
+      options.monthWidth(calendarWidth: 100, interMonthSpacing: 10) == 90,
+      "Incorrect month width")
+  }
+
+  func testMonthWidthOneAndAHalfVisibleMonth() {
+    let options = HorizontalMonthsLayoutOptions(numberOfFullyVisibleMonths: 1.5)
+
+    XCTAssert(
+      options.monthWidth(calendarWidth: 120, interMonthSpacing: 0) == 80,
+      "Incorrect month width")
+
+    XCTAssert(
+      options.monthWidth(calendarWidth: 120, interMonthSpacing: 10) == 70,
+      "Incorrect month width")
+  }
+
+  func testMonthWidthFourVisibleMonth() {
+    let options = HorizontalMonthsLayoutOptions(numberOfFullyVisibleMonths: 4)
+
+    XCTAssert(
+      options.monthWidth(calendarWidth: 100, interMonthSpacing: 0) == 25,
+      "Incorrect month width")
+
+    XCTAssert(
+      options.monthWidth(calendarWidth: 100, interMonthSpacing: 10) == 15,
+      "Incorrect month width")
+  }
+
+}

--- a/Tests/LayoutItemTypeEnumeratorTests.swift
+++ b/Tests/LayoutItemTypeEnumeratorTests.swift
@@ -44,7 +44,7 @@ final class LayoutItemTypeEnumeratorTests: XCTestCase {
     horizontalItemTypeEnumerator = LayoutItemTypeEnumerator(
       calendar: calendar,
       monthsLayout: .horizontal(
-        options: HorizontalMonthsLayoutOptions(numberOfFullyVisibleMonths: 305/300)),
+        options: HorizontalMonthsLayoutOptions(maximumFullyVisibleMonths: 305/300)),
       monthRange: monthRange,
       dayRange: dayRange)
 

--- a/Tests/LayoutItemTypeEnumeratorTests.swift
+++ b/Tests/LayoutItemTypeEnumeratorTests.swift
@@ -43,7 +43,8 @@ final class LayoutItemTypeEnumeratorTests: XCTestCase {
       dayRange: dayRange)
     horizontalItemTypeEnumerator = LayoutItemTypeEnumerator(
       calendar: calendar,
-      monthsLayout: .horizontal(monthWidth: 300),
+      monthsLayout: .horizontal(
+        options: HorizontalMonthsLayoutOptions(numberOfFullyVisibleMonths: 305/300)),
       monthRange: monthRange,
       dayRange: dayRange)
 

--- a/Tests/VisibleItemsProviderTests.swift
+++ b/Tests/VisibleItemsProviderTests.swift
@@ -1644,7 +1644,8 @@ final class VisibleItemsProviderTests: XCTestCase {
       fromBaseContent: CalendarViewContent(
         calendar: calendar,
         visibleDateRange: dateRange,
-        monthsLayout: .horizontal(monthWidth: 300))),
+        monthsLayout: .horizontal(
+          options: HorizontalMonthsLayoutOptions(numberOfFullyVisibleMonths: 64/63)))),
     size: size,
     layoutMargins: .zero,
     scale: 2,

--- a/Tests/VisibleItemsProviderTests.swift
+++ b/Tests/VisibleItemsProviderTests.swift
@@ -1645,7 +1645,7 @@ final class VisibleItemsProviderTests: XCTestCase {
         calendar: calendar,
         visibleDateRange: dateRange,
         monthsLayout: .horizontal(
-          options: HorizontalMonthsLayoutOptions(numberOfFullyVisibleMonths: 64/63)))),
+          options: HorizontalMonthsLayoutOptions(maximumFullyVisibleMonths: 64/63)))),
     size: size,
     layoutMargins: .zero,
     scale: 2,


### PR DESCRIPTION
## Details

I've started work on adding horizontal pagination to the calendar. Before making that change, I wanted clean up the horizontal months layout API.

This PR deprecates the `MonthsLayout.horizontal(monthWidth: CGFloat)` in favor of `horizontal(options: HorizontalMonthsLayoutOptions)`, which will enable more functionality to be added in the future without overloading the enum associate values. This follows the same pattern being used for the `.vertical` months layout.

I've also changed the API so that the width of each month can be specified in terms of the number of fully-visible months, rather than an explicit value. 

Lastly, I cleaned up the demo project code so that there's less duplication.

I'm not going to bump the version number until the pagination API changes are also merged. At that point, these API deprecations and additions will be packaged up into one release: `v1.7.0`.

## Related Issue

N/A

## Motivation and Context

Cleaning up API in preparation for horizontal pagination.

## How Has This Been Tested

Tested in iOS simulator using various form factors.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
