### PR TITLE
Bk/fix default item localization

### DIFF
--- a/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/DemoViewController.swift
+++ b/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/DemoViewController.swift
@@ -27,6 +27,7 @@ class DemoViewController: UIViewController {
   lazy var dayDateFormatter: DateFormatter = {
     let dateFormatter = DateFormatter()
     dateFormatter.calendar = calendar
+    dateFormatter.locale = calendar.locale
     dateFormatter.dateFormat = DateFormatter.dateFormat(
       fromTemplate: "EEEE, MMM d, yyyy",
       options: 0,

--- a/HorizonCalendar.podspec
+++ b/HorizonCalendar.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name = "HorizonCalendar"
-  spec.version = "1.6.0"
+  spec.version = "1.6.1"
   spec.license = "Apache License, Version 2.0"
   spec.summary = "A declarative, performant, calendar UI component that supports use cases ranging from simple date pickers to fully-featured calendar apps."
 

--- a/HorizonCalendar.xcodeproj/project.pbxproj
+++ b/HorizonCalendar.xcodeproj/project.pbxproj
@@ -570,7 +570,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.6.0;
+				MARKETING_VERSION = 1.6.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.HorizonCalendar;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -604,7 +604,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.6.0;
+				MARKETING_VERSION = 1.6.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.HorizonCalendar;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Sources/Public/CalendarViewContent.swift
+++ b/Sources/Public/CalendarViewContent.swift
@@ -56,6 +56,7 @@ public final class CalendarViewContent {
 
     let monthHeaderDateFormatter = DateFormatter()
     monthHeaderDateFormatter.calendar = calendar
+    monthHeaderDateFormatter.locale = calendar.locale
     monthHeaderDateFormatter.dateFormat = DateFormatter.dateFormat(
       fromTemplate: "MMMM yyyy",
       options: 0,
@@ -79,6 +80,7 @@ public final class CalendarViewContent {
 
     let dayDateFormatter = DateFormatter()
     dayDateFormatter.calendar = calendar
+    dayDateFormatter.locale = calendar.locale
     dayDateFormatter.dateFormat = DateFormatter.dateFormat(
       fromTemplate: "EEEE, MMM d, yyyy",
       options: 0,


### PR DESCRIPTION
## Details

This PR fixes the locale of the date formatters used for default items. I forgot that date formatters need their locale set explicitly, otherwise they'll return incorrect values for things like weekday / month headers.

| Before | After |
| ---- | ---- |
| ![Simulator Screen Shot - iPhone 8 - 2020-11-24 at 08 30 02](https://user-images.githubusercontent.com/746571/100137006-e24d7600-2e2f-11eb-8779-03c8356d04f0.png) | ![Simulator Screen Shot - iPhone 8 - 2020-11-24 at 08 29 22](https://user-images.githubusercontent.com/746571/100137018-e8435700-2e2f-11eb-9736-9e244a7c11b4.png) |

## Related Issue

N/A

## Motivation and Context

https://twitter.com/valeriyzubairov reached out to me and informed me that the calendar was not properly localizing for Russian.

## How Has This Been Tested

Tested in iOS simulator using Russian locale.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
