### PR TITLE
Bk/reduce frame math duplication

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -13,12 +13,12 @@ jobs:
 
     strategy:
       matrix:
-        destination: ['platform=iOS Simulator,OS=11.0,name=iPhone 8', 'platform=iOS Simulator,OS=14.0,name=iPhone 12']
+        destination: ['platform=iOS Simulator,OS=11.0,name=iPhone 8', 'platform=iOS Simulator,OS=14.2,name=iPhone 12']
 
     steps:
     - uses: actions/checkout@v2
     - name: Build
       run: xcodebuild clean build -scheme HorizonCalendar
     - name: Run tests
-      run: xcodebuild clean test -project HorizonCalendar.xcodeproj -scheme HorizonCalendar -destination "name=iPhone 8,OS=14.0"
+      run: xcodebuild clean test -project HorizonCalendar.xcodeproj -scheme HorizonCalendar -destination "name=iPhone 8,OS=14.2"
 

--- a/HorizonCalendar.podspec
+++ b/HorizonCalendar.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name = "HorizonCalendar"
-  spec.version = "1.6.1"
+  spec.version = "1.6.2"
   spec.license = "Apache License, Version 2.0"
   spec.summary = "A declarative, performant, calendar UI component that supports use cases ranging from simple date pickers to fully-featured calendar apps."
 

--- a/HorizonCalendar.xcodeproj/project.pbxproj
+++ b/HorizonCalendar.xcodeproj/project.pbxproj
@@ -566,7 +566,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.6.1;
+				MARKETING_VERSION = 1.6.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.HorizonCalendar;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -600,7 +600,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.6.1;
+				MARKETING_VERSION = 1.6.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.HorizonCalendar;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Sources/Internal/FrameProvider.swift
+++ b/Sources/Internal/FrameProvider.swift
@@ -140,14 +140,14 @@ final class FrameProvider {
     let date = calendar.startDate(of: day)
     let dayOfWeekPosition = calendar.dayOfWeekPosition(for: date)
     let rowInMonth = adjustedRowInMonth(for: day)
-    let numberOfWeekRows = rowInMonth + 1
+    let numberOfWeekRowsThroughDay = rowInMonth + 1
 
     let x = minXOfItem(at: dayOfWeekPosition, minXOfContainingRow: monthOrigin.x)
     let y = monthOrigin.y +
       monthHeaderHeight +
       content.monthDayInsets.top +
       heightOfDaysOfTheWeekRowInMonth() +
-      heightOfDayContent(forNumberOfWeekRows: numberOfWeekRows) -
+      heightOfDayContent(forNumberOfWeekRows: numberOfWeekRowsThroughDay) -
       daySize.height
     return CGRect(origin: CGPoint(x: x, y: y), size: daySize)
   }

--- a/Tests/FrameProviderTests.swift
+++ b/Tests/FrameProviderTests.swift
@@ -171,7 +171,7 @@ final class FrameProviderTests: XCTestCase {
         itemType: .dayOfWeekInMonth(
           position: .fourth,
           month: Month(era: 1, year: 2020, month: 01, isInGregorianCalendar: true)),
-        frame: CGRect(x: 130, y: 200, width: 40, height: 40))
+        frame: CGRect(origin: CGPoint(x: 130, y: 200), size: frameProvider.daySize))
       let origin2 = frameProvider.originOfMonth(containing: dayOfWeekLayoutItem)
         .alignedToPixels(forScreenWithScale: 3)
       XCTAssert(
@@ -181,7 +181,7 @@ final class FrameProviderTests: XCTestCase {
       let dayLayoutItem1 = LayoutItem(
         itemType: .day(
           Day(month: Month(era: 1, year: 2020, month: 02, isInGregorianCalendar: true), day: 10)),
-        frame: CGRect(x: 200, y: 300, width: 40, height: 40))
+        frame: CGRect(origin: CGPoint(x: 200, y: 300), size: frameProvider.daySize))
       let origin3 = frameProvider.originOfMonth(containing: dayLayoutItem1)
         .alignedToPixels(forScreenWithScale: 3)
       XCTAssert(origin3 == expectedOrigins3[index], "Incorrect month origin containing day.")
@@ -189,7 +189,7 @@ final class FrameProviderTests: XCTestCase {
       let dayLayoutItem2 = LayoutItem(
         itemType: .day(
           Day(month: Month(era: 1, year: 2020, month: 05, isInGregorianCalendar: true), day: 18)),
-        frame: CGRect(x: 200, y: 300, width: 40, height: 40))
+        frame: CGRect(origin: CGPoint(x: 200, y: 300), size: frameProvider.daySize))
       let origin4 = frameProvider.originOfMonth(containing: dayLayoutItem2)
         .alignedToPixels(forScreenWithScale: 3)
       XCTAssert(origin4 == expectedOrigins4[index], "Incorrect month origin containing day.")


### PR DESCRIPTION
## Details

This consolidates similar math / calculations in the `FrameProvider`. There were several places where I was determining the height of a certain number of day rows (weeks in a month) the same way, so it seems like a good place to consolidate the math into some private helper functions.

## Related Issue

N/A

## Motivation and Context

Simplify frame calculation logic since I noticed that it was tricky to get some of this stuff right in the Month Footer PR (#75)

## How Has This Been Tested

Unit tests, example app.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
