### PR TITLE
Prevent animated layout and item reuse

### DIFF
--- a/HorizonCalendar.podspec
+++ b/HorizonCalendar.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name = "HorizonCalendar"
-  spec.version = "1.6.3"
+  spec.version = "1.6.4"
   spec.license = "Apache License, Version 2.0"
   spec.summary = "A declarative, performant, calendar UI component that supports use cases ranging from simple date pickers to fully-featured calendar apps."
 

--- a/HorizonCalendar.xcodeproj/project.pbxproj
+++ b/HorizonCalendar.xcodeproj/project.pbxproj
@@ -566,7 +566,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.6.3;
+				MARKETING_VERSION = 1.6.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.HorizonCalendar;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -600,7 +600,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.6.3;
+				MARKETING_VERSION = 1.6.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.HorizonCalendar;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Sources/Public/CalendarView.swift
+++ b/Sources/Public/CalendarView.swift
@@ -559,7 +559,9 @@ public final class CalendarView: UIView {
       visibleItems,
       viewHandler: { view, visibleItem, previousBackingVisibleItem in
         if view.superview == nil {
-          scrollView.addSubview(view)
+          UIView.performWithoutAnimation {
+            scrollView.addSubview(view)
+          }
         }
 
         configureView(view, with: visibleItem)
@@ -581,13 +583,15 @@ public final class CalendarView: UIView {
     view.calendarItemModel = visibleItem.calendarItemModel
 
     // Update the visibility
-    view.frame = visibleItem.frame.alignedToPixels(forScreenWithScale: scale)
-    view.layer.zPosition = visibleItem.itemType.zPosition
+    UIView.performWithoutAnimation {
+      view.frame = visibleItem.frame.alignedToPixels(forScreenWithScale: scale)
+      view.layer.zPosition = visibleItem.itemType.zPosition
 
-    if traitCollection.layoutDirection == .rightToLeft {
-      view.transform = .init(scaleX: -1, y: 1)
-    } else {
-      view.transform = .identity
+      if traitCollection.layoutDirection == .rightToLeft {
+        view.transform = .init(scaleX: -1, y: 1)
+      } else {
+        view.transform = .identity
+      }
     }
 
     view.isUserInteractionEnabled = visibleItem.itemType.isUserInteractionEnabled


### PR DESCRIPTION
## Details

This prevents item reuse / item layout from happening with an animation. This can occur if the calendar is forced to layout in an animation block, which can occur if using custom screen-to-screen transitions and probably other scenarios I haven't thought of. These bugs are usually hard to track down since the animation and layout pass can be triggered from anywhere up the view hierarchy.

## Related Issue

N/A

## Motivation and Context

Noticed this happening in the Airbnb app if an animation started and the calendar's layout was forced. It's not 100% repro but seems like it could be nice to just explicitly prevent this.

## How Has This Been Tested

Tested in simulator.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
