### PR TITLE
Prevent Hashable conformance bug

### DIFF
--- a/HorizonCalendar.podspec
+++ b/HorizonCalendar.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name = "HorizonCalendar"
-  spec.version = "1.6.4"
+  spec.version = "1.6.5"
   spec.license = "Apache License, Version 2.0"
   spec.summary = "A declarative, performant, calendar UI component that supports use cases ranging from simple date pickers to fully-featured calendar apps."
 

--- a/HorizonCalendar.xcodeproj/project.pbxproj
+++ b/HorizonCalendar.xcodeproj/project.pbxproj
@@ -566,7 +566,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.6.4;
+				MARKETING_VERSION = 1.6.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.HorizonCalendar;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -600,7 +600,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.6.4;
+				MARKETING_VERSION = 1.6.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.HorizonCalendar;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Sources/Internal/VisibleCalendarItem.swift
+++ b/Sources/Internal/VisibleCalendarItem.swift
@@ -47,8 +47,8 @@ final class VisibleCalendarItem {
 
   // MARK: Private
 
-  // Performance optimization - storing this separately prevents `calendarItem` from getting
-  // copied in the `Equatable` implementation.
+  // Performance optimization - storing this separately speeds up the `Hashable` implementation,
+  // which is frequently invoked by the `ItemViewReuseManager`'s `Set` operations.
   private let cachedHashValue: Int
 
 }
@@ -58,7 +58,8 @@ final class VisibleCalendarItem {
 extension VisibleCalendarItem: Equatable {
 
   static func == (lhs: VisibleCalendarItem, rhs: VisibleCalendarItem) -> Bool {
-    lhs.cachedHashValue == rhs.cachedHashValue
+    lhs.calendarItemModel.itemViewDifferentiator == rhs.calendarItemModel.itemViewDifferentiator &&
+      lhs.itemType == rhs.itemType
   }
 
 }


### PR DESCRIPTION
## Details

This fixes a potential `Hashable` conformance bug. I must not have been totally thinking this optimization through back when I made it earlier this year, because implementing `Equatable` using a cached `hashValue` defeats the purpose of the `Equatable` implementation (to resolve hash-value collisions).

## Related Issue

N/A

## Motivation and Context

I haven't seen any bugs or crashes due to this, but it's possible so I'd rather take a small performance hit (~5% CPU when scrolling really fast) than have incorrect code. There may be other areas that can be optimized, but the current implementation before this PR simply isn't correct.

## How Has This Been Tested

Real device.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
