### PR TITLE
Bk/work around mac catalyst scroll bug

### DIFF
--- a/Docs/TECHNICAL_DETAILS.md
+++ b/Docs/TECHNICAL_DETAILS.md
@@ -21,7 +21,7 @@ Aside from performance concerns, `UICollectionView` also felt like the wrong too
 - A layout and data source that are too decoupled for `HorizonCalendar`'s feature requirements, making it difficult to create calendar items that depend on parts of the layout being resolved when querying the data source (day range items need to know the frames of the items in their associated day range, for example)
 - Difficult to write unit tests to ensure layout and behavior correctness
 
-Having built and maintained `MagazineLayout` for the past several years, I'm also all too familiar with collection view's quirks. By writing a custom layout solution for `HorizonCalendar`, I've reduced the number of hacky `UIKit` workarounds to _zero_. We control our own destiny in this project :)
+Lastly, our experience building and maintaining `MagazineLayout` has made us all too familiar with collection view's quirks. By writing a custom layout solution for `HorizonCalendar`, we've avoided needing to implement workarounds for many unresolved UIKit bugs.
 
 
 ## Architecture Overview

--- a/Sources/Internal/ScrollMetricsMutator.swift
+++ b/Sources/Internal/ScrollMetricsMutator.swift
@@ -145,6 +145,9 @@ protocol ScrollMetricsProvider: class {
 
   func endInset(for scrollAxis: ScrollAxis) -> CGFloat
   func setEndInset(to inset: CGFloat, for scrollAxis: ScrollAxis)
+  
+  func minimumOffset(for scrollAxis: ScrollAxis) -> CGFloat
+  func maximumOffset(for scrollAxis: ScrollAxis) -> CGFloat
 
 }
 
@@ -205,6 +208,20 @@ extension UIScrollView: ScrollMetricsProvider {
     switch scrollAxis {
     case .vertical: contentInset.bottom = inset
     case .horizontal: contentInset.right = inset
+    }
+  }
+  
+  func minimumOffset(for scrollAxis: ScrollAxis) -> CGFloat {
+    switch scrollAxis {
+    case .vertical: return -contentInset.top
+    case .horizontal: return -contentInset.left
+    }
+  }
+
+  func maximumOffset(for scrollAxis: ScrollAxis) -> CGFloat {
+    switch scrollAxis {
+    case .vertical: return contentSize.height + contentInset.bottom - bounds.height
+    case .horizontal: return contentSize.width + contentInset.right - bounds.width
     }
   }
 

--- a/Sources/Public/CalendarView.swift
+++ b/Sources/Public/CalendarView.swift
@@ -386,7 +386,7 @@ public final class CalendarView: UIView {
   }()
   
   // Necessary to work around a `UIScrollView` behavior difference on Mac. See `scrollViewDidScroll`
-  // and `preventOverscrollIfNeeded` for more context.
+  // and `preventLargeOverscrollIfNeeded` for more context.
   private lazy var isRunningOnMac: Bool = {
     if #available(iOS 13.0, *) {
       if ProcessInfo.processInfo.isMacCatalystApp {

--- a/Sources/Public/CalendarView.swift
+++ b/Sources/Public/CalendarView.swift
@@ -85,22 +85,11 @@ public final class CalendarView: UIView {
   /// Whether or not the calendar's scroll view is currently overscrolling, i.e, whether the rubber-banding or bouncing effect is in
   /// progress.
   public var isOverscrolling: Bool {
-    let isOverscrollingAtStart: Bool
-    let isOverscrollingAtEnd: Bool
-    switch content.monthsLayout {
-    case .vertical:
-      isOverscrollingAtStart = scrollView.contentOffset.y < -scrollView.contentInset.top
-      let contentBottom = scrollView.contentOffset.y + scrollView.bounds.height
-      let maxContentBottom = scrollView.contentSize.height + scrollView.contentInset.bottom
-      isOverscrollingAtEnd = contentBottom > maxContentBottom
-    case .horizontal:
-      isOverscrollingAtStart = scrollView.contentOffset.x < -scrollView.contentInset.left
-      let contentRight = scrollView.contentOffset.x + scrollView.bounds.width
-      let maxContentRight = scrollView.contentSize.width + scrollView.contentInset.right
-      isOverscrollingAtEnd = contentRight > maxContentRight
-    }
+    let scrollAxis = scrollMetricsMutator.scrollAxis
+    let offset = scrollView.offset(for: scrollAxis)
 
-    return isOverscrollingAtStart || isOverscrollingAtEnd
+    return offset < scrollView.minimumOffset(for: scrollAxis) ||
+      offset > scrollView.maximumOffset(for: scrollAxis)
   }
 
   /// The range of months that are partially of fully visible.
@@ -394,6 +383,18 @@ public final class CalendarView: UIView {
     scrollView.showsHorizontalScrollIndicator = false
     scrollView.delegate = self
     return scrollView
+  }()
+  
+  // Necessary to work around a `UIScrollView` behavior difference on Mac. See `scrollViewDidScroll`
+  // and `preventOverscrollIfNeeded` for more context.
+  private lazy var isRunningOnMac: Bool = {
+    if #available(iOS 13.0, *) {
+      if ProcessInfo.processInfo.isMacCatalystApp {
+        return true
+      }
+    }
+    
+    return false
   }()
 
   private var calendar: Calendar {
@@ -697,6 +698,65 @@ public final class CalendarView: UIView {
       break
     }
   }
+  
+  // This hack is needed to prevent the scroll view from overscrolling far past the content. This
+  // occurs in 2 scenarios:
+  // - On macOS if you scroll quickly toward a boundary
+  // - On iOS if you scroll quickly toward a boundary and targetContentOffset is mutated
+  //
+  // https://openradar.appspot.com/radar?id=4966130615582720 demonstrates this issue on macOS.
+  private func preventLargeOverscrollIfNeeded() {
+    // TODO(BK): Change to `isRunningOnMac || content.isHorizontalPadingationEnabled` once
+    // horizontal pagination is implemented.
+    guard isRunningOnMac else { return }
+    
+    let scrollAxis = scrollMetricsMutator.scrollAxis
+    let offset = scrollView.offset(for: scrollAxis)
+    
+    let boundsSize: CGFloat
+    switch scrollAxis {
+    case .vertical: boundsSize = scrollView.bounds.height * 0.7
+    case .horizontal: boundsSize = scrollView.bounds.width * 0.7
+    }
+    
+    let newOffset: CGPoint?
+    if offset < scrollView.minimumOffset(for: scrollAxis) - boundsSize {
+      switch scrollAxis {
+      case .vertical:
+        newOffset = CGPoint(
+          x: scrollView.contentOffset.x,
+          y: scrollView.minimumOffset(for: scrollAxis))
+        
+      case .horizontal:
+        newOffset = CGPoint(
+          x: scrollView.minimumOffset(for: scrollAxis),
+          y: scrollView.contentOffset.y)
+      }
+    } else if offset > scrollView.maximumOffset(for: scrollAxis) + boundsSize {
+      switch scrollAxis {
+      case .vertical:
+        newOffset = CGPoint(
+          x: scrollView.contentOffset.x,
+          y: scrollView.maximumOffset(for: scrollAxis))
+        
+      case .horizontal:
+        newOffset = CGPoint(
+          x: scrollView.maximumOffset(for: scrollAxis),
+          y: scrollView.contentOffset.y)
+      }
+    } else {
+      newOffset = nil
+    }
+    
+    if let newOffset = newOffset {
+      scrollView.performWithoutNotifyingDelegate {
+        // Passing `false` for `animated` is necessary to stop the in-flight deceleration animation
+        UIView.animate(withDuration: 0.4, delay: 0, options: [.curveEaseOut], animations: {
+          self.scrollView.setContentOffset(newOffset, animated: false)
+        })
+      }
+    }
+  }
 
 }
 
@@ -709,6 +769,8 @@ extension CalendarView: UIScrollViewDelegate {
     deprecated,
     message: "Do not invoke this function directly, as it is only intended to be called from the internal implementation of `CalendarView`. This will be removed in a future major release.")
   public func scrollViewDidScroll(_ scrollView: UIScrollView) {
+    preventLargeOverscrollIfNeeded()
+    
     if let anchorLayoutItem = anchorLayoutItem {
       scrollView.performWithoutNotifyingDelegate {
         self.anchorLayoutItem = scrollMetricsMutator.loopOffsetIfNeeded(

--- a/Tests/ScrollMetricsMutatorTests.swift
+++ b/Tests/ScrollMetricsMutatorTests.swift
@@ -23,8 +23,8 @@ final class ScrollMetricsMutatorTests: XCTestCase {
   // MARK: Internal
 
   override func setUp() {
-    verticalScrollMetricsProvider = MockScrollMetricsProvider()
-    horizontalScrollMetricsProvider = MockScrollMetricsProvider()
+    verticalScrollMetricsProvider = Self.mockScrollMetricsProvider()
+    horizontalScrollMetricsProvider = Self.mockScrollMetricsProvider()
 
     let initialSize = CGSize(width: 320, height: 480)
 
@@ -442,83 +442,52 @@ final class ScrollMetricsMutatorTests: XCTestCase {
       initialOffset2 - 1000 == horizontalScrollMetricsProvider.offset(for: .horizontal),
       "Scroll offset does not equal the initial offset - 1000.")
   }
+  
+  // MARK: Scroll Boundary Offsets
+  
+  func testVerticalMinimumScrollOffset() {
+    verticalScrollMetricsProvider.setStartInset(to: 100, for: .vertical)
+    XCTAssert(
+      verticalScrollMetricsProvider.minimumOffset(for: .vertical) == -100,
+      "The minimum offset should equal the negated top inset.")
+  }
+  
+  func testHorizontalMinimumScrollOffset() {
+    horizontalScrollMetricsProvider.setStartInset(to: 300, for: .horizontal)
+    XCTAssert(
+      horizontalScrollMetricsProvider.minimumOffset(for: .horizontal) == -300,
+      "The minimum offset should equal the negated left inset.")
+  }
+  
+  func testVerticalMaximumScrollOffset() {
+    verticalScrollMetricsProvider.setEndInset(to: -50, for: .vertical)
+    XCTAssert(
+      verticalScrollMetricsProvider.maximumOffset(for: .vertical) == 29470,
+      "The maximum offset should equal the content height plus bottom inset minus bounds height.")
+  }
+  
+  func testHorizontalMaximumScrollOffset() {
+    horizontalScrollMetricsProvider.setEndInset(to: -80, for: .horizontal)
+    XCTAssert(
+      horizontalScrollMetricsProvider.maximumOffset(for: .horizontal) == 29600,
+      "The maximum offset should equal the content width plus right inset minus bounds width.")
+  }
 
   // MARK: Private
 
-  private var verticalScrollMetricsProvider: MockScrollMetricsProvider!
-  private var horizontalScrollMetricsProvider: MockScrollMetricsProvider!
+  private var verticalScrollMetricsProvider: ScrollMetricsProvider!
+  private var horizontalScrollMetricsProvider: ScrollMetricsProvider!
 
   private var verticalScrollMetricsMutator: ScrollMetricsMutator!
   private var horizontalScrollMetricsMutator: ScrollMetricsMutator!
-
-}
-
-// MARK: - MockScrollMetricsProvider
-
-private final class MockScrollMetricsProvider: ScrollMetricsProvider {
-
-  // MARK: Internal
-
-  func size(for scrollAxis: ScrollAxis) -> CGFloat {
-    switch scrollAxis {
-    case .vertical: return contentSize.height
-    case .horizontal: return contentSize.width
-    }
+  
+  private static func mockScrollMetricsProvider() -> ScrollMetricsProvider {
+    let scrollView = UIScrollView(frame: CGRect(x: 0, y: 0, width: 320, height: 480))
+    scrollView.contentInsetAdjustmentBehavior = .never
+    scrollView.contentSize = CGSize(width: 10, height: 10)
+    scrollView.contentOffset = CGPoint(x: 1, y: -1)
+    scrollView.contentInset = UIEdgeInsets(top: 1, left: 2, bottom: 3, right: 4)
+    return scrollView
   }
-
-  func setSize(to size: CGFloat, for scrollAxis: ScrollAxis) {
-    switch scrollAxis {
-    case .vertical: contentSize.height = size
-    case .horizontal: contentSize.width = size
-    }
-  }
-
-  func offset(for scrollAxis: ScrollAxis) -> CGFloat {
-    switch scrollAxis {
-    case .vertical: return contentOffset.y
-    case .horizontal: return contentOffset.x
-    }
-  }
-
-  func setOffset(to offset: CGFloat, for scrollAxis: ScrollAxis) {
-    switch scrollAxis {
-    case .vertical: contentOffset.y = offset
-    case .horizontal: contentOffset.x = offset
-    }
-  }
-
-  func startInset(for scrollAxis: ScrollAxis) -> CGFloat {
-    switch scrollAxis {
-    case .vertical: return contentInset.top
-    case .horizontal: return contentInset.left
-    }
-  }
-
-  func setStartInset(to inset: CGFloat, for scrollAxis: ScrollAxis) {
-    switch scrollAxis {
-    case .vertical: contentInset.top = inset
-    case .horizontal: contentInset.left = inset
-    }
-  }
-
-  func endInset(for scrollAxis: ScrollAxis) -> CGFloat {
-    switch scrollAxis {
-    case .vertical: return contentInset.bottom
-    case .horizontal: return contentInset.right
-    }
-  }
-
-  func setEndInset(to inset: CGFloat, for scrollAxis: ScrollAxis) {
-    switch scrollAxis {
-    case .vertical: contentInset.bottom = inset
-    case .horizontal: contentInset.right = inset
-    }
-  }
-
-  // MARK: Private
-
-  private var contentSize = CGSize(width: 100, height: 100)
-  private var contentOffset = CGPoint(x: 1, y: -1)
-  private var contentInset = UIEdgeInsets(top: 1, left: 2, bottom: 3, right: 4)
 
 }


### PR DESCRIPTION
## Details

This adds a workaround for macOS's funky `UIScrollView` behavior. On macOS, `UIScrollView` will fly past the content boundary, leaving the user looking at a blank view for a few seconds before snapping back to the last valid offset.

See https://openradar.appspot.com/radar?id=4966130615582720 for more details.

Edit: I've also discovered that this issue happens on iOS as well, but _only_ if targetContentOffset is mutated in `scrollViewWillEndDragging(_:withVelocity:targetContentOffset:)` (even if only by 1pt!) 😅 ... Since this function will be used for horizontal pagination, this bug will happen on iOS once that's implemented.

## Related Issue

https://github.com/airbnb/HorizonCalendar/issues/43

## Motivation and Context

Make macOS work better, at the cost of losing scroll bouncing if scrolling really fast. This is also needed to work around this bug on iOS when horizontal pagination is enabled (not merged yet).

## How Has This Been Tested

macOS, iOS, example app.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
