### PR TITLE
Bk/fix scroll to item layout margins bug

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -13,12 +13,12 @@ jobs:
 
     strategy:
       matrix:
-        destination: ['platform=iOS Simulator,OS=11.0,name=iPhone 8', 'platform=iOS Simulator,OS=14.2,name=iPhone 12']
+        destination: ['platform=iOS Simulator,OS=11.0,name=iPhone 8', 'platform=iOS Simulator,OS=14.3,name=iPhone 12']
 
     steps:
     - uses: actions/checkout@v2
     - name: Build
       run: xcodebuild clean build -scheme HorizonCalendar
     - name: Run tests
-      run: xcodebuild clean test -project HorizonCalendar.xcodeproj -scheme HorizonCalendar -destination "name=iPhone 8,OS=14.2"
+      run: xcodebuild clean test -project HorizonCalendar.xcodeproj -scheme HorizonCalendar -destination "name=iPhone 8,OS=14.3"
 

--- a/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/DemoViewController.swift
+++ b/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/DemoViewController.swift
@@ -50,8 +50,8 @@ class DemoViewController: UIViewController {
     switch monthsLayout {
     case .vertical:
       NSLayoutConstraint.activate([
-        calendarView.topAnchor.constraint(equalTo: view.layoutMarginsGuide.topAnchor),
-        calendarView.bottomAnchor.constraint(equalTo: view.layoutMarginsGuide.bottomAnchor),
+        calendarView.topAnchor.constraint(equalTo: view.topAnchor),
+        calendarView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
         calendarView.leadingAnchor.constraint(
           greaterThanOrEqualTo: view.layoutMarginsGuide.leadingAnchor),
         calendarView.trailingAnchor.constraint(

--- a/HorizonCalendar.podspec
+++ b/HorizonCalendar.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name = "HorizonCalendar"
-  spec.version = "1.7.0"
+  spec.version = "1.7.1"
   spec.license = "Apache License, Version 2.0"
   spec.summary = "A declarative, performant, calendar UI component that supports use cases ranging from simple date pickers to fully-featured calendar apps."
 

--- a/HorizonCalendar.xcodeproj/project.pbxproj
+++ b/HorizonCalendar.xcodeproj/project.pbxproj
@@ -578,7 +578,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.7.0;
+				MARKETING_VERSION = 1.7.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.HorizonCalendar;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -612,7 +612,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.7.0;
+				MARKETING_VERSION = 1.7.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.HorizonCalendar;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Sources/Public/CalendarView.swift
+++ b/Sources/Public/CalendarView.swift
@@ -487,9 +487,17 @@ public final class CalendarView: UIView {
   }
 
   private func targetAnchorLayoutItem(for scrollToItemContext: ScrollToItemContext) -> LayoutItem {
-    let offset = CGPoint(
-      x: scrollView.contentOffset.x + directionalLayoutMargins.leading,
-      y: scrollView.contentOffset.y + directionalLayoutMargins.top)
+    let offset: CGPoint
+    switch scrollMetricsMutator.scrollAxis {
+    case .vertical:
+      offset = CGPoint(
+        x: scrollView.contentOffset.x + directionalLayoutMargins.leading,
+        y: scrollView.contentOffset.y)
+    case .horizontal:
+      offset = CGPoint(
+        x: scrollView.contentOffset.x,
+        y: scrollView.contentOffset.y + directionalLayoutMargins.top)
+    }
 
     switch scrollToItemContext.targetItem {
     case .month(let month):


### PR DESCRIPTION
## Details

This PR fixes an issue that causes the scroll-to-item animation to get glitchy if there are layout margins set along the same axis as the scroll direction. There was a simple oversight in the target item calculation that resulted in the scroll-to-item being unable to get to its final position.

## Related Issue

https://github.com/airbnb/HorizonCalendar/issues/90

## Motivation and Context

Bug fix.

## How Has This Been Tested

Simulator + device.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
