### PR TITLE
Bk/fix layout margins behavior

### DIFF
--- a/HorizonCalendar.podspec
+++ b/HorizonCalendar.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name = "HorizonCalendar"
-  spec.version = "1.7.1"
+  spec.version = "1.7.2"
   spec.license = "Apache License, Version 2.0"
   spec.summary = "A declarative, performant, calendar UI component that supports use cases ranging from simple date pickers to fully-featured calendar apps."
 

--- a/HorizonCalendar.xcodeproj/project.pbxproj
+++ b/HorizonCalendar.xcodeproj/project.pbxproj
@@ -578,7 +578,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.7.1;
+				MARKETING_VERSION = 1.7.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.HorizonCalendar;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -612,7 +612,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.7.1;
+				MARKETING_VERSION = 1.7.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.HorizonCalendar;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Sources/Internal/FrameProvider.swift
+++ b/Sources/Internal/FrameProvider.swift
@@ -207,11 +207,16 @@ final class FrameProvider {
     -> CGRect
   {
     let x = minXOfItem(at: dayOfWeekPosition, minXOfContainingRow: layoutMargins.leading)
-    return CGRect(origin: CGPoint(x: x, y: yContentOffset), size: daySize)
+    let y = layoutMargins.top + yContentOffset
+    return CGRect(origin: CGPoint(x: x, y: y), size: daySize)
   }
 
   func frameOfPinnedDaysOfWeekRowBackground(yContentOffset: CGFloat) -> CGRect {
-    CGRect(x: layoutMargins.leading, y: yContentOffset, width: monthWidth, height: daySize.height)
+    CGRect(
+      x: layoutMargins.leading,
+      y: layoutMargins.top + yContentOffset,
+      width: monthWidth,
+      height: daySize.height)
   }
 
   func frameOfPinnedDaysOfWeekRowSeparator(
@@ -221,7 +226,7 @@ final class FrameProvider {
   {
     CGRect(
       x: layoutMargins.leading,
-      y: yContentOffset + daySize.height - separatorHeight,
+      y: layoutMargins.top + yContentOffset + daySize.height - separatorHeight,
       width: monthWidth,
       height: separatorHeight)
   }

--- a/Sources/Public/CalendarView.swift
+++ b/Sources/Public/CalendarView.swift
@@ -139,23 +139,26 @@ public final class CalendarView: UIView {
 
   /// `CalendarView` only supports positive values for `layoutMargins`. Negative values will be changed to `0`.
   public override var layoutMargins: UIEdgeInsets {
-    didSet {
+    get { super.layoutMargins }
+    set {
       super.layoutMargins = UIEdgeInsets(
-        top: max(layoutMargins.top, 0),
-        left: max(layoutMargins.left, 0),
-        bottom: max(layoutMargins.bottom, 0),
-        right: max(layoutMargins.right, 0))
+        top: max(newValue.top, 0),
+        left: max(newValue.left, 0),
+        bottom: max(newValue.bottom, 0),
+        right: max(newValue.right, 0))
     }
   }
 
-  /// `CalendarView` only supports positive values for `directionalLayoutMargins`. Negative values will be changed to `0`.
+  /// `CalendarView` only supports positive values for `directionalLayoutMargins`. Negative values will be changed to
+  /// `0`.
   public override var directionalLayoutMargins: NSDirectionalEdgeInsets {
-    didSet {
+    get { super.directionalLayoutMargins }
+    set {
       super.directionalLayoutMargins = NSDirectionalEdgeInsets(
-        top: max(directionalLayoutMargins.top, 0),
-        leading: max(directionalLayoutMargins.leading, 0),
-        bottom: max(directionalLayoutMargins.bottom, 0),
-        trailing: max(directionalLayoutMargins.trailing, 0))
+        top: max(newValue.top, 0),
+        leading: max(newValue.leading, 0),
+        bottom: max(newValue.bottom, 0),
+        trailing: max(newValue.trailing, 0))
     }
   }
 


### PR DESCRIPTION
## Details

The way I overrode the `layoutMargins` property was wrong. By accessing `self.layoutMargins` in `didSet`, I was actually getting the system-computed layout margins (which includes the additional safe area margins). If someone called `calendarView.layoutMargins = .zero`, `self.layoutMargins.top` in the `didSet` would be `64` instead of `0`.

The correct way to override this is to access `newValue` in `set`. 

## Related Issue

N/A

## Motivation and Context

Make `layoutMargins` work correctly.

## How Has This Been Tested

Simulator

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
