### PR TITLE
Bk/accessibility elements for days

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -13,12 +13,12 @@ jobs:
 
     strategy:
       matrix:
-        destination: ['platform=iOS Simulator,OS=11.0,name=iPhone 8', 'platform=iOS Simulator,OS=14.3,name=iPhone 12']
+        destination: ['platform=iOS Simulator,OS=11.0,name=iPhone 8', 'platform=iOS Simulator,OS=14.4,name=iPhone 12']
 
     steps:
     - uses: actions/checkout@v2
     - name: Build
       run: xcodebuild clean build -scheme HorizonCalendar
     - name: Run tests
-      run: xcodebuild clean test -project HorizonCalendar.xcodeproj -scheme HorizonCalendar -destination "name=iPhone 8,OS=14.3"
+      run: xcodebuild clean test -project HorizonCalendar.xcodeproj -scheme HorizonCalendar -destination "name=iPhone 8,OS=14.4"
 

--- a/HorizonCalendar.podspec
+++ b/HorizonCalendar.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name = "HorizonCalendar"
-  spec.version = "1.7.2"
+  spec.version = "1.8.0"
   spec.license = "Apache License, Version 2.0"
   spec.summary = "A declarative, performant, calendar UI component that supports use cases ranging from simple date pickers to fully-featured calendar apps."
 

--- a/HorizonCalendar.xcodeproj/project.pbxproj
+++ b/HorizonCalendar.xcodeproj/project.pbxproj
@@ -578,7 +578,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.7.2;
+				MARKETING_VERSION = 1.8.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.HorizonCalendar;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -612,7 +612,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.7.2;
+				MARKETING_VERSION = 1.8.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.HorizonCalendar;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Sources/Public/CalendarView.swift
+++ b/Sources/Public/CalendarView.swift
@@ -281,6 +281,29 @@ public final class CalendarView: UIView {
     setNeedsLayout()
   }
 
+  /// Returns the accessibility element associated with the specified visible date. If the date is not currently visible, then there will be no
+  /// associated accessibility element and this function will return `nil`.
+  ///
+  /// Use this function to programmatically change the currently-focused date via
+  /// `UIAccessibility.post(notification:argument:)`, passing the returned accessibility element as the parameter for
+  /// `argument`.
+  ///
+  /// - Parameters:
+  ///   - date: The date for which to obtain an accessibility element. If the date is not currently visible, then it will not have an
+  ///   associated accessibility element.
+  /// - Returns: An accessibility element associated with the specified `date`, or `nil` if one cannot be found.
+  public func accessibilityElementForVisibleDate(_ date: Date) -> Any? {
+    let day = calendar.day(containing: date)
+    guard let visibleDayRange = visibleDayRange, visibleDayRange.contains(day) else { return nil }
+
+    for (visibleItem, visibleView) in visibleViewsForVisibleItems {
+      guard case .layoutItemType(.day(day)) = visibleItem.itemType else { continue }
+      return visibleView
+    }
+
+    return nil
+  }
+
   /// Scrolls the calendar to the specified month with the specified position.
   ///
   /// If the calendar has a non-zero frame, this function will scroll to the specified month immediately. Otherwise the scroll-to-month


### PR DESCRIPTION
## Details

This adds support for getting an accessibility element for a visible date in the calendar. The use case this will most commonly be used for is programmatically changing the accessibility focus (while VoiceOver is running) to be on a specific date (like on initial page load, or when returning from a modal back to the calendar). We need this functionality in the Airbnb app, and others might need it too.

## Related Issue

N/A

## Motivation and Context

Enables developers to support a better a11y experience.

## How Has This Been Tested

I tested on device with and without voiceover running, using variations of this code:

```swift
DispatchQueue.main.asyncAfter(deadline: .now() + 5, execute: {
      let date = self.calendar.date(from: DateComponents(year: 2020, month: 02, day: 28))!
      let accessibilityElement = self.calendarView.accessibilityElementForVisibleDate(date)!
      UIAccessibility.post(notification: .screenChanged, argument: accessibilityElement)
    })
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
