### PR TITLE
Fix view z positions when render in context snapshotting

### DIFF
--- a/HorizonCalendar.podspec
+++ b/HorizonCalendar.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name = "HorizonCalendar"
-  spec.version = "1.8.0"
+  spec.version = "1.8.1"
   spec.license = "Apache License, Version 2.0"
   spec.summary = "A declarative, performant, calendar UI component that supports use cases ranging from simple date pickers to fully-featured calendar apps."
 

--- a/HorizonCalendar.xcodeproj/project.pbxproj
+++ b/HorizonCalendar.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		938DA40F24BEEB1A008A3B47 /* CalendarItemViewRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 938DA40E24BEEB1A008A3B47 /* CalendarItemViewRepresentable.swift */; };
 		938DA41124BEFFCB008A3B47 /* AnyCalendarItemModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 938DA41024BEFFCB008A3B47 /* AnyCalendarItemModel.swift */; };
 		938DA41324BF0FFF008A3B47 /* DefaultItemProviders.swift in Sources */ = {isa = PBXBuildFile; fileRef = 938DA41224BF0FFF008A3B47 /* DefaultItemProviders.swift */; };
+		9391E66926293A3F00A79C6E /* CalendarLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9391E66826293A3F00A79C6E /* CalendarLayer.swift */; };
 		9391F15625C097DF001D14A2 /* PaginationHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9391F15525C097DF001D14A2 /* PaginationHelpers.swift */; };
 		9396F3CC2483261B008AD306 /* HorizonCalendar.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9396F3C22483261B008AD306 /* HorizonCalendar.framework */; };
 		9396F3DD24832715008AD306 /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 9396F3DC24832715008AD306 /* README.md */; };
@@ -76,6 +77,7 @@
 		938DA40E24BEEB1A008A3B47 /* CalendarItemViewRepresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarItemViewRepresentable.swift; sourceTree = "<group>"; };
 		938DA41024BEFFCB008A3B47 /* AnyCalendarItemModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyCalendarItemModel.swift; sourceTree = "<group>"; };
 		938DA41224BF0FFF008A3B47 /* DefaultItemProviders.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultItemProviders.swift; sourceTree = "<group>"; };
+		9391E66826293A3F00A79C6E /* CalendarLayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarLayer.swift; sourceTree = "<group>"; };
 		9391F15525C097DF001D14A2 /* PaginationHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginationHelpers.swift; sourceTree = "<group>"; };
 		9396F3C22483261B008AD306 /* HorizonCalendar.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = HorizonCalendar.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9396F3C62483261B008AD306 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -211,6 +213,7 @@
 				939E693224837E8700A8BCC7 /* CalendarItemModel.swift */,
 				938DA40E24BEEB1A008A3B47 /* CalendarItemViewRepresentable.swift */,
 				939E691724837E0200A8BCC7 /* CalendarView.swift */,
+				9391E66826293A3F00A79C6E /* CalendarLayer.swift */,
 				939E693524837E8700A8BCC7 /* CalendarViewContent.swift */,
 				939E693324837E8700A8BCC7 /* CalendarViewScrollPosition.swift */,
 				939E693F24846A8C00A8BCC7 /* Day.swift */,
@@ -370,6 +373,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				939E692A24837E0300A8BCC7 /* ItemViewReuseManager.swift in Sources */,
+				9391E66926293A3F00A79C6E /* CalendarLayer.swift in Sources */,
 				939E692524837E0300A8BCC7 /* LayoutItemTypeEnumerator.swift in Sources */,
 				938DA41124BEFFCB008A3B47 /* AnyCalendarItemModel.swift in Sources */,
 				939E692724837E0300A8BCC7 /* VisibleItemsProvider.swift in Sources */,
@@ -578,7 +582,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.8.0;
+				MARKETING_VERSION = 1.8.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.HorizonCalendar;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -612,7 +616,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.8.0;
+				MARKETING_VERSION = 1.8.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.HorizonCalendar;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Sources/Public/CalendarLayer.swift
+++ b/Sources/Public/CalendarLayer.swift
@@ -1,0 +1,18 @@
+// Created by Bryan Keller on 4/15/21.
+// Copyright © 2021 Airbnb Inc. All rights reserved.
+
+import UIKit
+
+/// A `CALayer` subclass that enables an observer to be notified when `render(in:)` is called (usually for the purpose of
+/// doing some work before a layer is snapshotted). This is needed so that `CalendarView` can sort its `subviews` array before
+/// snapshotting, since `render(in:)` does not respect `CALayer` `zPosition` values.
+final class RenderInContextObservingLayer: CALayer {
+
+  var willRenderInContext: (() -> Void)?
+
+  override func render(in ctx: CGContext) {
+    willRenderInContext?()
+    super.render(in: ctx)
+  }
+
+}


### PR DESCRIPTION
## Details

This PR fixes a rendering issue when `CalendarView` is part of a view hierarchy being snapshotted via `CALayer.render(in:)`. The core issue is that, for performance reasons, `CalendarView` does not sort its subviews before adding them to the view hierarchy, and instead simply sets each subview's layer's `zPosition` property. This works well, except when snapshotting a view view `CALayer.render(in:)`. It's unclear if this is a bug with that function or not (it certainly seems like a `CALayer` snapshotting function should respect `sublayer`'s `zPosition`s), but I'm not going to bank on Apple fixing this anytime soon.

| Before | After |
| ---- | ---- |
| ![Simulator Screen Shot - iPhone 8 - 2021-04-15 at 18 02 17](https://user-images.githubusercontent.com/746571/114973616-84402000-9e1c-11eb-9605-765d03bd1ead.png) | ![Simulator Screen Shot - iPhone 8 - 2021-04-15 at 19 03 23](https://user-images.githubusercontent.com/746571/114974006-45f73080-9e1d-11eb-9804-3549fd41586d.png) |

## Related Issue

N/A

## Motivation and Context

Fixes snapshotting for users who want that.

## How Has This Been Tested

Tested in example app by snapshotting demo VC.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
