### PR TITLE
Simplify zPosition sorting code

### DIFF
--- a/HorizonCalendar.podspec
+++ b/HorizonCalendar.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name = "HorizonCalendar"
-  spec.version = "1.8.1"
+  spec.version = "1.8.2"
   spec.license = "Apache License, Version 2.0"
   spec.summary = "A declarative, performant, calendar UI component that supports use cases ranging from simple date pickers to fully-featured calendar apps."
 

--- a/HorizonCalendar.xcodeproj/project.pbxproj
+++ b/HorizonCalendar.xcodeproj/project.pbxproj
@@ -582,7 +582,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.8.1;
+				MARKETING_VERSION = 1.8.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.HorizonCalendar;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -616,7 +616,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.8.1;
+				MARKETING_VERSION = 1.8.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.HorizonCalendar;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Sources/Public/CalendarView.swift
+++ b/Sources/Public/CalendarView.swift
@@ -813,17 +813,7 @@ public final class CalendarView: UIView {
   /// This is needed to ensure that the `subviews` array is sorted according to each sublayer's `zPosition`. This prevents
   /// z-index-related rendering issues when a `CalendarView` is being snapshotted via `CALayer.render(in:)`.
   private func sortSubviewsByLayerZPositions() {
-    // Bubble Sort implementation, which makes doing in-place swaps (subview exchanges) easy.
-    for i in 0..<scrollView.subviews.count {
-      for j in 0..<(scrollView.subviews.count - i - 1) {
-        let lhsZPosition = scrollView.subviews[j].layer.zPosition
-        let rhsZPosition = scrollView.subviews[j + 1].layer.zPosition
-
-        if lhsZPosition > rhsZPosition {
-          scrollView.exchangeSubview(at: j, withSubviewAt: j + 1)
-        }
-      }
-    }
+    scrollView.layer.sublayers?.sort { $0.zPosition < $1.zPosition }
   }
 
 }


### PR DESCRIPTION
## Details

Fast-follow to https://github.com/airbnb/HorizonCalendar/pull/114. Since `CALayer`'s `sublayers` property is `{get set}`, there's no need to implement our own in-place subview sorting - we can just call `.sort` on the sublayers array.

## Related Issue

N/A

## Motivation and Context

#simplify 

## How Has This Been Tested

Tested in Example project

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
