### PR TITLE
Bk/add default selected day example

### DIFF
--- a/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/PartialMonthVisibilityDemoViewController.swift
+++ b/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/PartialMonthVisibilityDemoViewController.swift
@@ -16,7 +16,7 @@ final class PartialMonthVisibilityDemoViewController: DemoViewController {
     calendarView.daySelectionHandler = { [weak self] day in
       guard let self = self else { return }
 
-      self.selectedDay = day
+      self.selectedDate = self.calendar.date(from: day.components)
       self.calendarView.setContent(self.makeContent())
     }
   }
@@ -25,7 +25,7 @@ final class PartialMonthVisibilityDemoViewController: DemoViewController {
     let startDate = calendar.date(from: DateComponents(year: 2020, month: 01, day: 16))!
     let endDate = calendar.date(from: DateComponents(year: 2020, month: 12, day: 05))!
 
-    let selectedDay = self.selectedDay
+    let selectedDate = self.selectedDate
 
     return CalendarViewContent(
       calendar: calendar,
@@ -44,22 +44,25 @@ final class PartialMonthVisibilityDemoViewController: DemoViewController {
           textColor = .black
         }
 
+        let isSelectedStyle: Bool
         let dayAccessibilityText: String?
         if let date = self?.calendar.date(from: day.components) {
+          isSelectedStyle = selectedDate == date
           dayAccessibilityText = self?.dayDateFormatter.string(from: date)
         } else {
+          isSelectedStyle = false
           dayAccessibilityText = nil
         }
 
         return CalendarItemModel<DayView>(
-          invariantViewProperties: .init(textColor: textColor, isSelectedStyle: day == selectedDay),
+          invariantViewProperties: .init(textColor: textColor, isSelectedStyle: isSelectedStyle),
           viewModel: .init(dayText: "\(day.day)", dayAccessibilityText: dayAccessibilityText))
       }
   }
 
   // MARK: Private
 
-  private var selectedDay: Day?
+  private var selectedDate: Date?
 
 }
 

--- a/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/SelectedDayTooltipDemoViewController.swift
+++ b/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/SelectedDayTooltipDemoViewController.swift
@@ -28,7 +28,7 @@ final class SelectedDayTooltipDemoViewController: DemoViewController {
     calendarView.daySelectionHandler = { [weak self] day in
       guard let self = self else { return }
 
-      self.selectedDay = day
+      self.selectedDate = self.calendar.date(from: day.components)
       self.calendarView.setContent(self.makeContent())
     }
   }
@@ -37,12 +37,11 @@ final class SelectedDayTooltipDemoViewController: DemoViewController {
     let startDate = calendar.date(from: DateComponents(year: 2020, month: 01, day: 01))!
     let endDate = calendar.date(from: DateComponents(year: 2021, month: 12, day: 31))!
 
-    let selectedDay = self.selectedDay
+    let selectedDate = self.selectedDate
 
     let overlaidItemLocations: Set<CalendarViewContent.OverlaidItemLocation>
-    if let selectedDay = selectedDay {
-      let dateToOverlay = calendar.date(from: selectedDay.components)!
-      overlaidItemLocations = [.day(containingDate: dateToOverlay)]
+    if let selectedDate = selectedDate {
+      overlaidItemLocations = [.day(containingDate: selectedDate)]
     } else {
       overlaidItemLocations = []
     }
@@ -62,15 +61,18 @@ final class SelectedDayTooltipDemoViewController: DemoViewController {
           textColor = .black
         }
 
+        let isSelectedStyle: Bool
         let dayAccessibilityText: String?
         if let date = self?.calendar.date(from: day.components) {
+          isSelectedStyle = selectedDate == date
           dayAccessibilityText = self?.dayDateFormatter.string(from: date)
         } else {
+          isSelectedStyle = false
           dayAccessibilityText = nil
         }
 
         return CalendarItemModel<DayView>(
-          invariantViewProperties: .init(textColor: textColor, isSelectedStyle: day == selectedDay),
+          invariantViewProperties: .init(textColor: textColor, isSelectedStyle: isSelectedStyle),
           viewModel: .init(dayText: "\(day.day)", dayAccessibilityText: dayAccessibilityText))
       }
 
@@ -85,6 +87,6 @@ final class SelectedDayTooltipDemoViewController: DemoViewController {
 
   // MARK: Private
 
-  private var selectedDay: Day?
+  private var selectedDate: Date?
 
 }

--- a/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/SingleDaySelectionDemoViewController.swift
+++ b/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/SingleDaySelectionDemoViewController.swift
@@ -18,6 +18,17 @@ import UIKit
 
 final class SingleDaySelectionDemoViewController: DemoViewController {
 
+  // MARK: Lifecycle
+
+  required init(monthsLayout: MonthsLayout) {
+    super.init(monthsLayout: monthsLayout)
+    selectedDate = calendar.date(from: DateComponents(year: 2020, month: 01, day: 19))!
+  }
+
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
   // MARK: Internal
 
   override func viewDidLoad() {
@@ -28,7 +39,7 @@ final class SingleDaySelectionDemoViewController: DemoViewController {
     calendarView.daySelectionHandler = { [weak self] day in
       guard let self = self else { return }
 
-      self.selectedDay = day
+      self.selectedDate = self.calendar.date(from: day.components)
       self.calendarView.setContent(self.makeContent())
     }
   }
@@ -37,7 +48,7 @@ final class SingleDaySelectionDemoViewController: DemoViewController {
     let startDate = calendar.date(from: DateComponents(year: 2020, month: 01, day: 01))!
     let endDate = calendar.date(from: DateComponents(year: 2021, month: 12, day: 31))!
 
-    let selectedDay = self.selectedDay
+    let selectedDate = self.selectedDate
 
     return CalendarViewContent(
       calendar: calendar,
@@ -56,21 +67,24 @@ final class SingleDaySelectionDemoViewController: DemoViewController {
           textColor = .black
         }
 
+        let isSelectedStyle: Bool
         let dayAccessibilityText: String?
         if let date = self?.calendar.date(from: day.components) {
+          isSelectedStyle = selectedDate == date
           dayAccessibilityText = self?.dayDateFormatter.string(from: date)
         } else {
+          isSelectedStyle = false
           dayAccessibilityText = nil
         }
 
         return CalendarItemModel<DayView>(
-          invariantViewProperties: .init(textColor: textColor, isSelectedStyle: day == selectedDay),
+          invariantViewProperties: .init(textColor: textColor, isSelectedStyle: isSelectedStyle),
           viewModel: .init(dayText: "\(day.day)", dayAccessibilityText: dayAccessibilityText))
       }
   }
 
   // MARK: Private
 
-  private var selectedDay: Day?
+  private var selectedDate: Date?
 
 }

--- a/HorizonCalendar.podspec
+++ b/HorizonCalendar.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name = "HorizonCalendar"
-  spec.version = "1.8.3"
+  spec.version = "1.8.4"
   spec.license = "Apache License, Version 2.0"
   spec.summary = "A declarative, performant, calendar UI component that supports use cases ranging from simple date pickers to fully-featured calendar apps."
 

--- a/HorizonCalendar.xcodeproj/project.pbxproj
+++ b/HorizonCalendar.xcodeproj/project.pbxproj
@@ -582,7 +582,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.8.3;
+				MARKETING_VERSION = 1.8.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.HorizonCalendar;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -616,7 +616,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.8.3;
+				MARKETING_VERSION = 1.8.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.HorizonCalendar;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";


### PR DESCRIPTION
## Details

This PR aims to solve some confusion with how to make a day in the calendar appear selected by default. Since `Day`s can only be initialized internally (library consumers cannot initialize them), the example project was confusing since there wasn't an obvious way to set the `selectedDay` property yourself.

I've updated the example project to store of `Date` instances instead of `Day`s, and also added a default selection to fully demonstrate how library consumers should implement something like this.

## Related Issue

https://github.com/airbnb/HorizonCalendar/issues/123

## Motivation and Context

Make this common use case much more clear.

## How Has This Been Tested

Tested by running demo app.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
