### PR TITLE
Add page scrolled accessibility notification

### DIFF
--- a/HorizonCalendar.podspec
+++ b/HorizonCalendar.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name = "HorizonCalendar"
-  spec.version = "1.8.6"
+  spec.version = "1.8.7"
   spec.license = "Apache License, Version 2.0"
   spec.summary = "A declarative, performant, calendar UI component that supports use cases ranging from simple date pickers to fully-featured calendar apps."
 

--- a/HorizonCalendar.xcodeproj/project.pbxproj
+++ b/HorizonCalendar.xcodeproj/project.pbxproj
@@ -582,7 +582,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.8.6;
+				MARKETING_VERSION = 1.8.7;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.HorizonCalendar;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -616,7 +616,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.8.6;
+				MARKETING_VERSION = 1.8.7;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.HorizonCalendar;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Sources/Public/CalendarView.swift
+++ b/Sources/Public/CalendarView.swift
@@ -1050,6 +1050,13 @@ extension CalendarView {
     guard let targetMonthDate = calendar.date(from: targetMonth.components) else { return false }
 
     scroll(toMonthContaining: targetMonthDate, scrollPosition: scrollPosition, animated: false)
+
+    let targetMonthItem = content.monthHeaderItemModelProvider(targetMonth)
+    let targetMonthView = targetMonthItem.makeView()
+    targetMonthItem.setViewModelOnViewOfSameType(targetMonthView)
+    let accessibilityScrollText = targetMonthView.accessibilityLabel
+    UIAccessibility.post(notification: .pageScrolled, argument: accessibilityScrollText)
+
     return true
   }
 


### PR DESCRIPTION
## Details

This adds the missing `.pageScrolled` accessibility notification to HorizonCalendar. [According to the documentation](https://developer.apple.com/documentation/uikit/uiaccessibility/notification/1620190-pagescrolled), we should post this notification with some `NSString` describing the current scroll position. 

## Related Issue

N/A

## Motivation and Context

Improve accessibility UX.

## How Has This Been Tested

Real device using VoiceOver.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
