### PR TITLE
Preserve scroll position after bounds or layout margins change

### DIFF
--- a/HorizonCalendar.podspec
+++ b/HorizonCalendar.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name = "HorizonCalendar"
-  spec.version = "1.8.7"
+  spec.version = "1.8.8"
   spec.license = "Apache License, Version 2.0"
   spec.summary = "A declarative, performant, calendar UI component that supports use cases ranging from simple date pickers to fully-featured calendar apps."
 

--- a/HorizonCalendar.xcodeproj/project.pbxproj
+++ b/HorizonCalendar.xcodeproj/project.pbxproj
@@ -582,7 +582,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.8.7;
+				MARKETING_VERSION = 1.8.8;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.HorizonCalendar;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -616,7 +616,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.8.7;
+				MARKETING_VERSION = 1.8.8;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.HorizonCalendar;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";


### PR DESCRIPTION
## Details

When the bounds changes (e.g. on rotation) and when the layout margins change, we should attempt to preserve the current scroll position. In the case of layout margins, the following examples explain the new behavior:

1. If a user is scrolled down by several months, changing the top margin won't cause the content to jump. Once they scroll to the top, they'll notice the new top margin.
2. If a user is scrolled to the top already, changing the top margin will cause the topmost content to move down to respect the new top margin.

## Related Issue

N/A

## Motivation and Context

In the Airbnb app, our navigation infrastructure adjusts the top layout margin of the view to account for Epoxy top bars. Without this change, the topmost content would be covered by the top bars until the user manually scrolled to the top. Prior to this change, we would need to constrain `CalendarView`'s top anchor to `view.layoutMarginsGuide.topAnchor`, rather than `view.topAnchor`, which meant that the calendar's content would get clipped when scrolling under translucent top bars.

| Before | After |
| ---- | ---- |
| ![Simulator Screen Shot - iPhone 8 - 2021-07-26 at 14 17 21](https://user-images.githubusercontent.com/746571/127063673-6779b10c-86a3-44cf-b23d-dd77b82509c8.png) | ![Simulator Screen Shot - iPhone 8 - 2021-07-26 at 14 15 55](https://user-images.githubusercontent.com/746571/127063716-0fe932e9-f5a0-4ca2-94b2-a0870e5576e9.png) | 

## How Has This Been Tested

Tested in example app and Airbnb app.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
