### PR TITLE
Bk/add decleration info to did end dragging

### DIFF
--- a/HorizonCalendar.podspec
+++ b/HorizonCalendar.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name = "HorizonCalendar"
-  spec.version = "1.8.8"
+  spec.version = "1.9.0"
   spec.license = "Apache License, Version 2.0"
   spec.summary = "A declarative, performant, calendar UI component that supports use cases ranging from simple date pickers to fully-featured calendar apps."
 

--- a/HorizonCalendar.xcodeproj/project.pbxproj
+++ b/HorizonCalendar.xcodeproj/project.pbxproj
@@ -582,7 +582,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.8.8;
+				MARKETING_VERSION = 1.9.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.HorizonCalendar;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -616,7 +616,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.8.8;
+				MARKETING_VERSION = 1.9.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.HorizonCalendar;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Sources/Public/CalendarView.swift
+++ b/Sources/Public/CalendarView.swift
@@ -83,7 +83,14 @@ public final class CalendarView: UIView {
   public var didScroll: ((_ visibleDayRange: DayRange, _ isUserDragging: Bool) -> Void)?
 
   /// A closure (that is retained) that is invoked inside `scrollViewDidEndDragging(_: willDecelerate:)`.
+  @available(
+    *,
+    deprecated,
+    message: "Use `_didEndDragging` instead, since it includes a `Bool` to indicate whether the calendar will decelerate when dragging ends. In a future release, `_didEndDragging` will be renamed to `didEndDragging`, and this deprecated property will be removed.")
   public var didEndDragging: ((_ visibleDayRange: DayRange) -> Void)?
+
+  /// A closure (that is retained) that is invoked inside `scrollViewDidEndDragging(_: willDecelerate:)`.
+  public var _didEndDragging: ((_ visibleDayRange: DayRange, _ willDecelerate: Bool) -> Void)?
 
   /// A closure (that is retained) that is invoked inside `scrollViewDidEndDecelerating(_:)`.
   public var didEndDecelerating: ((_ visibleDayRange: DayRange) -> Void)?
@@ -878,6 +885,7 @@ extension CalendarView: UIScrollViewDelegate {
   {
     guard let visibleDayRange = visibleDayRange else { return }
     didEndDragging?(visibleDayRange)
+    _didEndDragging?(visibleDayRange, decelerate)
   }
 
   @available(


### PR DESCRIPTION
## Details

Adds a new `didEndDragging` property that includes a `willDecelerate` property, which is necessary for knowing whether to wait for `didEndDecelerating` to be called or not when you're trying to watch the currently-visible range of days.

To ensure that this is a non-breaking change, I've given the new property an underscore prefix, and deprecated the old property.

## Related Issue

https://github.com/airbnb/HorizonCalendar/issues/135

## Motivation and Context

Resolve issue.

## How Has This Been Tested

Tested in example app.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
