### PR TITLE
Fixed typo on creating the day view + adjusted day output to print only the day instead of the description of the "Day" class

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ struct DayLabel: CalendarItemViewRepresentable {
   }
 
   static func setViewModel(_ viewModel: ViewModel, on view: UILabel) {
-    view.text = "\(viewModel.day)"
+    view.text = "\(viewModel.day.day)"
   }
 
 }
@@ -247,7 +247,7 @@ Now that we have a type conforming to `CalendarItemViewRepresentable`, we can us
         invariantViewProperties: .init(
           font: UIFont.systemFont(ofSize: 18), 
           textColor: .darkGray,
-          backgroundColor: .clear)
+          backgroundColor: .clear),
         viewModel: .init(day: day))
     }
 ```


### PR DESCRIPTION
## Details

Just some minor changes on README to fix a missing comma & the output to look similar to what's presented on the screenshot.

## Related Issue

Code that is on the README does not compile.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
