### PR TITLE
Bk/make horizontal calendars easier

### DIFF
--- a/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/DemoViewController.swift
+++ b/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/DemoViewController.swift
@@ -35,6 +35,12 @@ class DemoViewController: UIViewController {
     return dateFormatter
   }()
 
+  // We use a placeholder height until `calendarView.maximumMonthHeightDidChange` is invoked. Once
+  // we know the maximum size that a month can be in the horizontally-scrolling calendar, we can
+  // adjust this constraint's constant so that it perfectly fits each month.
+  lazy var horizontalCalendarViewHeightConstraint = calendarView.heightAnchor.constraint(
+    equalToConstant: 0)
+
   override func viewDidLoad() {
     super.viewDidLoad()
 
@@ -60,15 +66,21 @@ class DemoViewController: UIViewController {
         calendarView.widthAnchor.constraint(lessThanOrEqualToConstant: 375)
       ])
     case .horizontal:
+      calendarView.maximumMonthHeightDidChange = { [weak self] maximumMonthHeight in
+        guard let self = self else { return }
+        let heightConstant = maximumMonthHeight +
+          self.calendarView.layoutMargins.top +
+          self.calendarView.layoutMargins.bottom
+        self.horizontalCalendarViewHeightConstraint.constant = heightConstant
+      }
+
       NSLayoutConstraint.activate([
         calendarView.centerYAnchor.constraint(equalTo: view.layoutMarginsGuide.centerYAnchor),
-        calendarView.heightAnchor.constraint(equalToConstant: 275),
-        calendarView.leadingAnchor.constraint(
-          greaterThanOrEqualTo: view.leadingAnchor),
-        calendarView.trailingAnchor.constraint(
-          lessThanOrEqualTo: view.trailingAnchor),
+        calendarView.leadingAnchor.constraint(greaterThanOrEqualTo: view.leadingAnchor),
+        calendarView.trailingAnchor.constraint(lessThanOrEqualTo: view.trailingAnchor),
         calendarView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-        calendarView.widthAnchor.constraint(lessThanOrEqualToConstant: 375)
+        calendarView.widthAnchor.constraint(lessThanOrEqualToConstant: 375),
+        horizontalCalendarViewHeightConstraint,
       ])
     }
   }

--- a/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/DemoViewController.swift
+++ b/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/DemoViewController.swift
@@ -35,12 +35,6 @@ class DemoViewController: UIViewController {
     return dateFormatter
   }()
 
-  // We use a placeholder height until `calendarView.maximumMonthHeightDidChange` is invoked. Once
-  // we know the maximum size that a month can be in the horizontally-scrolling calendar, we can
-  // adjust this constraint's constant so that it perfectly fits each month.
-  lazy var horizontalCalendarViewHeightConstraint = calendarView.heightAnchor.constraint(
-    equalToConstant: 0)
-
   override func viewDidLoad() {
     super.viewDidLoad()
 
@@ -63,30 +57,34 @@ class DemoViewController: UIViewController {
         calendarView.trailingAnchor.constraint(
           lessThanOrEqualTo: view.layoutMarginsGuide.trailingAnchor),
         calendarView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-        calendarView.widthAnchor.constraint(lessThanOrEqualToConstant: 375)
+        calendarView.widthAnchor.constraint(lessThanOrEqualToConstant: 375),
+        calendarView.widthAnchor.constraint(equalToConstant: 375).prioritize(at: .defaultLow),
       ])
     case .horizontal:
-      calendarView.maximumMonthHeightDidChange = { [weak self] maximumMonthHeight in
-        guard let self = self else { return }
-        let heightConstant = maximumMonthHeight +
-          self.calendarView.layoutMargins.top +
-          self.calendarView.layoutMargins.bottom
-        self.horizontalCalendarViewHeightConstraint.constant = heightConstant
-      }
-
       NSLayoutConstraint.activate([
         calendarView.centerYAnchor.constraint(equalTo: view.layoutMarginsGuide.centerYAnchor),
         calendarView.leadingAnchor.constraint(greaterThanOrEqualTo: view.leadingAnchor),
         calendarView.trailingAnchor.constraint(lessThanOrEqualTo: view.trailingAnchor),
         calendarView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
         calendarView.widthAnchor.constraint(lessThanOrEqualToConstant: 375),
-        horizontalCalendarViewHeightConstraint,
+        calendarView.widthAnchor.constraint(equalToConstant: 375).prioritize(at: .defaultLow),
       ])
     }
   }
 
   func makeContent() -> CalendarViewContent {
     fatalError("Must be implemented by a subclass.")
+  }
+
+}
+
+// MARK: NSLayoutConstraint + Priority Helper
+
+extension NSLayoutConstraint {
+
+  fileprivate func prioritize(at priority: UILayoutPriority) -> NSLayoutConstraint {
+    self.priority = priority
+    return self
   }
 
 }

--- a/HorizonCalendar.podspec
+++ b/HorizonCalendar.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name = "HorizonCalendar"
-  spec.version = "1.10.1"
+  spec.version = "1.11.0"
   spec.license = "Apache License, Version 2.0"
   spec.summary = "A declarative, performant, calendar UI component that supports use cases ranging from simple date pickers to fully-featured calendar apps."
 

--- a/HorizonCalendar.xcodeproj/project.pbxproj
+++ b/HorizonCalendar.xcodeproj/project.pbxproj
@@ -610,7 +610,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.10.1;
+				MARKETING_VERSION = 1.11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.HorizonCalendar;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -644,7 +644,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.10.1;
+				MARKETING_VERSION = 1.11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.HorizonCalendar;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/HorizonCalendar.xcodeproj/project.pbxproj
+++ b/HorizonCalendar.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		932E24142558DF6E001648D2 /* HorizontalMonthsLayoutOptionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 932E24132558DF6E001648D2 /* HorizontalMonthsLayoutOptionsTests.swift */; };
 		932FC00E26ED5191005E39A6 /* DayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 932FC00D26ED5191005E39A6 /* DayView.swift */; };
 		932FC01126ED6C49005E39A6 /* UIEdgeInsets+Hashable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 932FC01026ED6C49005E39A6 /* UIEdgeInsets+Hashable.swift */; };
+		933992992736562D00C80380 /* DoubleLayoutPassHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 933992982736562C00C80380 /* DoubleLayoutPassHelpers.swift */; };
 		938DA40F24BEEB1A008A3B47 /* CalendarItemViewRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 938DA40E24BEEB1A008A3B47 /* CalendarItemViewRepresentable.swift */; };
 		938DA41124BEFFCB008A3B47 /* AnyCalendarItemModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 938DA41024BEFFCB008A3B47 /* AnyCalendarItemModel.swift */; };
 		9391E66926293A3F00A79C6E /* RenderInContextObservingLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9391E66826293A3F00A79C6E /* RenderInContextObservingLayer.swift */; };
@@ -85,6 +86,7 @@
 		932E24132558DF6E001648D2 /* HorizontalMonthsLayoutOptionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HorizontalMonthsLayoutOptionsTests.swift; sourceTree = "<group>"; };
 		932FC00D26ED5191005E39A6 /* DayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DayView.swift; sourceTree = "<group>"; };
 		932FC01026ED6C49005E39A6 /* UIEdgeInsets+Hashable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIEdgeInsets+Hashable.swift"; sourceTree = "<group>"; };
+		933992982736562C00C80380 /* DoubleLayoutPassHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DoubleLayoutPassHelpers.swift; sourceTree = "<group>"; };
 		938DA40E24BEEB1A008A3B47 /* CalendarItemViewRepresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarItemViewRepresentable.swift; sourceTree = "<group>"; };
 		938DA41024BEFFCB008A3B47 /* AnyCalendarItemModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyCalendarItemModel.swift; sourceTree = "<group>"; };
 		9391E66826293A3F00A79C6E /* RenderInContextObservingLayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenderInContextObservingLayer.swift; sourceTree = "<group>"; };
@@ -269,6 +271,7 @@
 				939E692124837E0300A8BCC7 /* ScrollToItemContext.swift */,
 				939E691C24837E0200A8BCC7 /* VisibleCalendarItem.swift */,
 				939E691A24837E0200A8BCC7 /* VisibleItemsProvider.swift */,
+				933992982736562C00C80380 /* DoubleLayoutPassHelpers.swift */,
 			);
 			path = Internal;
 			sourceTree = "<group>";
@@ -421,6 +424,7 @@
 				939E693A24837E8700A8BCC7 /* CalendarViewContent.swift in Sources */,
 				939E692F24837E0300A8BCC7 /* OffScreenCalendarItemAccessibilityElement.swift in Sources */,
 				939E694624847BA300A8BCC7 /* DayOfWeekPosition.swift in Sources */,
+				933992992736562D00C80380 /* DoubleLayoutPassHelpers.swift in Sources */,
 				939E694024846A8C00A8BCC7 /* Day.swift in Sources */,
 				939E692424837E0300A8BCC7 /* CalendarView.swift in Sources */,
 				939E693924837E8700A8BCC7 /* MonthsLayout.swift in Sources */,

--- a/Sources/Internal/DoubleLayoutPassHelpers.swift
+++ b/Sources/Internal/DoubleLayoutPassHelpers.swift
@@ -99,6 +99,7 @@ final class DoubleLayoutPassSizingLabel: UILabel {
     numberOfLines = 0
     isUserInteractionEnabled = false
     isAccessibilityElement = false
+    isHidden = true
   }
 
   @available(*, unavailable)
@@ -118,14 +119,6 @@ final class DoubleLayoutPassSizingLabel: UILabel {
     } else {
       return provider.intrinsicContentSize(forHorizontallyInsetWidth: preferredMaxLayoutWidth)
     }
-  }
-
-  override func draw(_: CGRect) {
-    // Do nothing, this view doesn't render any visual content.
-  }
-
-  override func drawText(in _: CGRect) {
-    // Do nothing, this view doesn't render any visual content.
   }
 
   // MARK: Private

--- a/Sources/Internal/DoubleLayoutPassHelpers.swift
+++ b/Sources/Internal/DoubleLayoutPassHelpers.swift
@@ -1,0 +1,136 @@
+// Created by Bryan Keller on 11/5/21.
+// Copyright © 2021 Airbnb Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import UIKit
+
+// MARK: CalendarView + Double Layout Pass Helpers
+
+/// `CalendarView`'s `intrinsicContentSize.height` should be equal to the maximum vertical space that a month can
+/// occupy. This month height calculation is dependent on the available width. For a horizontally-scrolling calendar, the available width for
+/// a month is dependent on the `bounds.width`, the `interMonthSpacing`, and the `maximumFullyVisibleMonths`. For
+/// a vertically-scrolling calendar, the available width for a month is dependent on the `bounds.width` and any horizontal layout
+/// margins.
+///
+/// UIKit does not provide custom views with a final width before calling `intrinsicContentSize`, making it difficult to do
+/// width-dependent height calculations in time for the Auto Layout engine's layout computations. When embedding such a view in a
+/// `UICollectionViewCell`  or `UITableViewCell`, self-sizing will not work correctly due to the view not having enough
+/// information to return an accurate `intrinsicContentSize`. None of this is terribly surprising, since the documentation for
+/// `intrinsicContentSize` specifically says "...intrinsic size must be independent of the content frame,
+/// because there’s no way to dynamically communicate a changed width to the layout system based on a changed height, for
+/// example."
+///
+/// There is one exception to this rule: `UILabel`. When `-[UILabel setNumberOfLines:]` is called with `0` as the number of
+/// lines, the private method `-[UIView _needsDoubleUpdateConstraintPass]` will return `true`. UIKit will then invoke
+/// `-[UILabel intrinsicContentSize]` multiple times with the most up-to-date `preferredMaxLayoutWidth`, enabling
+/// the label to size correctly.
+///
+/// `CalendarView` can leverage `UILabel`'s double layout pass behavior by calling into this extension. Under the hood, a sizing
+/// `UILabel` is used to get a second layout pass, giving `CalendarView` a chance to size itself knowing its final width.
+
+extension CalendarView {
+
+  func installDoubleLayoutPassSizingLabel() {
+    doubleLayoutPassSizingLabel.removeFromSuperview()
+    addSubview(doubleLayoutPassSizingLabel)
+    subviews.first.map(doubleLayoutPassSizingLabel.sendSubviewToBack(_:))
+
+    doubleLayoutPassSizingLabel.translatesAutoresizingMaskIntoConstraints = false
+    NSLayoutConstraint.activate([
+      doubleLayoutPassSizingLabel.leadingAnchor.constraint(
+        equalTo: layoutMarginsGuide.leadingAnchor),
+      doubleLayoutPassSizingLabel.trailingAnchor.constraint(
+        equalTo: layoutMarginsGuide.trailingAnchor),
+      doubleLayoutPassSizingLabel.topAnchor.constraint(equalTo: layoutMarginsGuide.topAnchor),
+      doubleLayoutPassSizingLabel.bottomAnchor.constraint(equalTo: layoutMarginsGuide.bottomAnchor),
+    ])
+  }
+
+  public override func invalidateIntrinsicContentSize() {
+    doubleLayoutPassSizingLabel.invalidateIntrinsicContentSize()
+  }
+
+  public override func setContentHuggingPriority(
+    _ priority: UILayoutPriority,
+    for axis: NSLayoutConstraint.Axis)
+  {
+    doubleLayoutPassSizingLabel.setContentHuggingPriority(priority, for: axis)
+  }
+
+  public override func setContentCompressionResistancePriority(
+    _ priority: UILayoutPriority,
+    for axis: NSLayoutConstraint.Axis)
+  {
+    doubleLayoutPassSizingLabel.setContentCompressionResistancePriority(priority, for: axis)
+  }
+
+}
+
+// MARK: - WidthDependentIntrinsicContentHeightProviding
+
+protocol WidthDependentIntrinsicContentHeightProviding: CalendarView {
+
+  func intrinsicContentSize(forHorizontallyInsetWidth width: CGFloat) -> CGSize
+
+}
+
+// MARK: - DoubleLayoutPassSizingLabel
+
+final class DoubleLayoutPassSizingLabel: UILabel {
+
+  // MARK: Lifecycle
+
+  init(provider: WidthDependentIntrinsicContentHeightProviding) {
+    self.provider = provider
+
+    super.init(frame: .zero)
+
+    numberOfLines = 0
+    isUserInteractionEnabled = false
+    isAccessibilityElement = false
+  }
+
+  @available(*, unavailable)
+  required init?(coder _: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  // MARK: Internal
+
+  override var intrinsicContentSize: CGSize {
+    guard let provider = provider else {
+      preconditionFailure(
+        "The sizing label's `provider` should not be `nil` for the duration of the its life")
+    }
+    if preferredMaxLayoutWidth == 0 {
+      return super.intrinsicContentSize
+    } else {
+      return provider.intrinsicContentSize(forHorizontallyInsetWidth: preferredMaxLayoutWidth)
+    }
+  }
+
+  override func draw(_: CGRect) {
+    // Do nothing, this view doesn't render any visual content.
+  }
+
+  override func drawText(in _: CGRect) {
+    // Do nothing, this view doesn't render any visual content.
+  }
+
+  // MARK: Private
+
+  private weak var provider: WidthDependentIntrinsicContentHeightProviding?
+
+}
+

--- a/Sources/Internal/FrameProvider.swift
+++ b/Sources/Internal/FrameProvider.swift
@@ -60,6 +60,15 @@ final class FrameProvider {
   let scale: CGFloat
   let daySize: CGSize
 
+  var maxMonthHeight: CGFloat {
+    let maxNumberOfWeekRowsPerMonth = 6
+    return monthHeaderHeight +
+      content.monthDayInsets.top +
+      heightOfDaysOfTheWeekRowInMonth() +
+      heightOfDayContent(forNumberOfWeekRows: maxNumberOfWeekRowsPerMonth) +
+      content.monthDayInsets.bottom
+  }
+
   // MARK: Month locations
 
   func originOfMonth(containing layoutItem: LayoutItem) -> CGPoint {
@@ -247,7 +256,7 @@ final class FrameProvider {
 
   /// Returns translated item frames for the specified scroll offset and scroll position. Note that the returned frames may not be at valid
   /// resting positions. For example, someone could try to scroll the last day in the calendar to be at a vertically-centered scroll
-  /// position, which would cause the calendar to be laid out in an overscrolled position. The `VisibleItemsProvider` will detect
+  /// position, which would cause the calendar to be laid out in an over-scrolled position. The `VisibleItemsProvider` will detect
   /// this scenario and adjust the frame so it's at a valid resting position.
   func frameOfItem(
     withOriginalFrame originalFrame: CGRect,
@@ -322,25 +331,6 @@ final class FrameProvider {
         Calendar metrics and size resulted in a negative-or-zero size of \(daySize.width) points for
         each day. If ignored, this will cause very odd / incorrect layouts.
       """)
-
-    if case .horizontal = monthsLayout {
-      let maxNumberOfWeekRowsPerMonth = 6
-
-      let availableHeight = size.height -
-        monthHeaderHeight -
-        content.monthDayInsets.top -
-        heightOfDaysOfTheWeekRowInMonth() -
-        heightOfDayContent(forNumberOfWeekRows: maxNumberOfWeekRowsPerMonth) -
-        content.monthDayInsets.bottom
-
-      assert(
-        availableHeight > 0,
-        """
-          Calendar metrics and size resulted in a negative-or-zero amount of remaining height
-          (\(availableHeight) points) after allocating room for calendar elements. If ignored, this
-          will cause very odd / incorrect layouts.
-        """)
-    }
   }
 
   private func minXOfItem(

--- a/Sources/Internal/ScrollMetricsMutator.swift
+++ b/Sources/Internal/ScrollMetricsMutator.swift
@@ -105,7 +105,7 @@ enum ScrollAxis {
 
 // MARK: - ScrollMetricsProvider
 
-protocol ScrollMetricsProvider: class {
+protocol ScrollMetricsProvider: AnyObject {
 
   func size(for scrollAxis: ScrollAxis) -> CGFloat
   func setSize(to size: CGFloat, for scrollAxis: ScrollAxis)

--- a/Sources/Internal/VisibleItemsProvider.swift
+++ b/Sources/Internal/VisibleItemsProvider.swift
@@ -250,7 +250,8 @@ final class VisibleItemsProvider {
       framesForVisibleDays: framesForVisibleDays,
       contentStartBoundary: contentStartBoundary,
       contentEndBoundary: contentEndBoundary,
-      heightOfPinnedContent: heightOfPinnedContent)
+      heightOfPinnedContent: heightOfPinnedContent,
+      maxMonthHeight: frameProvider.maxMonthHeight)
   }
 
   func visibleItemsForAccessibilityElements(
@@ -904,7 +905,7 @@ final class VisibleItemsProvider {
   }
 
   /// This function takes a proposed frame for a target item toward which we're programmatically scrolling, and adjusts it so that it's a
-  /// valid frame when the calendar is at rest / not being overscrolled.
+  /// valid frame when the calendar is at rest / not being over-scrolled.
   ///
   /// A concrete example of when we'd need this correction is when we scroll to the first visible month with a scroll position of
   /// `.centered` - the proposed frame would position the month in the middle of the bounds, even though that is not a valid resting
@@ -926,7 +927,7 @@ final class VisibleItemsProvider {
 
     // Look backwards for boundary-determining months
     while
-      bounds.contains(currentMonthFrame.origin.alignedToPixels(forScreenWithScale: scale)),
+      bounds.intersects(currentMonthFrame.alignedToPixels(forScreenWithScale: scale)),
       contentStartBoundary == nil
     {
       determineContentBoundariesIfNeeded(
@@ -951,9 +952,7 @@ final class VisibleItemsProvider {
     currentMonth = month
     currentMonthFrame = monthFrame
     while
-      bounds.contains(
-        CGPoint(x: currentMonthFrame.maxX - 1, y: currentMonthFrame.maxY - 1)
-          .alignedToPixels(forScreenWithScale: scale)),
+      bounds.intersects(currentMonthFrame.alignedToPixels(forScreenWithScale: scale)),
       contentEndBoundary == nil
     {
       determineContentBoundariesIfNeeded(
@@ -1022,6 +1021,7 @@ struct VisibleItemsDetails {
   let contentStartBoundary: CGFloat?
   let contentEndBoundary: CGFloat?
   let heightOfPinnedContent: CGFloat
+  let maxMonthHeight: CGFloat
 }
 
 // MARK: - DayRangeLayoutContext

--- a/Tests/FrameProviderTests.swift
+++ b/Tests/FrameProviderTests.swift
@@ -85,6 +85,26 @@ final class FrameProviderTests: XCTestCase {
       monthHeaderHeight: monthHeaderHeight)
   }
 
+  func testMaxMonthHeight() {
+    let maxHeight1 = verticalFrameProvider.maxMonthHeight.alignedToPixel(forScreenWithScale: 3)
+    let expectedMaxHeight1 = CGFloat(424).alignedToPixel(forScreenWithScale: 3)
+    XCTAssert(maxHeight1 == expectedMaxHeight1, "Incorrect max month height.")
+
+    let maxHeight2 = verticalPinnedDaysOfWeekFrameProvider.maxMonthHeight
+      .alignedToPixel(forScreenWithScale: 3)
+    let expectedMaxHeight2 = CGFloat(369.1428571428571).alignedToPixel(forScreenWithScale: 3)
+    XCTAssert(maxHeight2 == expectedMaxHeight2, "Incorrect max month height.")
+
+    let maxHeight3 = verticalPartialMonthFrameProvider.maxMonthHeight
+      .alignedToPixel(forScreenWithScale: 3)
+    let expectedMaxHeight3 = CGFloat(424).alignedToPixel(forScreenWithScale: 3)
+    XCTAssert(maxHeight3 == expectedMaxHeight3, "Incorrect max month height.")
+
+    let maxHeight4 = horizontalFrameProvider.maxMonthHeight.alignedToPixel(forScreenWithScale: 3)
+    let expectedMaxHeight4 = CGFloat(404.0).alignedToPixel(forScreenWithScale: 3)
+    XCTAssert(maxHeight4 == expectedMaxHeight4, "Incorrect max month height.")
+  }
+
   func testDaySize() {
     let size1 = verticalFrameProvider.daySize.alignedToPixels(forScreenWithScale: 3)
     let expectedSize1 = CGSize(width: 34.857142857142854, height: 34.857142857142854)


### PR DESCRIPTION
## Details

#### Background

The PR makes it easier to implement horizontally-scrolling calendars. The really annoying issue before was that `HorizonCalendar` would assert if the available height of the calendar was too small to fit the calendar's contents. In practice, this was a pretty easy scenario to hit. Consider the following:

1. Constrain a `CalendarView` instance to have a height of 200pt and a width of 375pt (wider than it is tall)
2. Use `MonthsLayout.horizontal` with `maximumFullyVisibleMonths` set to 1.
3. Assert :(

The problem is that the size of each day in a horizontally-scrolling calendar is determined by looking at the available width (375pt) and the `maximumFullyVisibleMonths` (1). If we only want to display 1 month in the available width, then that's going to result in some pretty large day items, which means each row of days in a month is going to be pretty tall (day views are 1:1 aspect ratio so big width = big height).

Here's what that scenario looks like (if I ignore the assert):

<img src="https://user-images.githubusercontent.com/746571/140034226-8908fa77-61cd-44a3-b1dc-188fa22ae219.png" width="375">

As we can see, a large portion of the month is getting clipped. What's worse is that API consumers have no way of knowing what to set their `CalendarView`'s `frame.height` to in order to prevent clipping / the assert.

#### Solution

This PR makes 2 improvements:
- Get rid of the pesky assert, and just let the calendar's content get clipped
- Use a sizing `UILabel` to take advantage of `-[UIView _needsDoubleUpdateConstraintPass]` without actually calling that private function ourselves. We know this method works since we use it in the Airbnb app. The result is that `intrinsicContentSize` is invoked multiple times, allowing CalendarView to return an `intrinsicContentSize` with an intrinsic height that depends on a known width.

| Vertical Intrinsic Height | Horizontal Intrinsic Height 1 | Horizontal Intrinsic Height 2 |
| ---- | ---- | ---- |
| ![Simulator Screen Recording - iPhone 12 Pro - 2021-11-06 at 01 14 26](https://user-images.githubusercontent.com/746571/140603744-e28c6a63-98e7-4757-9e1c-85adbf5dfb6e.gif) | ![Simulator Screen Recording - iPhone 12 Pro - 2021-11-06 at 01 15 34](https://user-images.githubusercontent.com/746571/140603748-7b48f5e3-0966-4bfa-a3d3-9435c88cd19c.gif) | ![Simulator Screen Recording - iPhone 12 Pro - 2021-11-06 at 01 16 23](https://user-images.githubusercontent.com/746571/140603758-f4eede7d-ef4b-4e70-8a20-7786aea1e9c1.gif) |


## Related Issue

https://github.com/airbnb/HorizonCalendar/issues/88
https://github.com/airbnb/HorizonCalendar/issues/110
https://github.com/airbnb/HorizonCalendar/issues/125

## Motivation and Context

Several people have struggled with this. I think we'd struggle with it too if we used horizontal-scrolling calendars anywhere in the Airbnb app. Anyways, I've put off a fix for this long enough. This should unblock people!

## How Has This Been Tested

Tested iPhone and iPad, added unit tests

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
