### PR TITLE
Add support for rectangular days

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -13,12 +13,12 @@ jobs:
 
     strategy:
       matrix:
-        destination: ['platform=iOS Simulator,OS=11.0,name=iPhone 8', 'platform=iOS Simulator,OS=14.4,name=iPhone 12']
+        destination: ['platform=iOS Simulator,OS=11.0,name=iPhone 8', 'platform=iOS Simulator,OS=15.0,name=iPhone 12']
 
     steps:
     - uses: actions/checkout@v2
     - name: Build
       run: xcodebuild clean build -scheme HorizonCalendar
     - name: Run tests
-      run: xcodebuild clean test -project HorizonCalendar.xcodeproj -scheme HorizonCalendar -destination "name=iPhone 8,OS=14.4"
+      run: xcodebuild clean test -project HorizonCalendar.xcodeproj -scheme HorizonCalendar -destination "name=iPhone 8,OS=15.0"
 

--- a/HorizonCalendar.podspec
+++ b/HorizonCalendar.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name = "HorizonCalendar"
-  spec.version = "1.11.0"
+  spec.version = "1.12.0"
   spec.license = "Apache License, Version 2.0"
   spec.summary = "A declarative, performant, calendar UI component that supports use cases ranging from simple date pickers to fully-featured calendar apps."
 

--- a/HorizonCalendar.xcodeproj/project.pbxproj
+++ b/HorizonCalendar.xcodeproj/project.pbxproj
@@ -614,7 +614,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.11.0;
+				MARKETING_VERSION = 1.12.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.HorizonCalendar;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -648,7 +648,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.11.0;
+				MARKETING_VERSION = 1.12.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.HorizonCalendar;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Sources/Internal/FrameProvider.swift
+++ b/Sources/Internal/FrameProvider.swift
@@ -47,8 +47,9 @@ final class FrameProvider {
     let insetWidth = monthWidth - content.monthDayInsets.left - content.monthDayInsets.right
     let numberOfDaysPerWeek = CGFloat(7)
     let availableWidth = insetWidth - (content.horizontalDayMargin * (numberOfDaysPerWeek - 1))
-    let points = availableWidth / numberOfDaysPerWeek
-    daySize = CGSize(width: points, height: points)
+    let width = availableWidth / numberOfDaysPerWeek
+    let height = width * content.dayAspectRatio
+    daySize = CGSize(width: width, height: height)
 
     validateCalendarMetrics(size: size)
   }
@@ -189,7 +190,7 @@ final class FrameProvider {
     let origin: CGPoint
     if distanceFromAdjacentDay < 0 {
       let proposedX = adjacentDayFrame.minX - content.horizontalDayMargin - daySize.width
-      if proposedX > minX || proposedX.isEqual(to: minX, threshhold: 1 / scale) {
+      if proposedX > minX || proposedX.isEqual(to: minX, threshold: 1 / scale) {
         origin = CGPoint(x: proposedX, y: adjacentDayFrame.minY)
       } else {
         origin = CGPoint(
@@ -198,7 +199,7 @@ final class FrameProvider {
       }
     } else {
       let proposedX = adjacentDayFrame.maxX + content.horizontalDayMargin
-      if proposedX < maxX || proposedX.isEqual(to: maxX, threshhold: 1 / scale) {
+      if proposedX < maxX || proposedX.isEqual(to: maxX, threshold: 1 / scale) {
         origin = CGPoint(x: proposedX, y: adjacentDayFrame.minY)
       } else {
         origin = CGPoint(x: minX, y: adjacentDayFrame.maxY + content.verticalDayMargin)

--- a/Sources/Internal/ScreenPixelAlignment.swift
+++ b/Sources/Internal/ScreenPixelAlignment.swift
@@ -24,8 +24,8 @@ extension CGFloat {
   
   /// Tests `self` for approximate equality using the threshold value. For example, 1.48 equals 1.52 if the threshold is 0.05.
   /// `threshold` will be treated as a postive value by taking its absolute value.
-  func isEqual(to rhs: CGFloat, threshhold: CGFloat) -> Bool {
-    abs(self - rhs) <= abs(threshhold)
+  func isEqual(to rhs: CGFloat, threshold: CGFloat) -> Bool {
+    abs(self - rhs) <= abs(threshold)
   }
 
 }

--- a/Sources/Public/CalendarViewContent.swift
+++ b/Sources/Public/CalendarViewContent.swift
@@ -116,6 +116,26 @@ public final class CalendarViewContent {
     return self
   }
 
+  /// Configures the aspect ratio of each day.
+  ///
+  /// Values less than 1 will result in rectangular days that are wider than they are tall. Values
+  /// greater than 1 will result in rectangular days that are taller than they are wide. The default value is `1`, which results in square
+  /// views with the same width and height.
+  ///
+  /// - Parameters:
+  ///   - dayAspectRatio: The aspect ratio of each day view.
+  /// - Returns: A mutated `CalendarViewContent` instance with a new day aspect ratio value.
+  public func withDayAspectRatio(_ dayAspectRatio: CGFloat) -> CalendarViewContent {
+    let validAspectRatioRange: ClosedRange<CGFloat> = 0.5...3
+    assert(
+      validAspectRatioRange.contains(dayAspectRatio),
+      "A day aspect ratio of \(dayAspectRatio) will likely cause strange calendar layouts. Only values between \(validAspectRatioRange.lowerBound) and \(validAspectRatioRange.upperBound) should be used.")
+    self.dayAspectRatio = min(
+      max(dayAspectRatio, validAspectRatioRange.lowerBound),
+      validAspectRatioRange.upperBound)
+    return self
+  }
+
   /// Configures the amount of spacing, in points, between months. The default value is `0`.
   ///
   /// - Parameters:
@@ -319,6 +339,7 @@ public final class CalendarViewContent {
 
   // TODO(BK): Remove; the `withBackgroundColor` function is deprecated.
   private(set) var backgroundColor: UIColor?
+  private(set) var dayAspectRatio: CGFloat = 1
   private(set) var interMonthSpacing: CGFloat = 0
   private(set) var monthDayInsets: UIEdgeInsets = .zero
   private(set) var verticalDayMargin: CGFloat = 0

--- a/Sources/Public/Item Views/DayView.swift
+++ b/Sources/Public/Item Views/DayView.swift
@@ -94,10 +94,10 @@ public final class DayView: UIView {
     let path: CGPath
     switch invariantViewProperties.shape {
     case .circle:
-      path = UIBezierPath(
-        ovalIn: CGRect(
-          origin: CGPoint(x: edgeInsets.leading, y: edgeInsets.top),
-          size: insetBounds.size)).cgPath
+      let radius = min(insetBounds.size.width, insetBounds.size.height) / 2
+      let origin = CGPoint(x: insetBounds.midX - radius, y: insetBounds.midY - radius)
+      let size = CGSize(width: radius * 2, height: radius * 2)
+      path = UIBezierPath(ovalIn: CGRect(origin: origin, size: size)).cgPath
 
     case .rectangle(let cornerRadius):
       path = UIBezierPath(roundedRect: insetBounds, cornerRadius: cornerRadius).cgPath

--- a/Tests/FrameProviderTests.swift
+++ b/Tests/FrameProviderTests.swift
@@ -83,6 +83,20 @@ final class FrameProviderTests: XCTestCase {
       layoutMargins: .zero,
       scale: 3,
       monthHeaderHeight: monthHeaderHeight)
+    rectangularDayFrameProvider = FrameProvider(
+      content: CalendarViewContent(
+        calendar: calendar,
+        visibleDateRange: Date.distantPast...Date.distantFuture,
+        monthsLayout: .vertical(options: VerticalMonthsLayoutOptions()))
+        .withMonthDayInsets(UIEdgeInsets(top: 5, left: 8, bottom: 5, right: 8))
+        .withDayAspectRatio(1.5)
+        .withInterMonthSpacing(20)
+        .withVerticalDayMargin(20)
+        .withHorizontalDayMargin(10),
+      size: size,
+      layoutMargins: .zero,
+      scale: 3,
+      monthHeaderHeight: monthHeaderHeight)
   }
 
   func testMaxMonthHeight() {
@@ -119,6 +133,11 @@ final class FrameProviderTests: XCTestCase {
     let size3 = horizontalFrameProvider.daySize.alignedToPixels(forScreenWithScale: 3)
     let expectedSize3 = CGSize(width: 32, height: 32).alignedToPixels(forScreenWithScale: 3)
     XCTAssert(size3 == expectedSize3, "Incorrect day size.")
+
+    let size4 = rectangularDayFrameProvider.daySize.alignedToPixels(forScreenWithScale: 3)
+    let expectedSize4 = CGSize(width: 34.857142857142854, height: 52.28571428571428)
+      .alignedToPixels(forScreenWithScale: 3)
+    XCTAssert(size4 == expectedSize4, "Incorrect day size.")
   }
 
   // MARK: Test initial month calculations
@@ -366,6 +385,18 @@ final class FrameProviderTests: XCTestCase {
     let expectedFrame3 = CGRect(x: 460, y: 55, width: 32, height: 32)
       .alignedToPixels(forScreenWithScale: 3)
     XCTAssert(frame3 == expectedFrame3, "Incorrect frame for day of week.")
+
+    let frame4 = rectangularDayFrameProvider.frameOfDayOfWeek(
+      at: .fifth,
+      inMonthWithOrigin: CGPoint(x: 0, y: 200))
+      .alignedToPixels(forScreenWithScale: 3)
+    let expectedFrame4 = CGRect(
+      x: 187.42857142857142,
+      y: 255,
+      width: 34.857142857142854,
+      height: 52.28571428571428)
+      .alignedToPixels(forScreenWithScale: 3)
+    XCTAssert(frame4 == expectedFrame4, "Incorrect frame for day of week.")
   }
 
   func testDayFrameInMonth() {
@@ -412,6 +443,18 @@ final class FrameProviderTests: XCTestCase {
     let expectedFrame4 = CGRect(x: 476, y: 315, width: 32, height: 32)
       .alignedToPixels(forScreenWithScale: 3)
     XCTAssert(frame4 == expectedFrame4, "Incorrect frame for day of week.")
+
+    let frame5 = rectangularDayFrameProvider.frameOfDay(
+      Day(month: Month(era: 1, year: 2020, month: 04, isInGregorianCalendar: true), day: 20),
+      inMonthWithOrigin: CGPoint(x: 0, y: 69))
+      .alignedToPixels(forScreenWithScale: 3)
+    let expectedFrame5 = CGRect(
+      x: 52.857142857142854,
+      y: 413.1428571428571,
+      width: 34.857142857142854,
+      height: 52.28571428571428)
+      .alignedToPixels(forScreenWithScale: 3)
+    XCTAssert(frame5 == expectedFrame5, "Incorrect frame for day.")
   }
 
   func testAdjacentDayFrame() {
@@ -565,6 +608,18 @@ final class FrameProviderTests: XCTestCase {
       height: 34.857142857142854)
       .alignedToPixels(forScreenWithScale: 3)
     XCTAssert(frame1 == expectedFrame1, "Incorrect frame for pinned day of week.")
+
+    let frame2 = rectangularDayFrameProvider.frameOfPinnedDayOfWeek(
+      at: .second,
+      yContentOffset: 275)
+      .alignedToPixels(forScreenWithScale: 3)
+    let expectedFrame2 = CGRect(
+      x: 52.857142857142854,
+      y: 275,
+      width: 34.857142857142854,
+      height: 52.28571428571428)
+      .alignedToPixels(forScreenWithScale: 3)
+    XCTAssert(frame2 == expectedFrame2, "Incorrect frame for pinned day of week.")
   }
 
   func testPinnedDaysOfWeekBackgroundFrame() {
@@ -574,26 +629,47 @@ final class FrameProviderTests: XCTestCase {
     let expectedFrame1 = CGRect(x: 0, y: 140, width: 320, height: 34.857142857142854)
       .alignedToPixels(forScreenWithScale: 3)
     XCTAssert(frame1 == expectedFrame1, "Incorrect frame for pinned days-of-week row background.")
+
+    let frame2 = rectangularDayFrameProvider.frameOfPinnedDaysOfWeekRowBackground(
+      yContentOffset: 140)
+      .alignedToPixels(forScreenWithScale: 3)
+    let expectedFrame2 = CGRect(x: 0, y: 140, width: 320, height: 52.28571428571428)
+      .alignedToPixels(forScreenWithScale: 3)
+    XCTAssert(frame2 == expectedFrame2, "Incorrect frame for pinned days-of-week row background.")
   }
 
   func testPinnedDaysOfWeekSeparatorFrame() {
     let frame1 = verticalPinnedDaysOfWeekFrameProvider.frameOfPinnedDaysOfWeekRowSeparator(
       yContentOffset: 120,
       separatorHeight: 2)
+      .alignedToPixels(forScreenWithScale: 3)
     let expectedFrame1 = CGRect(x: 0, y: 152.85714285714286, width: 320, height: 2)
+      .alignedToPixels(forScreenWithScale: 3)
     XCTAssert(frame1 == expectedFrame1, "Incorrect frame for pinned day-of-week row separator.")
 
     let frame2 = verticalFrameProvider.frameOfDaysOfWeekRowSeparator(
       inMonthWithOrigin: CGPoint(x: 0, y: 120),
       separatorHeight: 1)
+      .alignedToPixels(forScreenWithScale: 3)
     let expectedFrame2 = CGRect(x: 0, y: 208.85714285714286, width: 320, height: 1)
+      .alignedToPixels(forScreenWithScale: 3)
     XCTAssert(frame2 == expectedFrame2, "Incorrect frame for day-of-week row separator.")
 
     let frame3 = horizontalFrameProvider.frameOfDaysOfWeekRowSeparator(
       inMonthWithOrigin: CGPoint(x: 421, y: 0),
       separatorHeight: 10)
+      .alignedToPixels(forScreenWithScale: 3)
     let expectedFrame3 = CGRect(x: 421, y: 77, width: 300, height: 10)
+      .alignedToPixels(forScreenWithScale: 3)
     XCTAssert(frame3 == expectedFrame3, "Incorrect frame for day-of-week row separator.")
+
+    let frame4 = rectangularDayFrameProvider.frameOfDaysOfWeekRowSeparator(
+      inMonthWithOrigin: CGPoint(x: 0, y: 120),
+      separatorHeight: 3)
+      .alignedToPixels(forScreenWithScale: 3)
+    let expectedFrame4 = CGRect(x: 0, y: 224.28571428571428, width: 320, height: 3)
+      .alignedToPixels(forScreenWithScale: 3)
+    XCTAssert(frame4 == expectedFrame4, "Incorrect frame for day-of-week row separator.")
   }
 
   // MARK: Scroll-to-item Frame Calculations
@@ -716,6 +792,7 @@ final class FrameProviderTests: XCTestCase {
   private var verticalPinnedDaysOfWeekFrameProvider: FrameProvider!
   private var verticalPartialMonthFrameProvider: FrameProvider!
   private var horizontalFrameProvider: FrameProvider!
+  private var rectangularDayFrameProvider: FrameProvider!
 
 }
 

--- a/Tests/ScreenPixelAlignmentTests.swift
+++ b/Tests/ScreenPixelAlignmentTests.swift
@@ -125,17 +125,17 @@ final class ScreenPixelAlignmentTests: XCTestCase {
   // MARK: CGFloat Approximate Comparison Tests
   
   func testApproximateEquality() {
-    XCTAssert(CGFloat(1.48).isEqual(to: 1.52, threshhold: 0.05))
-    XCTAssert(!CGFloat(1.48).isEqual(to: 1.53, threshhold: 0.05))
+    XCTAssert(CGFloat(1.48).isEqual(to: 1.52, threshold: 0.05))
+    XCTAssert(!CGFloat(1.48).isEqual(to: 1.53, threshold: 0.05))
     
-    XCTAssert(CGFloat(1).isEqual(to: 10, threshhold: 9))
-    XCTAssert(!CGFloat(1).isEqual(to: 11, threshhold: 9))
+    XCTAssert(CGFloat(1).isEqual(to: 10, threshold: 9))
+    XCTAssert(!CGFloat(1).isEqual(to: 11, threshold: 9))
     
-    XCTAssert(CGFloat(1).isEqual(to: 10, threshhold: 9))
-    XCTAssert(!CGFloat(1).isEqual(to: 11, threshhold: 9))
+    XCTAssert(CGFloat(1).isEqual(to: 10, threshold: 9))
+    XCTAssert(!CGFloat(1).isEqual(to: 11, threshold: 9))
     
-    XCTAssert(CGFloat(1.333).isEqual(to: 1.666, threshhold: 1 / 3))
-    XCTAssert(!CGFloat(1.332).isEqual(to: 1.666, threshhold: 1 / 3))
+    XCTAssert(CGFloat(1.333).isEqual(to: 1.666, threshold: 1 / 3))
+    XCTAssert(!CGFloat(1.332).isEqual(to: 1.666, threshold: 1 / 3))
   }
 
 }


### PR DESCRIPTION
## Details

This PR adds support for rectangular day views. Prior to this change, all day views would be rendered as squares (aspect ration = 1). Now, people can specify other aspect ratios so that their day views can be tall or wide.

| Wide days | Tall days |
| ---- | ---- |
| ![Simulator Screen Shot - iPhone 13 Pro - 2021-12-21 at 21 59 51](https://user-images.githubusercontent.com/746571/147037814-9d66767b-f3f5-4b70-9b0e-b7058660e191.png) | ![Simulator Screen Shot - iPhone 13 Pro - 2021-12-21 at 22 00 34](https://user-images.githubusercontent.com/746571/147037845-384bb5c2-dc01-4902-9aa3-2e71118b0c1d.png) |

## Related Issue

N/A

## Motivation and Context

Might need this internally @ Airbnb.

## How Has This Been Tested

Tested in iOS simulator + unit tests.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
