### PR TITLE
Bk/prepare for api rename

### DIFF
--- a/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/DayRangeSelectionDemoViewController.swift
+++ b/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/DayRangeSelectionDemoViewController.swift
@@ -74,11 +74,11 @@ final class DayRangeSelectionDemoViewController: DemoViewController {
       visibleDateRange: startDate...endDate,
       monthsLayout: monthsLayout)
 
-      .withInterMonthSpacing(24)
-      .withVerticalDayMargin(8)
-      .withHorizontalDayMargin(8)
+      .interMonthSpacing(24)
+      .verticalDayMargin(8)
+      .horizontalDayMargin(8)
 
-      .withDayItemModelProvider { [calendar, dayDateFormatter] day in
+      .dayItemProvider { [calendar, dayDateFormatter] day in
         var invariantViewProperties = DayView.InvariantViewProperties.baseInteractive
 
         let isSelectedStyle: Bool
@@ -105,7 +105,7 @@ final class DayRangeSelectionDemoViewController: DemoViewController {
             accessibilityHint: nil))
       }
 
-      .withDayRangeItemModelProvider(for: dateRanges) { dayRangeLayoutContext in
+      .dayRangeItemProvider(for: dateRanges) { dayRangeLayoutContext in
         CalendarItemModel<DayRangeIndicatorView>(
           invariantViewProperties: .init(),
           viewModel: .init(

--- a/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/LargeDayRangeDemoViewController.swift
+++ b/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/LargeDayRangeDemoViewController.swift
@@ -54,7 +54,7 @@ final class LargeDayRangeDemoViewController: DemoViewController {
       calendar: calendar,
       visibleDateRange: startDate...endDate,
       monthsLayout: monthsLayout)
-      .withInterMonthSpacing(24)
+      .interMonthSpacing(24)
   }
 
   // MARK: Private

--- a/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/PartialMonthVisibilityDemoViewController.swift
+++ b/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/PartialMonthVisibilityDemoViewController.swift
@@ -39,11 +39,11 @@ final class PartialMonthVisibilityDemoViewController: DemoViewController {
       visibleDateRange: startDate...endDate,
       monthsLayout: monthsLayout)
 
-      .withInterMonthSpacing(24)
-      .withVerticalDayMargin(8)
-      .withHorizontalDayMargin(8)
+      .interMonthSpacing(24)
+      .verticalDayMargin(8)
+      .horizontalDayMargin(8)
 
-      .withDayItemModelProvider { [calendar, dayDateFormatter] day in
+      .dayItemProvider { [calendar, dayDateFormatter] day in
         var invariantViewProperties = DayView.InvariantViewProperties.baseInteractive
 
         let date = calendar.date(from: day.components)

--- a/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/ScrollToDayWithAnimationDemoViewController.swift
+++ b/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/ScrollToDayWithAnimationDemoViewController.swift
@@ -42,7 +42,7 @@ final class ScrollToDayWithAnimationDemoViewController: DemoViewController {
       calendar: calendar,
       visibleDateRange: startDate...endDate,
       monthsLayout: monthsLayout)
-      .withInterMonthSpacing(24)
+      .interMonthSpacing(24)
   }
 
 }

--- a/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/SelectedDayTooltipDemoViewController.swift
+++ b/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/SelectedDayTooltipDemoViewController.swift
@@ -58,9 +58,9 @@ final class SelectedDayTooltipDemoViewController: DemoViewController {
       visibleDateRange: startDate...endDate,
       monthsLayout: monthsLayout)
 
-      .withInterMonthSpacing(24)
+      .interMonthSpacing(24)
 
-      .withDayItemModelProvider { [calendar, dayDateFormatter] day in
+      .dayItemProvider { [calendar, dayDateFormatter] day in
         var invariantViewProperties = DayView.InvariantViewProperties.baseInteractive
 
         let date = calendar.date(from: day.components)
@@ -77,7 +77,7 @@ final class SelectedDayTooltipDemoViewController: DemoViewController {
             accessibilityHint: nil))
       }
 
-      .withOverlayItemModelProvider(for: overlaidItemLocations) { overlayLayoutContext in
+      .overlayItemProvider(for: overlaidItemLocations) { overlayLayoutContext in
         CalendarItemModel<TooltipView>(
           invariantViewProperties: .init(),
           viewModel: .init(

--- a/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/SingleDaySelectionDemoViewController.swift
+++ b/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/SingleDaySelectionDemoViewController.swift
@@ -62,11 +62,11 @@ final class SingleDaySelectionDemoViewController: DemoViewController {
       visibleDateRange: startDate...endDate,
       monthsLayout: monthsLayout)
 
-      .withInterMonthSpacing(24)
-      .withVerticalDayMargin(8)
-      .withHorizontalDayMargin(8)
+      .interMonthSpacing(24)
+      .verticalDayMargin(8)
+      .horizontalDayMargin(8)
 
-      .withDayItemModelProvider { [calendar, dayDateFormatter] day in
+      .dayItemProvider { [calendar, dayDateFormatter] day in
         var invariantViewProperties = DayView.InvariantViewProperties.baseInteractive
 
         let date = calendar.date(from: day.components)

--- a/HorizonCalendar.podspec
+++ b/HorizonCalendar.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name = "HorizonCalendar"
-  spec.version = "1.12.0"
+  spec.version = "1.13.0"
   spec.license = "Apache License, Version 2.0"
   spec.summary = "A declarative, performant, calendar UI component that supports use cases ranging from simple date pickers to fully-featured calendar apps."
 

--- a/HorizonCalendar.xcodeproj/project.pbxproj
+++ b/HorizonCalendar.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		93A0062C24F206BE00F667A3 /* ItemViewReuseManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93A0062B24F206BE00F667A3 /* ItemViewReuseManagerTests.swift */; };
 		93A361F4248332AE00E6544A /* ScreenPixelAlignment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93A361F3248332AE00E6544A /* ScreenPixelAlignment.swift */; };
 		93B6D99E24F0C6220027A60C /* InternalAnyCalendarItemModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93B6D99D24F0C6220027A60C /* InternalAnyCalendarItemModel.swift */; };
+		93D6789E2772EC1D004948E5 /* Deprecations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93D6789D2772EC1D004948E5 /* Deprecations.swift */; };
 		93E24A70249D915900B856F7 /* CONTRIBUTING.md in Resources */ = {isa = PBXBuildFile; fileRef = 93E24A56249D915900B856F7 /* CONTRIBUTING.md */; };
 		93E24A71249D915900B856F7 /* TECHNICAL_DETAILS.md in Resources */ = {isa = PBXBuildFile; fileRef = 93E24A57249D915900B856F7 /* TECHNICAL_DETAILS.md */; };
 		93FA64EC248CDD3E00A8B7B1 /* MonthHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93FA64EB248CDD3E00A8B7B1 /* MonthHelperTests.swift */; };
@@ -129,6 +130,7 @@
 		93A0062B24F206BE00F667A3 /* ItemViewReuseManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ItemViewReuseManagerTests.swift; sourceTree = "<group>"; };
 		93A361F3248332AE00E6544A /* ScreenPixelAlignment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScreenPixelAlignment.swift; sourceTree = "<group>"; };
 		93B6D99D24F0C6220027A60C /* InternalAnyCalendarItemModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InternalAnyCalendarItemModel.swift; sourceTree = "<group>"; };
+		93D6789D2772EC1D004948E5 /* Deprecations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Deprecations.swift; sourceTree = "<group>"; };
 		93E24A56249D915900B856F7 /* CONTRIBUTING.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = CONTRIBUTING.md; sourceTree = "<group>"; };
 		93E24A57249D915900B856F7 /* TECHNICAL_DETAILS.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = TECHNICAL_DETAILS.md; sourceTree = "<group>"; };
 		93FA64EB248CDD3E00A8B7B1 /* MonthHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonthHelperTests.swift; sourceTree = "<group>"; };
@@ -244,6 +246,7 @@
 				939E693F24846A8C00A8BCC7 /* Day.swift */,
 				939E694524847BA300A8BCC7 /* DayOfWeekPosition.swift */,
 				939E694124846EB400A8BCC7 /* DayRange.swift */,
+				93D6789D2772EC1D004948E5 /* Deprecations.swift */,
 				939E693D24846A6600A8BCC7 /* Month.swift */,
 				939E693424837E8700A8BCC7 /* MonthsLayout.swift */,
 				939E693B2483824600A8BCC7 /* MonthRange.swift */,
@@ -422,6 +425,7 @@
 				9321958226EEB6AB0001C7E9 /* DrawingConfig.swift in Sources */,
 				939E692D24837E0300A8BCC7 /* LayoutItem.swift in Sources */,
 				939E693A24837E8700A8BCC7 /* CalendarViewContent.swift in Sources */,
+				93D6789E2772EC1D004948E5 /* Deprecations.swift in Sources */,
 				939E692F24837E0300A8BCC7 /* OffScreenCalendarItemAccessibilityElement.swift in Sources */,
 				939E694624847BA300A8BCC7 /* DayOfWeekPosition.swift in Sources */,
 				933992992736562D00C80380 /* DoubleLayoutPassHelpers.swift in Sources */,
@@ -614,7 +618,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.12.0;
+				MARKETING_VERSION = 1.13.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.HorizonCalendar;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -648,7 +652,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.12.0;
+				MARKETING_VERSION = 1.13.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.HorizonCalendar;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/README.md
+++ b/README.md
@@ -183,13 +183,13 @@ private func makeContent() -> CalendarViewContent {
     visibleDateRange: today...endDate,
     monthsLayout: .vertical(VerticalMonthsLayoutOptions()))
     
-    .withDayItemModelProvider { day in
+    .dayItemProvider { day in
       // Return a `CalendarItemModel` representing the view for each day
     }
 }
 ```
 
-The `withDayItemModelProvider(_:)` function on `CalendarViewContent` returns a new `CalendarViewContent` instance with the custom day item model provider configured. This function takes a single parameter - a provider closure that returns a `CalendarItemModel` for a given `Day`.
+The `withDayItemProvider(_:)` function on `CalendarViewContent` returns a new `CalendarViewContent` instance with the custom day item model provider configured. This function takes a single parameter - a provider closure that returns a `CalendarItemModel` for a given `Day`.
 
 `CalendarItemModel` is a type that abstracts away the creation and configuration of a `UIView`. It's generic over a `ViewRepresentable` type, which can be any type conforming to `CalendarItemViewRepresentable`. You can think of `CalendarItemViewRepresentable` as a blueprint for creating and updating instances of a particular type of view to be displayed in the calendar. For example, if we want to use a `UILabel` for our custom day view, we'll need to create a type that knows how to create and update that label. Here's a simple example:
 ```swift
@@ -242,7 +242,7 @@ Now that we have a type conforming to `CalendarItemViewRepresentable`, we can us
 ```swift
   return CalendarViewContent(...)
 
-    .withDayItemModelProvider { day in
+    .dayItemProvider { day in
       CalendarItemModel<DayLabel>(
         invariantViewProperties: .init(
           font: UIFont.systemFont(ofSize: 18), 
@@ -262,11 +262,11 @@ If you build and run your app, it should now look like this:
 We can also use `CalendarViewContent` to adjust layout metrics. We can improve the layout of our current `CalendarView` by adding some additional spacing between individual days and months:
 ```swift
   return CalendarViewContent(...)
-    .withDayItemModelProvider { ... }
+    .dayItemProvider { ... }
 
-    .withInterMonthSpacing(24)
-    .withVerticalDayMargin(8)
-    .withHorizontalDayMargin(8)
+    .interMonthSpacing(24)
+    .verticalDayMargin(8)
+    .horizontalDayMargin(8)
 ```
 
 Just like when we configured a custom day view via the day item provider, changes to layout metrics are also done through `CalendarViewContent`. `withInterMonthSpacing(_:)`, `withVerticalDayMargin(_:)`, and `withHorizontalDayMargin(_:)` each return a mutated `CalendarViewContent` with the corresponding layout metric value updated, enabling you to chain function calls together to produce a final content instance.
@@ -276,7 +276,7 @@ After building and running your app, you should see a much less cramped layout:
 ![Custom Layout Metrics](Docs/Images/tutorial3.png)
 
 #### Adding a day range indicator
-Day range indicators are useful for date pickers that need to highlight not just individual days, but ranges of days. `HorizonCalendar` offers an API to do exactly this via the `CalendarViewContent` function `withDayRangeItemModelProvider(for:_:)`. Similar to what we did for our custom day item model provider, for day ranges, we need to provide a `CalendarItemModel` for each day range we want to highlight.
+Day range indicators are useful for date pickers that need to highlight not just individual days, but ranges of days. `HorizonCalendar` offers an API to do exactly this via the `CalendarViewContent` function `withDayRangeItemProvider(for:_:)`. Similar to what we did for our custom day item model provider, for day ranges, we need to provide a `CalendarItemModel` for each day range we want to highlight.
 
 First, we need to create a `ClosedRange<Date>` that represents the day range for which we'd like to provide a `CalendarItemModel`. The `Date`s in our range will be interpreted as `Day`s using the `Calendar` instance with which we initialized our `CalendarViewContent`.
 ```swift
@@ -285,12 +285,12 @@ First, we need to create a `ClosedRange<Date>` that represents the day range for
   let dateRangeToHighlight = lowerDate...upperDate
 ```
 
-Next, we need to invoke the `withDayRangeItemModelProvider(for:_:)` on our `CalendarViewContent`:
+Next, we need to invoke the `withDayRangeItemProvider(for:_:)` on our `CalendarViewContent`:
 ```swift
   return CalendarViewContent(...)
     ...
     
-    .withDayRangeItemModelProvider(for: [dateRangeToHighlight]) { dayRangeLayoutContext in 
+    .dayRangeItemProvider(for: [dateRangeToHighlight]) { dayRangeLayoutContext in 
       // Return a `CalendarItemModel` representing the view that highlights the entire day range
     }
 ```
@@ -380,7 +380,7 @@ Last, we need to return a `CalendarItemModel` representing our `DayRangeIndicato
   return CalendarViewContent(...)
     ...
     
-    .withDayRangeItemModelProvider(for: [dateRangeToHighlight]) { dayRangeLayoutContext in
+    .dayRangeItemProvider(for: [dateRangeToHighlight]) { dayRangeLayoutContext in
       CalendarItemModel<DayRangeIndicatorView>(
         invariantViewProperties: .init(indicatorColor: UIColor.blue.withAlphaComponent(0.15)),
         viewModel: .init(framesOfDaysToHighlight: dayRangeLayoutContext.daysAndFrames.map { $0.frame }))
@@ -405,7 +405,7 @@ Like all other customizations, we'll add an overlay by calling a function on our
   return CalendarViewContent(...)
     ...
     
-    .withOverlayItemModelProvider(for: [overlaidItemLocation]) { overlayLayoutContext in
+    .overlayItemProvider(for: [overlaidItemLocation]) { overlayLayoutContext in
       // Return a `CalendarItemModel` representing the view to use as an overlay for the overlaid item location
     }
 ```
@@ -537,7 +537,7 @@ Last, we need to return a `CalendarItemModel` representing our `TooltipView` fro
   return CalendarViewContent(...)
     ...
     
-    .withOverlayItemModelProvider(for: [overlaidItemLocation]) { overlayLayoutContext in
+    .overlayItemProvider(for: [overlaidItemLocation]) { overlayLayoutContext in
       CalendarItemModel<TooltipView>(
         invariantViewProperties: .init(
           backgroundColor: .white, 
@@ -573,7 +573,7 @@ The day selection handler closure is invoked whenever a day in the calendar is s
 
   return CalendarViewContent(...)
 
-    .withDayItemModelProvider { day in
+    .dayItemProvider { day in
       var invariantViewProperties = DayLabel.InvariantViewProperties(
         font: UIFont.systemFont(ofSize: 18), 
         textColor: .darkGray,

--- a/Sources/Internal/VisibleItemsProvider.swift
+++ b/Sources/Internal/VisibleItemsProvider.swift
@@ -274,10 +274,10 @@ final class VisibleItemsProvider {
       switch layoutItem.itemType {
       case .monthHeader(let _month):
         month = _month
-        calendarItemModel = self.content.monthHeaderItemModelProvider(month)
+        calendarItemModel = self.content.monthHeaderItemProvider(month)
       case .day(let day):
         month = day.month
-        calendarItemModel = self.content.dayItemModelProvider(day)
+        calendarItemModel = self.content.dayItemProvider(day)
       case .dayOfWeekInMonth:
         return
       }
@@ -622,7 +622,7 @@ final class VisibleItemsProvider {
             for: itemType,
             missingValueProvider: {
               previousCalendarItemModelCache?[itemType]
-                ?? content.monthHeaderItemModelProvider(month)
+                ?? content.monthHeaderItemProvider(month)
             })
 
           // Create a visible item for the separator view, if needed.
@@ -662,14 +662,14 @@ final class VisibleItemsProvider {
             missingValueProvider: {
               let weekdayIndex = calendar.weekdayIndex(for: dayOfWeekPosition)
               return previousCalendarItemModelCache?[itemType]
-                ?? content.dayOfWeekItemModelProvider(month, weekdayIndex)
+                ?? content.dayOfWeekItemProvider(month, weekdayIndex)
             })
 
         case .day(let day):
           calendarItemModel = calendarItemModelCache.value(
             for: itemType,
             missingValueProvider: {
-              previousCalendarItemModelCache?[itemType] ?? content.dayItemModelProvider(day)
+              previousCalendarItemModelCache?[itemType] ?? content.dayItemProvider(day)
             })
 
           handleDayRangesContaining(
@@ -747,7 +747,7 @@ final class VisibleItemsProvider {
     originsForMonths: inout [Month: CGPoint])
   {
     // Handle day ranges that start or end with the current day.
-    for dayRange in content.dayRangesAndItemModelProvider?.dayRanges ?? [] {
+    for dayRange in content.dayRangesAndItemProvider?.dayRanges ?? [] {
       guard
         !handledDayRanges.contains(dayRange),
         dayRange.contains(day)
@@ -775,11 +775,11 @@ final class VisibleItemsProvider {
     visibleItems: inout Set<VisibleCalendarItem>)
   {
     guard
-      let dayRangeItemModelProvider = content.dayRangesAndItemModelProvider?.dayRangeItemModelProvider
+      let dayRangeItemProvider = content.dayRangesAndItemProvider?.dayRangeItemProvider
     else
     {
       preconditionFailure(
-        "`content.dayRangesAndItemModelProvider` cannot be nil when handling a day range.")
+        "`content.dayRangesAndItemProvider` cannot be nil when handling a day range.")
     }
 
     let frame = dayRangeLayoutContext.frame
@@ -789,7 +789,7 @@ final class VisibleItemsProvider {
 
     visibleItems.insert(
       VisibleCalendarItem(
-        calendarItemModel: dayRangeItemModelProvider(dayRangeLayoutContext),
+        calendarItemModel: dayRangeItemProvider(dayRangeLayoutContext),
         itemType: .dayRange(dayRange),
         frame: frame))
   }
@@ -814,7 +814,7 @@ final class VisibleItemsProvider {
             missingValueProvider: {
               let weekdayIndex = calendar.weekdayIndex(for: dayOfWeekPosition)
               return previousCalendarItemModelCache?[itemType] ??
-                content.dayOfWeekItemModelProvider(nil, weekdayIndex)
+                content.dayOfWeekItemProvider(nil, weekdayIndex)
             }),
           itemType: itemType,
           frame: frame))
@@ -878,7 +878,7 @@ final class VisibleItemsProvider {
     visibleItems: inout Set<VisibleCalendarItem>)
   {
     guard
-      let (overlaidItemLocations, itemModelProvider) = content.overlaidItemLocationsAndItemModelProvider
+      let (overlaidItemLocations, itemModelProvider) = content.overlaidItemLocationsAndItemProvider
     else
     {
       return

--- a/Sources/Public/CalendarView.swift
+++ b/Sources/Public/CalendarView.swift
@@ -87,7 +87,8 @@ public final class CalendarView: UIView {
   @available(
     *,
     deprecated,
-    message: "Use `_didEndDragging` instead, since it includes a `Bool` to indicate whether the calendar will decelerate when dragging ends. In a future release, `_didEndDragging` will be renamed to `didEndDragging`, and this deprecated property will be removed.")
+    message: "Use `_didEndDragging` instead, since it includes a `Bool` to indicate whether the calendar will decelerate when dragging ends. In a future release, `_didEndDragging` will be renamed to `didEndDragging`, and this deprecated property will be removed.",
+     renamed: "_didEndDragging")
   public var didEndDragging: ((_ visibleDayRange: DayRange) -> Void)?
 
   /// A closure (that is retained) that is invoked inside `scrollViewDidEndDragging(_: willDecelerate:)`.
@@ -98,7 +99,7 @@ public final class CalendarView: UIView {
 
   /// Whether or not the calendar's scroll view is currently over-scrolling, i.e, whether the rubber-banding or bouncing effect is in
   /// progress.
-  public var isOverscrolling: Bool {
+  public var isOverScrolling: Bool {
     let scrollAxis = scrollMetricsMutator.scrollAxis
     let offset = scrollView.offset(for: scrollAxis)
 
@@ -586,7 +587,7 @@ public final class CalendarView: UIView {
         interMonthSpacing: content.interMonthSpacing)
     }
 
-    let firstMonthHeaderItemModel = content.monthHeaderItemModelProvider(
+    let firstMonthHeaderItemModel = content.monthHeaderItemProvider(
       content.monthRange.lowerBound)
     let firstMonthHeader = firstMonthHeaderItemModel.makeView()
     firstMonthHeaderItemModel.setViewModelOnViewOfSameType(firstMonthHeader)
@@ -1113,7 +1114,7 @@ extension CalendarView {
 
     scroll(toMonthContaining: targetMonthDate, scrollPosition: scrollPosition, animated: false)
 
-    let targetMonthItem = content.monthHeaderItemModelProvider(targetMonth)
+    let targetMonthItem = content.monthHeaderItemProvider(targetMonth)
     let targetMonthView = targetMonthItem.makeView()
     targetMonthItem.setViewModelOnViewOfSameType(targetMonthView)
     let accessibilityScrollText = targetMonthView.accessibilityLabel

--- a/Sources/Public/CalendarViewContent.swift
+++ b/Sources/Public/CalendarViewContent.swift
@@ -62,7 +62,7 @@ public final class CalendarViewContent {
       options: 0,
       locale: calendar.locale ?? Locale.current)
 
-    monthHeaderItemModelProvider = { month in
+    monthHeaderItemProvider = { month in
       let firstDateInMonth = calendar.firstDate(of: month)
       let monthText = monthHeaderDateFormatter.string(from: firstDateInMonth)
       let itemModel = CalendarItemModel<MonthHeaderView>(
@@ -71,7 +71,7 @@ public final class CalendarViewContent {
       return .itemModel(itemModel)
     }
 
-    dayOfWeekItemModelProvider = { _, weekdayIndex in
+    dayOfWeekItemProvider = { _, weekdayIndex in
       let dayOfWeekText = monthHeaderDateFormatter.veryShortStandaloneWeekdaySymbols[weekdayIndex]
       let itemModel = CalendarItemModel<DayOfWeekView>(
         invariantViewProperties: .base,
@@ -87,7 +87,7 @@ public final class CalendarViewContent {
       options: 0,
       locale: calendar.locale ?? Locale.current)
 
-    dayItemModelProvider = { day in
+    dayItemProvider = { day in
       let date = calendar.startDate(of: day)
       let itemModel = CalendarItemModel<DayView>(
         invariantViewProperties: .baseNonInteractive,
@@ -125,7 +125,7 @@ public final class CalendarViewContent {
   /// - Parameters:
   ///   - dayAspectRatio: The aspect ratio of each day view.
   /// - Returns: A mutated `CalendarViewContent` instance with a new day aspect ratio value.
-  public func withDayAspectRatio(_ dayAspectRatio: CGFloat) -> CalendarViewContent {
+  public func dayAspectRatio(_ dayAspectRatio: CGFloat) -> CalendarViewContent {
     let validAspectRatioRange: ClosedRange<CGFloat> = 0.5...3
     assert(
       validAspectRatioRange.contains(dayAspectRatio),
@@ -141,7 +141,7 @@ public final class CalendarViewContent {
   /// - Parameters:
   ///   - interMonthSpacing: The amount of spacing, in points, between months.
   /// - Returns: A mutated `CalendarViewContent` instance with a new inter-month-spacing value.
-  public func withInterMonthSpacing(_ interMonthSpacing: CGFloat) -> CalendarViewContent {
+  public func interMonthSpacing(_ interMonthSpacing: CGFloat) -> CalendarViewContent {
     self.interMonthSpacing = interMonthSpacing
     return self
   }
@@ -151,7 +151,7 @@ public final class CalendarViewContent {
   /// - Parameters:
   ///   - monthDayInsets: The amount to inset days and day-of-week items from the edges of a month.
   /// - Returns: A mutated `CalendarViewContent` instance with a new month-day-insets value.
-  public func withMonthDayInsets(_ monthDayInsets: UIEdgeInsets) -> CalendarViewContent {
+  public func monthDayInsets(_ monthDayInsets: UIEdgeInsets) -> CalendarViewContent {
     self.monthDayInsets = monthDayInsets
     return self
   }
@@ -165,7 +165,7 @@ public final class CalendarViewContent {
   /// - Parameters:
   ///   - verticalDayMargin: The amount of space between two day frames along the vertical axis.
   /// - Returns: A mutated `CalendarViewContent` instance with a new vertical day margin value.
-  public func withVerticalDayMargin(_ verticalDayMargin: CGFloat) -> CalendarViewContent {
+  public func verticalDayMargin(_ verticalDayMargin: CGFloat) -> CalendarViewContent {
     self.verticalDayMargin = verticalDayMargin
     return self
   }
@@ -179,7 +179,7 @@ public final class CalendarViewContent {
   /// - Parameters:
   ///   - horizontalDayMargin: The amount of space between two day frames along the horizontal axis.
   /// - Returns: A mutated `CalendarViewContent` instance with a new horizontal day margin value.
-  public func withHorizontalDayMargin(_ horizontalDayMargin: CGFloat) -> CalendarViewContent {
+  public func horizontalDayMargin(_ horizontalDayMargin: CGFloat) -> CalendarViewContent {
     self.horizontalDayMargin = horizontalDayMargin
     return self
   }
@@ -189,7 +189,7 @@ public final class CalendarViewContent {
   /// - Parameters:
   ///   - options: An instance that has properties to control various aspects of the separator's design.
   /// - Returns: A mutated `CalendarViewContent` instance with a days-of-the-week row separator configured.
-  public func withDaysOfTheWeekRowSeparator(
+  public func daysOfTheWeekRowSeparator(
     options: DaysOfTheWeekRowSeparatorOptions)
     -> CalendarViewContent
   {
@@ -199,7 +199,7 @@ public final class CalendarViewContent {
 
   /// Configures the month header item provider.
   ///
-  /// `CalendarView` invokes the provided `monthHeaderItemModelProvider` for each month in the range of months being
+  /// `CalendarView` invokes the provided `monthHeaderItemProvider` for each month in the range of months being
   /// displayed. The `CalendarItemModel`s that you return will be used to create the views for each month header in
   /// `CalendarView`.
   ///
@@ -207,47 +207,47 @@ public final class CalendarViewContent {
   /// used.
   ///
   /// - Parameters:
-  ///   - monthHeaderItemModelProvider: A closure (that is retained) that returns a `CalendarItemModel` representing a
+  ///   - monthHeaderItemProvider: A closure (that is retained) that returns a `CalendarItemModel` representing a
   ///   month header.
   ///   - month: The `Month` for which to provide a month header item.
   /// - Returns: A mutated `CalendarViewContent` instance with a new month header item provider.
-  public func withMonthHeaderItemModelProvider(
-    _ monthHeaderItemModelProvider: @escaping (_ month: Month) -> AnyCalendarItemModel)
+  public func monthHeaderItemProvider(
+    _ monthHeaderItemProvider: @escaping (_ month: Month) -> AnyCalendarItemModel)
     -> CalendarViewContent
   {
-    self.monthHeaderItemModelProvider = { .itemModel(monthHeaderItemModelProvider($0)) }
+    self.monthHeaderItemProvider = { .itemModel(monthHeaderItemProvider($0)) }
     return self
   }
 
   /// Configures the day-of-week item provider.
   ///
-  /// `CalendarView` invokes the provided `dayOfWeekItemModelProvider` for each weekday index for the current calendar.
+  /// `CalendarView` invokes the provided `dayOfWeekItemProvider` for each weekday index for the current calendar.
   /// For example, for the en_US locale, 0 is Sunday, 1 is Monday, and 6 is Saturday. This will be different in some other locales. The
   /// `CalendarItemModel`s that you return will be used to create the views for each day-of-week view in `CalendarView`.
   ///
   /// If you don't configure your own day-of-week item provider via this function, then a default day-of-week item provider will be used.
   ///
   /// - Parameters:
-  ///   - dayOfWeekItemModelProvider: A closure (that is retained) that returns a `CalendarItemModel` representing a
+  ///   - dayOfWeekItemProvider: A closure (that is retained) that returns a `CalendarItemModel` representing a
   ///   day of the week.
   ///   - month: The month in which the day-of-week item belongs. This parameter will be `nil` if days of the week are pinned to
   ///   the top of the calendar, since in that scenario, they don't belong to any particular month.
   ///   - weekdayIndex: The weekday index for which to provide a `CalendarItemModel`.
   /// - Returns: A mutated `CalendarViewContent` instance with a new day-of-week item provider.
-  public func withDayOfWeekItemModelProvider(
-    _ dayOfWeekItemModelProvider: @escaping (
+  public func dayOfWeekItemProvider(
+    _ dayOfWeekItemProvider: @escaping (
       _ month: Month?,
       _ weekdayIndex: Int)
       -> AnyCalendarItemModel)
     -> CalendarViewContent
   {
-    self.dayOfWeekItemModelProvider = { .itemModel(dayOfWeekItemModelProvider($0, $1)) }
+    self.dayOfWeekItemProvider = { .itemModel(dayOfWeekItemProvider($0, $1)) }
     return self
   }
 
   /// Configures the day item provider.
   ///
-  /// `CalendarView` invokes the provided `dayItemModelProvider` for each day being displayed. The
+  /// `CalendarView` invokes the provided `dayItemProvider` for each day being displayed. The
   /// `CalendarItemModel`s that you return will be used to create the views for each day in `CalendarView`. In most cases, this
   /// view should be some kind of label that tells the user the day number of the month. You can also add other decoration, like a badge
   /// or background, by including it in the view that your `CalendarItemModel` creates.
@@ -255,21 +255,21 @@ public final class CalendarViewContent {
   /// If you don't configure your own day item provider via this function, then a default day item provider will be used.
   ///
   /// - Parameters:
-  ///   - dayItemModelProvider: A closure (that is retained) that returns a `CalendarItemModel` representing a single day
+  ///   - dayItemProvider: A closure (that is retained) that returns a `CalendarItemModel` representing a single day
   ///   in the calendar.
   ///   - day: The `Day` for which to provide a day item.
   /// - Returns: A mutated `CalendarViewContent` instance with a new day item provider.
-  public func withDayItemModelProvider(
-    _ dayItemModelProvider: @escaping (_ day: Day) -> AnyCalendarItemModel)
+  public func dayItemProvider(
+    _ dayItemProvider: @escaping (_ day: Day) -> AnyCalendarItemModel)
     -> CalendarViewContent
   {
-    self.dayItemModelProvider = { .itemModel(dayItemModelProvider($0)) }
+    self.dayItemProvider = { .itemModel(dayItemProvider($0)) }
     return self
   }
 
   /// Configures the day range item provider.
   ///
-  /// `CalendarView` invokes the provided `dayRangeItemModelProvider` for each day range in the `dateRanges` set.
+  /// `CalendarView` invokes the provided `dayRangeItemProvider` for each day range in the `dateRanges` set.
   /// Date ranges will be converted to day ranges by using the `calendar`passed into the `CalendarViewContent` initializer. The
   /// `CalendarItemModel` that you return for each day range will be used to create a view that spans the entire frame
   /// encapsulating all days in that day range. This behavior makes day range items useful for things like day range selection indicators
@@ -284,49 +284,49 @@ public final class CalendarViewContent {
   ///
   /// - Parameters:
   ///   - dateRanges: The date ranges for which `CalendarView` will invoke your day range item provider closure.
-  ///   - dayRangeItemModelProvider: A closure (that is retained) that returns a `CalendarItemModel` representing a day
+  ///   - dayRangeItemProvider: A closure (that is retained) that returns a `CalendarItemModel` representing a day
   ///   range in the calendar.
   ///   - dayRangeLayoutContext: The layout context for the day range containing information about the frames of days and
   ///   bounds in which your day range item will be displayed.
   /// - Returns: A mutated `CalendarViewContent` instance with a new day range item provider.
-  public func withDayRangeItemModelProvider(
+  public func dayRangeItemProvider(
     for dateRanges: Set<ClosedRange<Date>>,
-    _ dayRangeItemModelProvider: @escaping (
+    _ dayRangeItemProvider: @escaping (
       _ dayRangeLayoutContext: DayRangeLayoutContext)
       -> AnyCalendarItemModel)
     -> CalendarViewContent
   {
     let dayRanges = Set(dateRanges.map { DayRange(containing: $0, in: calendar) })
-    dayRangesAndItemModelProvider = (dayRanges, { .itemModel(dayRangeItemModelProvider($0)) })
+    dayRangesAndItemProvider = (dayRanges, { .itemModel(dayRangeItemProvider($0)) })
     return self
   }
 
   /// Configures the overlay item provider.
   ///
-  /// `CalendarView` invokes the provided `overlayItemModelProvider` for each overlaid item location in the
+  /// `CalendarView` invokes the provided `overlayItemProvider` for each overlaid item location in the
   /// `overlaidItemLocations` set. All of the layout information needed to create an overlay item is provided via the overlay
-  /// context passed into the `overlayItemModelProvider` closure. The `CalendarItemModel` that you return for each
+  /// context passed into the `overlayItemProvider` closure. The `CalendarItemModel` that you return for each
   /// overlaid item location will be used to create a view that spans the visible bounds of the calendar when that overlaid item's location
   /// is visible. This behavior makes overlay items useful for things like tooltips.
   ///
   /// - Parameters:
   ///   - overlaidItemLocations: The overlaid item locations for which `CalendarView` will invoke your overlay item
   ///   provider closure.
-  ///   - overlayItemModelProvider: A closure (that is retained) that returns a `CalendarItemModel` representing an
+  ///   - overlayItemProvider: A closure (that is retained) that returns a `CalendarItemModel` representing an
   ///   overlay.
   ///   - overlayLayoutContext: The layout context for the overlaid item location containing information about that location's
   ///   frame and the bounds in which your overlay item will be displayed.
   /// - Returns: A mutated `CalendarViewContent` instance with a new overlay item provider.
-  public func withOverlayItemModelProvider(
+  public func overlayItemProvider(
     for overlaidItemLocations: Set<OverlaidItemLocation>,
-    _ overlayItemModelProvider: @escaping (
+    _ overlayItemProvider: @escaping (
       _ overlayLayoutContext: OverlayLayoutContext)
       -> AnyCalendarItemModel)
     -> CalendarViewContent
   {
-    overlaidItemLocationsAndItemModelProvider = (
+    overlaidItemLocationsAndItemProvider = (
       overlaidItemLocations,
-      { .itemModel(overlayItemModelProvider($0)) })
+      { .itemModel(overlayItemProvider($0)) })
     return self
   }
 
@@ -347,18 +347,18 @@ public final class CalendarViewContent {
   private(set) var daysOfTheWeekRowSeparatorOptions: DaysOfTheWeekRowSeparatorOptions?
 
   // TODO(BK): Make all item provider closures private(set) after legacy `CalendarItem` is removed.
-  var monthHeaderItemModelProvider: (Month) -> InternalAnyCalendarItemModel
-  var dayOfWeekItemModelProvider: (
+  var monthHeaderItemProvider: (Month) -> InternalAnyCalendarItemModel
+  var dayOfWeekItemProvider: (
     _ month: Month?,
     _ weekdayIndex: Int)
     -> InternalAnyCalendarItemModel
-  var dayItemModelProvider: (Day) -> InternalAnyCalendarItemModel
-  var dayRangesAndItemModelProvider: (
+  var dayItemProvider: (Day) -> InternalAnyCalendarItemModel
+  var dayRangesAndItemProvider: (
     dayRanges: Set<DayRange>,
-    dayRangeItemModelProvider: (DayRangeLayoutContext) -> InternalAnyCalendarItemModel)?
-  var overlaidItemLocationsAndItemModelProvider: (
+    dayRangeItemProvider: (DayRangeLayoutContext) -> InternalAnyCalendarItemModel)?
+  var overlaidItemLocationsAndItemProvider: (
     overlaidItemLocations: Set<OverlaidItemLocation>,
-    overlayItemModelProvider: (OverlayLayoutContext) -> InternalAnyCalendarItemModel)?
+    overlayItemProvider: (OverlayLayoutContext) -> InternalAnyCalendarItemModel)?
 
 }
 

--- a/Sources/Public/Deprecations.swift
+++ b/Sources/Public/Deprecations.swift
@@ -1,0 +1,302 @@
+// Created by Bryan Keller on 12/22/21.
+// Copyright © 2021 Airbnb Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import UIKit
+
+// MARK: CalendarView Deprecations
+
+extension CalendarView {
+
+  @available(*, deprecated, renamed: "isOverScrolling")
+  public var isOverscrolling: Bool {
+    isOverScrolling
+  }
+
+}
+
+// MARK: MonthsLayout Deprecations
+
+extension MonthsLayout {
+
+  /// Calendar months will be arranged in a single column, and scroll on the vertical axis.
+  ///
+  /// - `pinDaysOfWeekToTop`: Whether the days of the week will appear once, pinned at the top, or separately for each month.
+  @available(
+    *,
+    deprecated,
+    message: "Use .vertical(options: VerticalMonthsLayoutOptions) instead. This will be removed in a future major release.")
+  public static func vertical(pinDaysOfWeekToTop: Bool) -> Self {
+    let options = VerticalMonthsLayoutOptions(pinDaysOfWeekToTop: pinDaysOfWeekToTop)
+    return .vertical(options: options)
+  }
+
+  /// Calendar months will be arranged in a single row, and scroll on the horizontal axis.
+  ///
+  /// - `monthWidth`: The width of each month.
+  @available(
+    *,
+    deprecated,
+    message: "Use .horizontal(options: HorizontalMonthsLayoutOptions) instead. This will be removed in a future major release.")
+  public static func horizontal(monthWidth: CGFloat) -> Self {
+    var options = HorizontalMonthsLayoutOptions(scrollingBehavior: .freeScrolling)
+    options.monthWidth = monthWidth
+    return .horizontal(options: options)
+  }
+
+}
+
+// MARK: CalendarViewContent Deprecations
+
+extension CalendarViewContent {
+
+  /// Configures the aspect ratio of each day.
+  ///
+  /// Values less than 1 will result in rectangular days that are wider than they are tall. Values
+  /// greater than 1 will result in rectangular days that are taller than they are wide. The default value is `1`, which results in square
+  /// views with the same width and height.
+  ///
+  /// - Parameters:
+  ///   - dayAspectRatio: The aspect ratio of each day view.
+  /// - Returns: A mutated `CalendarViewContent` instance with a new day aspect ratio value.
+  @available(
+    *,
+    deprecated,
+    renamed: "dayAspectRatio(_:)")
+  public func withDayAspectRatio(_ dayAspectRatio: CGFloat) -> CalendarViewContent {
+    self.dayAspectRatio(dayAspectRatio)
+  }
+
+  /// Configures the amount of spacing, in points, between months. The default value is `0`.
+  ///
+  /// - Parameters:
+  ///   - interMonthSpacing: The amount of spacing, in points, between months.
+  /// - Returns: A mutated `CalendarViewContent` instance with a new inter-month-spacing value.
+  @available(
+    *,
+    deprecated,
+    renamed: "interMonthSpacing(_:)")
+  public func withInterMonthSpacing(_ interMonthSpacing: CGFloat) -> CalendarViewContent {
+    self.interMonthSpacing(interMonthSpacing)
+  }
+
+  /// Configures the amount to inset days and day-of-week items from the edges of a month. The default value is `.zero`.
+  ///
+  /// - Parameters:
+  ///   - monthDayInsets: The amount to inset days and day-of-week items from the edges of a month.
+  /// - Returns: A mutated `CalendarViewContent` instance with a new month-day-insets value.
+  @available(
+    *,
+    deprecated,
+    renamed: "monthDayInsets(_:)")
+  public func withMonthDayInsets(_ monthDayInsets: UIEdgeInsets) -> CalendarViewContent {
+    self.monthDayInsets(monthDayInsets)
+  }
+
+  /// Configures the amount of space between two day frames vertically.
+  ///
+  /// If `verticalDayMargin` and `horizontalDayMargin` are the same, then each day will appear to
+  /// have a 1:1 (square) aspect ratio. If `verticalDayMargin` and `horizontalDayMargin` are different, then days can
+  /// appear wider or taller.
+  ///
+  /// - Parameters:
+  ///   - verticalDayMargin: The amount of space between two day frames along the vertical axis.
+  /// - Returns: A mutated `CalendarViewContent` instance with a new vertical day margin value.
+  @available(
+    *,
+    deprecated,
+    renamed: "verticalDayMargin(_:)")
+  public func withVerticalDayMargin(_ verticalDayMargin: CGFloat) -> CalendarViewContent {
+    self.verticalDayMargin(verticalDayMargin)
+  }
+
+  /// Configures the amount of space between two day frames horizontally.
+  ///
+  /// If `verticalDayMargin` and `horizontalDayMargin` are the same, then each day will appear to
+  /// have a 1:1 (square) aspect ratio. If `verticalDayMargin` and `horizontalDayMargin` are
+  /// different, then days can appear wider or taller.
+  ///
+  /// - Parameters:
+  ///   - horizontalDayMargin: The amount of space between two day frames along the horizontal axis.
+  /// - Returns: A mutated `CalendarViewContent` instance with a new horizontal day margin value.
+  @available(
+    *,
+    deprecated,
+    renamed: "horizontalDayMargin(_:)")
+  public func withHorizontalDayMargin(_ horizontalDayMargin: CGFloat) -> CalendarViewContent {
+    self.horizontalDayMargin(horizontalDayMargin)
+  }
+
+  /// Configures the days-of-the-week row's separator options. The separator appears below the days-of-the-week row.
+  ///
+  /// - Parameters:
+  ///   - options: An instance that has properties to control various aspects of the separator's design.
+  /// - Returns: A mutated `CalendarViewContent` instance with a days-of-the-week row separator configured.
+  @available(
+    *,
+    deprecated,
+    renamed: "daysOfTheWeekRowSeparator(options:)")
+  public func withDaysOfTheWeekRowSeparator(
+    options: DaysOfTheWeekRowSeparatorOptions)
+    -> CalendarViewContent
+  {
+    daysOfTheWeekRowSeparator(options: options)
+  }
+
+  /// Configures the month header item provider.
+  ///
+  /// `CalendarView` invokes the provided `monthHeaderItemProvider` for each month in the range of months being
+  /// displayed. The `CalendarItemModel`s that you return will be used to create the views for each month header in
+  /// `CalendarView`.
+  ///
+  /// If you don't configure your own month header item provider via this function, then a default month header item provider will be
+  /// used.
+  ///
+  /// - Parameters:
+  ///   - monthHeaderItemProvider: A closure (that is retained) that returns a `CalendarItemModel` representing a
+  ///   month header.
+  ///   - month: The `Month` for which to provide a month header item.
+  /// - Returns: A mutated `CalendarViewContent` instance with a new month header item provider.
+  @available(
+    *,
+    deprecated,
+    renamed: "monthHeaderItemProvider(_:)")
+  public func withMonthHeaderItemProvider(
+    _ monthHeaderItemProvider: @escaping (_ month: Month) -> AnyCalendarItemModel)
+    -> CalendarViewContent
+  {
+    self.monthHeaderItemProvider(monthHeaderItemProvider)
+  }
+
+  /// Configures the day-of-week item provider.
+  ///
+  /// `CalendarView` invokes the provided `dayOfWeekItemProvider` for each weekday index for the current calendar.
+  /// For example, for the en_US locale, 0 is Sunday, 1 is Monday, and 6 is Saturday. This will be different in some other locales. The
+  /// `CalendarItemModel`s that you return will be used to create the views for each day-of-week view in `CalendarView`.
+  ///
+  /// If you don't configure your own day-of-week item provider via this function, then a default day-of-week item provider will be used.
+  ///
+  /// - Parameters:
+  ///   - dayOfWeekItemProvider: A closure (that is retained) that returns a `CalendarItemModel` representing a
+  ///   day of the week.
+  ///   - month: The month in which the day-of-week item belongs. This parameter will be `nil` if days of the week are pinned to
+  ///   the top of the calendar, since in that scenario, they don't belong to any particular month.
+  ///   - weekdayIndex: The weekday index for which to provide a `CalendarItemModel`.
+  /// - Returns: A mutated `CalendarViewContent` instance with a new day-of-week item provider.
+  @available(
+    *,
+    deprecated,
+    renamed: "dayOfWeekItemProvider(_:)")
+  public func withDayOfWeekItemProvider(
+    _ dayOfWeekItemProvider: @escaping (
+      _ month: Month?,
+      _ weekdayIndex: Int)
+      -> AnyCalendarItemModel)
+    -> CalendarViewContent
+  {
+    self.dayOfWeekItemProvider(dayOfWeekItemProvider)
+  }
+
+  /// Configures the day item provider.
+  ///
+  /// `CalendarView` invokes the provided `dayItemProvider` for each day being displayed. The
+  /// `CalendarItemModel`s that you return will be used to create the views for each day in `CalendarView`. In most cases, this
+  /// view should be some kind of label that tells the user the day number of the month. You can also add other decoration, like a badge
+  /// or background, by including it in the view that your `CalendarItemModel` creates.
+  ///
+  /// If you don't configure your own day item provider via this function, then a default day item provider will be used.
+  ///
+  /// - Parameters:
+  ///   - dayItemProvider: A closure (that is retained) that returns a `CalendarItemModel` representing a single day
+  ///   in the calendar.
+  ///   - day: The `Day` for which to provide a day item.
+  /// - Returns: A mutated `CalendarViewContent` instance with a new day item provider.
+  @available(
+    *,
+    deprecated,
+    renamed: "dayItemProvider(_:)")
+  public func withDayItemProvider(
+    _ dayItemProvider: @escaping (_ day: Day) -> AnyCalendarItemModel)
+    -> CalendarViewContent
+  {
+    self.dayItemProvider(dayItemProvider)
+  }
+
+  /// Configures the day range item provider.
+  ///
+  /// `CalendarView` invokes the provided `dayRangeItemProvider` for each day range in the `dateRanges` set.
+  /// Date ranges will be converted to day ranges by using the `calendar`passed into the `CalendarViewContent` initializer. The
+  /// `CalendarItemModel` that you return for each day range will be used to create a view that spans the entire frame
+  /// encapsulating all days in that day range. This behavior makes day range items useful for things like day range selection indicators
+  /// that might have specific styling requirements for different parts of the selected day range. For example, you might have a cross
+  /// fade in your day range selection indicator view when a day range spans multiple months, or you might have rounded end caps for
+  /// the start and end of a day range.
+  ///
+  /// The views created by the `CalendarItemModel`s provided by this function will be placed at a lower z-index than the layer of
+  /// day items. If you don't configure your own day range item provider via this function, then no day range view will be displayed.
+  ///
+  /// If you don't want to show any day range items, pass in an empty set for the `dateRanges` parameter.
+  ///
+  /// - Parameters:
+  ///   - dateRanges: The date ranges for which `CalendarView` will invoke your day range item provider closure.
+  ///   - dayRangeItemProvider: A closure (that is retained) that returns a `CalendarItemModel` representing a day
+  ///   range in the calendar.
+  ///   - dayRangeLayoutContext: The layout context for the day range containing information about the frames of days and
+  ///   bounds in which your day range item will be displayed.
+  /// - Returns: A mutated `CalendarViewContent` instance with a new day range item provider.
+  @available(
+    *,
+    deprecated,
+    renamed: "dayRangeItemProvider(for:_:)")
+  public func withDayRangeItemProvider(
+    for dateRanges: Set<ClosedRange<Date>>,
+    _ dayRangeItemProvider: @escaping (
+      _ dayRangeLayoutContext: DayRangeLayoutContext)
+      -> AnyCalendarItemModel)
+    -> CalendarViewContent
+  {
+    self.dayRangeItemProvider(for: dateRanges, dayRangeItemProvider)
+  }
+
+  /// Configures the overlay item provider.
+  ///
+  /// `CalendarView` invokes the provided `overlayItemProvider` for each overlaid item location in the
+  /// `overlaidItemLocations` set. All of the layout information needed to create an overlay item is provided via the overlay
+  /// context passed into the `overlayItemProvider` closure. The `CalendarItemModel` that you return for each
+  /// overlaid item location will be used to create a view that spans the visible bounds of the calendar when that overlaid item's location
+  /// is visible. This behavior makes overlay items useful for things like tooltips.
+  ///
+  /// - Parameters:
+  ///   - overlaidItemLocations: The overlaid item locations for which `CalendarView` will invoke your overlay item
+  ///   provider closure.
+  ///   - overlayItemProvider: A closure (that is retained) that returns a `CalendarItemModel` representing an
+  ///   overlay.
+  ///   - overlayLayoutContext: The layout context for the overlaid item location containing information about that location's
+  ///   frame and the bounds in which your overlay item will be displayed.
+  /// - Returns: A mutated `CalendarViewContent` instance with a new overlay item provider.
+  @available(
+    *,
+    deprecated,
+    renamed: "overlayItemProvider(for:_:)")
+  public func withOverlayItemProvider(
+    for overlaidItemLocations: Set<OverlaidItemLocation>,
+    _ overlayItemProvider: @escaping (
+      _ overlayLayoutContext: OverlayLayoutContext)
+      -> AnyCalendarItemModel)
+    -> CalendarViewContent
+  {
+    self.overlayItemProvider(for: overlaidItemLocations, overlayItemProvider)
+  }
+
+}

--- a/Sources/Public/Legacy CalendarItem Support/CalendarViewContent+CalendarItem.swift
+++ b/Sources/Public/Legacy CalendarItem Support/CalendarViewContent+CalendarItem.swift
@@ -32,12 +32,13 @@ extension CalendarViewContent {
   @available(
     *,
     deprecated,
-    message: "`CalendarItem` has been replaced with `CalendarItemModel`, a type that simplifies the creation of views displayed in `CalendarView`. Use `withMonthHeaderItemModelProvider` instead.")
+    message: "`CalendarItem` has been replaced with `CalendarItemModel`, a type that simplifies the creation of views displayed in `CalendarView`. Use `monthHeaderItemProvider` instead.",
+     renamed: "monthHeaderItemProvider(_:)")
   public func withMonthHeaderItemProvider(
     _ monthHeaderItemProvider: @escaping (_ month: Month) -> AnyCalendarItem)
     -> CalendarViewContent
   {
-    monthHeaderItemModelProvider = { .legacy(monthHeaderItemProvider($0)) }
+    self.monthHeaderItemProvider = { .legacy(monthHeaderItemProvider($0)) }
     return self
   }
 
@@ -58,12 +59,13 @@ extension CalendarViewContent {
   @available(
     *,
     deprecated,
-    message: "`CalendarItem` has been replaced with `CalendarItemModel`, a type that simplifies the creation of views displayed in `CalendarView`. Use `withDayOfWeekItemModelProvider` instead.")
+    message: "`CalendarItem` has been replaced with `CalendarItemModel`, a type that simplifies the creation of views displayed in `CalendarView`. Use `withDayOfWeekItemProvider` instead.",
+     renamed: "dayOfWeekItemProvider(_:)")
   public func withDayOfWeekItemProvider(
     _ dayOfWeekItemProvider: @escaping (_ month: Month?, _ weekdayIndex: Int) -> AnyCalendarItem)
     -> CalendarViewContent
   {
-    dayOfWeekItemModelProvider = { .legacy(dayOfWeekItemProvider($0, $1)) }
+    self.dayOfWeekItemProvider = { .legacy(dayOfWeekItemProvider($0, $1)) }
     return self
   }
 
@@ -84,12 +86,13 @@ extension CalendarViewContent {
   @available(
     *,
     deprecated,
-    message: "`CalendarItem` has been replaced with `CalendarItemModel`, a type that simplifies the creation of views displayed in `CalendarView`. Use `withDayItemModelProvider` instead.")
+    message: "`CalendarItem` has been replaced with `CalendarItemModel`, a type that simplifies the creation of views displayed in `CalendarView`. Use `withDayItemProvider` instead.",
+     renamed: "dayItemProvider(_:)")
   public func withDayItemProvider(
     _ dayItemProvider: @escaping (_ day: Day) -> AnyCalendarItem)
     -> CalendarViewContent
   {
-    dayItemModelProvider = { .legacy(dayItemProvider($0)) }
+    self.dayItemProvider = { .legacy(dayItemProvider($0)) }
     return self
   }
 
@@ -118,7 +121,8 @@ extension CalendarViewContent {
   @available(
     *,
     deprecated,
-    message: "`CalendarItem` has been replaced with `CalendarItemModel`, a type that simplifies the creation of views displayed in `CalendarView`. Use `withDayRangeItemModelProvider` instead.")
+    message: "`CalendarItem` has been replaced with `CalendarItemModel`, a type that simplifies the creation of views displayed in `CalendarView`. Use `withDayRangeItemProvider` instead.",
+     renamed: "dayRangeItemProvider(for:_:)")
   public func withDayRangeItemProvider(
     for dateRanges: Set<ClosedRange<Date>>,
     _ dayRangeItemProvider: @escaping (
@@ -127,7 +131,7 @@ extension CalendarViewContent {
     -> CalendarViewContent
   {
     let dayRanges = Set(dateRanges.map { DayRange(containing: $0, in: calendar) })
-    dayRangesAndItemModelProvider = (dayRanges, { .legacy(dayRangeItemProvider($0)) })
+    dayRangesAndItemProvider = (dayRanges, { .legacy(dayRangeItemProvider($0)) })
     return self
   }
 
@@ -149,7 +153,8 @@ extension CalendarViewContent {
   @available(
     *,
     deprecated,
-    message: "`CalendarItem` has been replaced with `CalendarItemModel`, a type that simplifies the creation of views displayed in `CalendarView`. Use `withOverlayItemModelProvider` instead.")
+    message: "`CalendarItem` has been replaced with `CalendarItemModel`, a type that simplifies the creation of views displayed in `CalendarView`. Use `withOverlayItemProvider` instead.",
+     renamed: "overlayItemProvider(for:_:)")
   public func withOverlayItemProvider(
     for overlaidItemLocations: Set<OverlaidItemLocation>,
     _ overlayItemProvider: @escaping (
@@ -157,7 +162,7 @@ extension CalendarViewContent {
       -> AnyCalendarItem)
     -> CalendarViewContent
   {
-    overlaidItemLocationsAndItemModelProvider = (
+    overlaidItemLocationsAndItemProvider = (
       overlaidItemLocations,
       { .legacy(overlayItemProvider($0)) })
     return self

--- a/Sources/Public/MonthsLayout.swift
+++ b/Sources/Public/MonthsLayout.swift
@@ -66,37 +66,6 @@ public enum MonthsLayout {
   }
 }
 
-// MARK: Deprecated
-
-extension MonthsLayout {
-
-  /// Calendar months will be arranged in a single column, and scroll on the vertical axis.
-  ///
-  /// - `pinDaysOfWeekToTop`: Whether the days of the week will appear once, pinned at the top, or separately for each month.
-  @available(
-    *,
-    deprecated,
-    message: "Use .vertical(options: VerticalMonthsLayoutOptions) instead. This will be removed in a future major release.")
-  public static func vertical(pinDaysOfWeekToTop: Bool) -> Self {
-    let options = VerticalMonthsLayoutOptions(pinDaysOfWeekToTop: pinDaysOfWeekToTop)
-    return .vertical(options: options)
-  }
-
-  /// Calendar months will be arranged in a single row, and scroll on the horizontal axis.
-  ///
-  /// - `monthWidth`: The width of each month.
-  @available(
-    *,
-    deprecated,
-    message: "Use .horizontal(options: HorizontalMonthsLayoutOptions) instead. This will be removed in a future major release.")
-  public static func horizontal(monthWidth: CGFloat) -> Self {
-    var options = HorizontalMonthsLayoutOptions(scrollingBehavior: .freeScrolling)
-    options.monthWidth = monthWidth
-    return .horizontal(options: options)
-  }
-
-}
-
 // MARK: Equatable
 
 extension MonthsLayout: Equatable {

--- a/Tests/FrameProviderTests.swift
+++ b/Tests/FrameProviderTests.swift
@@ -34,10 +34,10 @@ final class FrameProviderTests: XCTestCase {
         calendar: calendar,
         visibleDateRange: Date.distantPast...Date.distantFuture,
         monthsLayout: .vertical(options: VerticalMonthsLayoutOptions()))
-        .withMonthDayInsets(UIEdgeInsets(top: 5, left: 8, bottom: 5, right: 8))
-        .withInterMonthSpacing(20)
-        .withVerticalDayMargin(20)
-        .withHorizontalDayMargin(10),
+        .monthDayInsets(UIEdgeInsets(top: 5, left: 8, bottom: 5, right: 8))
+        .interMonthSpacing(20)
+        .verticalDayMargin(20)
+        .horizontalDayMargin(10),
       size: size,
       layoutMargins: .zero,
       scale: 3,
@@ -47,10 +47,10 @@ final class FrameProviderTests: XCTestCase {
         calendar: calendar,
         visibleDateRange: Date.distantPast...Date.distantFuture,
         monthsLayout: .vertical(options: VerticalMonthsLayoutOptions(pinDaysOfWeekToTop: true)))
-        .withMonthDayInsets(UIEdgeInsets(top: 5, left: 8, bottom: 5, right: 8))
-        .withInterMonthSpacing(20)
-        .withVerticalDayMargin(20)
-        .withHorizontalDayMargin(10),
+        .monthDayInsets(UIEdgeInsets(top: 5, left: 8, bottom: 5, right: 8))
+        .interMonthSpacing(20)
+        .verticalDayMargin(20)
+        .horizontalDayMargin(10),
       size: size,
       layoutMargins: .zero,
       scale: 3,
@@ -61,10 +61,10 @@ final class FrameProviderTests: XCTestCase {
         visibleDateRange: lowerBoundDate...upperBoundDate,
         monthsLayout: .vertical(
           options: VerticalMonthsLayoutOptions(alwaysShowCompleteBoundaryMonths: false)))
-        .withMonthDayInsets(UIEdgeInsets(top: 5, left: 8, bottom: 5, right: 8))
-        .withInterMonthSpacing(20)
-        .withVerticalDayMargin(20)
-        .withHorizontalDayMargin(10),
+        .monthDayInsets(UIEdgeInsets(top: 5, left: 8, bottom: 5, right: 8))
+        .interMonthSpacing(20)
+        .verticalDayMargin(20)
+        .horizontalDayMargin(10),
       size: size,
       layoutMargins: .zero,
       scale: 3,
@@ -75,10 +75,10 @@ final class FrameProviderTests: XCTestCase {
         visibleDateRange: Date.distantPast...Date.distantFuture,
         monthsLayout: .horizontal(
           options: HorizontalMonthsLayoutOptions(maximumFullyVisibleMonths: 1)))
-        .withMonthDayInsets(UIEdgeInsets(top: 5, left: 8, bottom: 5, right: 8))
-        .withInterMonthSpacing(20)
-        .withVerticalDayMargin(20)
-        .withHorizontalDayMargin(10),
+        .monthDayInsets(UIEdgeInsets(top: 5, left: 8, bottom: 5, right: 8))
+        .interMonthSpacing(20)
+        .verticalDayMargin(20)
+        .horizontalDayMargin(10),
       size: size,
       layoutMargins: .zero,
       scale: 3,
@@ -88,11 +88,11 @@ final class FrameProviderTests: XCTestCase {
         calendar: calendar,
         visibleDateRange: Date.distantPast...Date.distantFuture,
         monthsLayout: .vertical(options: VerticalMonthsLayoutOptions()))
-        .withMonthDayInsets(UIEdgeInsets(top: 5, left: 8, bottom: 5, right: 8))
-        .withDayAspectRatio(1.5)
-        .withInterMonthSpacing(20)
-        .withVerticalDayMargin(20)
-        .withHorizontalDayMargin(10),
+        .monthDayInsets(UIEdgeInsets(top: 5, left: 8, bottom: 5, right: 8))
+        .dayAspectRatio(1.5)
+        .interMonthSpacing(20)
+        .verticalDayMargin(20)
+        .horizontalDayMargin(10),
       size: size,
       layoutMargins: .zero,
       scale: 3,
@@ -570,7 +570,7 @@ final class FrameProviderTests: XCTestCase {
         calendar: calendar,
         visibleDateRange: Date.distantPast...Date.distantFuture,
         monthsLayout: .horizontal(monthWidth: 163.5))
-        .withInterMonthSpacing(24),
+        .interMonthSpacing(24),
       size: CGSize(width: 375, height: 275),
       layoutMargins: .init(top: 8, leading: 8, bottom: 8, trailing: 8),
       scale: 3,

--- a/Tests/VisibleItemsProviderTests.swift
+++ b/Tests/VisibleItemsProviderTests.swift
@@ -1671,15 +1671,15 @@ final class VisibleItemsProviderTests: XCTestCase {
     -> CalendarViewContent
   {
     baseContent
-      .withMonthDayInsets(UIEdgeInsets(top: 30, left: 5, bottom: 0, right: 5))
-      .withInterMonthSpacing(15)
-      .withVerticalDayMargin(20)
-      .withHorizontalDayMargin(10)
-      .withDaysOfTheWeekRowSeparator(options: .init(height: 1, color: .gray))
-      .withMonthHeaderItemModelProvider  { _ in mockCalendarItemModel }
-      .withDayOfWeekItemModelProvider { _, _ in mockCalendarItemModel }
-      .withDayItemModelProvider { _ in mockCalendarItemModel }
-      .withDayRangeItemModelProvider(
+      .monthDayInsets(UIEdgeInsets(top: 30, left: 5, bottom: 0, right: 5))
+      .interMonthSpacing(15)
+      .verticalDayMargin(20)
+      .horizontalDayMargin(10)
+      .daysOfTheWeekRowSeparator(options: .init(height: 1, color: .gray))
+      .monthHeaderItemProvider  { _ in mockCalendarItemModel }
+      .dayOfWeekItemProvider { _, _ in mockCalendarItemModel }
+      .dayItemProvider { _ in mockCalendarItemModel }
+      .dayRangeItemProvider(
         for: [
           calendar.date(from: DateComponents(year: 2020, month: 03, day: 11))!
             ...
@@ -1690,7 +1690,7 @@ final class VisibleItemsProviderTests: XCTestCase {
           calendar.date(from: DateComponents(year: 2020, month: 05, day: 14))!,
         ],
         { _ in mockCalendarItemModel })
-      .withOverlayItemModelProvider(
+      .overlayItemProvider(
         for: [
           .day(
             containingDate: calendar.date(from: DateComponents(year: 2020, month: 01, day: 19))!),


### PR DESCRIPTION
## Details

Taking a hint from both SwiftUI and [Epoxy](https://github.com/airbnb/epoxy-ios), this PR renames all of the `CalendarViewContent.with*` content modifier functions to omit the `with` prefix. I don't think it really adds much clarity.

Since this is only a minor version bump (1.12.0 -> 1.13.0), I can't remove the old functions. I _can_ deprecate them, though, and provide an easy path to adopt the new function names via the `renamed:` `@available` functionality. See screenshot: 

<img width="782" alt="Screen Shot 2021-12-22 at 12 36 14 AM" src="https://user-images.githubusercontent.com/746571/147042431-285b9f33-7203-4e0e-9733-acd6d4f3b0c7.png">

## Related Issue

N/A

## Motivation and Context

More concise API. Will remove deprecated functions in v2.0.0

## How Has This Been Tested

- Simulator
- Xcode rename functionality (tested all cases)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
