### PR TITLE
OOF - Fix build

### DIFF
--- a/HorizonCalendar.podspec
+++ b/HorizonCalendar.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name = "HorizonCalendar"
-  spec.version = "1.13.0"
+  spec.version = "1.13.1"
   spec.license = "Apache License, Version 2.0"
   spec.summary = "A declarative, performant, calendar UI component that supports use cases ranging from simple date pickers to fully-featured calendar apps."
 

--- a/HorizonCalendar.xcodeproj/project.pbxproj
+++ b/HorizonCalendar.xcodeproj/project.pbxproj
@@ -618,7 +618,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.13.0;
+				MARKETING_VERSION = 1.13.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.HorizonCalendar;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -652,7 +652,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.13.0;
+				MARKETING_VERSION = 1.13.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.HorizonCalendar;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Sources/Public/Deprecations.swift
+++ b/Sources/Public/Deprecations.swift
@@ -172,7 +172,7 @@ extension CalendarViewContent {
     *,
     deprecated,
     renamed: "monthHeaderItemProvider(_:)")
-  public func withMonthHeaderItemProvider(
+  public func withMonthHeaderItemModelProvider(
     _ monthHeaderItemProvider: @escaping (_ month: Month) -> AnyCalendarItemModel)
     -> CalendarViewContent
   {
@@ -198,7 +198,7 @@ extension CalendarViewContent {
     *,
     deprecated,
     renamed: "dayOfWeekItemProvider(_:)")
-  public func withDayOfWeekItemProvider(
+  public func withDayOfWeekItemModelProvider(
     _ dayOfWeekItemProvider: @escaping (
       _ month: Month?,
       _ weekdayIndex: Int)
@@ -226,7 +226,7 @@ extension CalendarViewContent {
     *,
     deprecated,
     renamed: "dayItemProvider(_:)")
-  public func withDayItemProvider(
+  public func withDayItemModelProvider(
     _ dayItemProvider: @escaping (_ day: Day) -> AnyCalendarItemModel)
     -> CalendarViewContent
   {
@@ -259,7 +259,7 @@ extension CalendarViewContent {
     *,
     deprecated,
     renamed: "dayRangeItemProvider(for:_:)")
-  public func withDayRangeItemProvider(
+  public func withDayRangeItemModelProvider(
     for dateRanges: Set<ClosedRange<Date>>,
     _ dayRangeItemProvider: @escaping (
       _ dayRangeLayoutContext: DayRangeLayoutContext)
@@ -289,7 +289,7 @@ extension CalendarViewContent {
     *,
     deprecated,
     renamed: "overlayItemProvider(for:_:)")
-  public func withOverlayItemProvider(
+  public func withOverlayItemModelProvider(
     for overlaidItemLocations: Set<OverlaidItemLocation>,
     _ overlayItemProvider: @escaping (
       _ overlayLayoutContext: OverlayLayoutContext)


### PR DESCRIPTION
## Details

When I deprecated function names in favor of simpler, more concise names, I named some of the functions incorrectly in `Deprecations.swift`.

Original PR https://github.com/airbnb/HorizonCalendar/pull/156

`withMonthHeaderItemProvider` should have been `withMonthHeaderItem*Model*Provider`

## Related Issue

https://github.com/airbnb/HorizonCalendar/issues/159

## Motivation and Context

Fix build 🥲

## How Has This Been Tested

Reproduced broken build. This fixes it.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
