### PR TITLE
Fix scroll to day bounds check

### DIFF
--- a/HorizonCalendar.podspec
+++ b/HorizonCalendar.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name = "HorizonCalendar"
-  spec.version = "1.13.1"
+  spec.version = "1.13.2"
   spec.license = "Apache License, Version 2.0"
   spec.summary = "A declarative, performant, calendar UI component that supports use cases ranging from simple date pickers to fully-featured calendar apps."
 

--- a/HorizonCalendar.xcodeproj/project.pbxproj
+++ b/HorizonCalendar.xcodeproj/project.pbxproj
@@ -618,7 +618,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.13.1;
+				MARKETING_VERSION = 1.13.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.HorizonCalendar;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -652,7 +652,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.13.1;
+				MARKETING_VERSION = 1.13.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.HorizonCalendar;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Sources/Public/CalendarView.swift
+++ b/Sources/Public/CalendarView.swift
@@ -352,10 +352,10 @@ public final class CalendarView: UIView {
     animated: Bool)
   {
     let day = calendar.day(containing: dateInTargetDay)
-    guard content.monthRange.contains(day.month) else {
+    guard content.dayRange.contains(day) else {
       assertionFailure("""
         Attempted to scroll to day \(day), which is out of bounds of the total date range
-        \(content.monthRange).
+        \(content.dayRange).
       """)
       return
     }


### PR DESCRIPTION
## Details

This fixes an incorrect bounds check when attempting to scroll to a day. Logic was copied from the `scrollToMonth` function, which does not cover all cases for scrolling to a day. The specific case that's broken is:

1. Calendar is not showing complete month boundaries, so the first visible date could be something like 2022-01-16
2. An attempt is made to scroll to the day 2022-01-01

This should assert in scrollToDay. Without the proper bounds check, it makes it deeper into layout code and ends up hitting a `preconditionFailure` (should never be hit unless something else is wrong... guess that part worked lol) in `FrameProvider`.

## Related Issue

Internal Airbnb bug

## Motivation and Context

Fix crash

## How Has This Been Tested

Tested fix in Airbnb app and example app.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
