### PR TITLE
Remove unnecessary layout assert

### DIFF
--- a/HorizonCalendar.podspec
+++ b/HorizonCalendar.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name = "HorizonCalendar"
-  spec.version = "1.13.2"
+  spec.version = "1.13.3"
   spec.license = "Apache License, Version 2.0"
   spec.summary = "A declarative, performant, calendar UI component that supports use cases ranging from simple date pickers to fully-featured calendar apps."
 

--- a/HorizonCalendar.xcodeproj/project.pbxproj
+++ b/HorizonCalendar.xcodeproj/project.pbxproj
@@ -618,7 +618,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.13.2;
+				MARKETING_VERSION = 1.13.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.HorizonCalendar;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -652,7 +652,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.13.2;
+				MARKETING_VERSION = 1.13.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.HorizonCalendar;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Sources/Internal/FrameProvider.swift
+++ b/Sources/Internal/FrameProvider.swift
@@ -51,7 +51,9 @@ final class FrameProvider {
     let height = width * content.dayAspectRatio
     daySize = CGSize(width: width, height: height)
 
-    validateCalendarMetrics(size: size)
+    if daySize.width <= 0 || daySize.height <= 0 {
+      print("Calendar metrics and size resulted in a negative-or-zero size of (\(daySize.debugDescription) points for each day. If ignored, this will cause incorrect / unexpected layouts.")
+    }
   }
 
   // MARK: Internal
@@ -323,15 +325,6 @@ final class FrameProvider {
 
   private var monthsLayout: MonthsLayout {
     content.monthsLayout
-  }
-
-  private func validateCalendarMetrics(size: CGSize) {
-    assert(
-      daySize.width > 0,
-      """
-        Calendar metrics and size resulted in a negative-or-zero size of \(daySize.width) points for
-        each day. If ignored, this will cause very odd / incorrect layouts.
-      """)
   }
 
   private func minXOfItem(


### PR DESCRIPTION
## Details

This assert isn't really necessary - it's more of a warning. Just going to print something for now.

## Related Issue

N/A

## Motivation and Context

It's possible that a layout might resolve to be 0 height or 0 width initially, but later be corrected to have an actual width and height. This is probably an indication of bad layout code, but I'm not sure HorizonCalendar needs to be the police in this situation, especially since we'll ultimately render correctly as long as we get a > 0 width and height eventually.

## How Has This Been Tested

Simulator

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
