### PR TITLE
Fix layout after layout metric is changed

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -13,12 +13,12 @@ jobs:
 
     strategy:
       matrix:
-        destination: ['platform=iOS Simulator,OS=11.0,name=iPhone 8', 'platform=iOS Simulator,OS=15.0,name=iPhone 12']
+        destination: ['platform=iOS Simulator,OS=11.0,name=iPhone 8', 'platform=iOS Simulator,OS=15.2,name=iPhone 12']
 
     steps:
     - uses: actions/checkout@v2
     - name: Build
       run: xcodebuild clean build -scheme HorizonCalendar
     - name: Run tests
-      run: xcodebuild clean test -project HorizonCalendar.xcodeproj -scheme HorizonCalendar -destination "name=iPhone 8,OS=15.0"
+      run: xcodebuild clean test -project HorizonCalendar.xcodeproj -scheme HorizonCalendar -destination "name=iPhone 8,OS=15.2"
 

--- a/HorizonCalendar.podspec
+++ b/HorizonCalendar.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name = "HorizonCalendar"
-  spec.version = "1.13.3"
+  spec.version = "1.13.4"
   spec.license = "Apache License, Version 2.0"
   spec.summary = "A declarative, performant, calendar UI component that supports use cases ranging from simple date pickers to fully-featured calendar apps."
 

--- a/HorizonCalendar.xcodeproj/project.pbxproj
+++ b/HorizonCalendar.xcodeproj/project.pbxproj
@@ -618,7 +618,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.13.3;
+				MARKETING_VERSION = 1.13.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.HorizonCalendar;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -652,7 +652,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.13.3;
+				MARKETING_VERSION = 1.13.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.HorizonCalendar;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Sources/Internal/VisibleItemsProvider.swift
+++ b/Sources/Internal/VisibleItemsProvider.swift
@@ -149,8 +149,18 @@ final class VisibleItemsProvider {
     var handledDayRanges = Set<DayRange>()
 
     var originsForMonths = [Month: CGPoint]()
-    var lastHandledLayoutItemEnumeratingBackwards = previouslyVisibleLayoutItem
-    var lastHandledLayoutItemEnumeratingForwards = previouslyVisibleLayoutItem
+
+    // Creating a new starting layout item based on our previous visible layout item allows us to
+    // ensure that the most up-to-date layout metrics (day aspect ratio, margins, etc) are taken
+    // into account. If layout metrics were just updated, then our previously visible layout item
+    // could still have old values, leading to a slightly incorrect layout.
+    let startingLayoutItem = layoutItem(
+      for: previouslyVisibleLayoutItem.itemType,
+      lastHandledLayoutItem: previouslyVisibleLayoutItem,
+      originsForMonths: &originsForMonths)
+
+    var lastHandledLayoutItemEnumeratingBackwards = startingLayoutItem
+    var lastHandledLayoutItemEnumeratingForwards = startingLayoutItem
 
     layoutItemTypeEnumerator.enumerateItemTypes(
       startingAt: previouslyVisibleLayoutItem.itemType,

--- a/Sources/Public/CalendarView.swift
+++ b/Sources/Public/CalendarView.swift
@@ -237,8 +237,6 @@ public final class CalendarView: UIView {
   /// - Parameters:
   ///   - content: The content to use when rendering `CalendarView`.
   public func setContent(_ content: CalendarViewContent) {
-    self.content = content
-
     if let contentBackgroundColor = content.backgroundColor {
       backgroundColor = contentBackgroundColor
     }
@@ -268,6 +266,19 @@ public final class CalendarView: UIView {
       scrollView.decelerationRate = .normal
     }
 
+    let oldContent = self.content
+
+    if
+      oldContent.monthsLayout != content.monthsLayout ||
+      oldContent.monthDayInsets != content.monthDayInsets ||
+      oldContent.dayAspectRatio != content.dayAspectRatio ||
+      oldContent.horizontalDayMargin != content.horizontalDayMargin ||
+      oldContent.verticalDayMargin != content.verticalDayMargin
+    {
+      invalidateIntrinsicContentSize()
+    }
+
+    self.content = content
     setNeedsLayout()
   }
 

--- a/Tests/VisibleItemsProviderTests.swift
+++ b/Tests/VisibleItemsProviderTests.swift
@@ -284,6 +284,93 @@ final class VisibleItemsProviderTests: XCTestCase {
 
   // MARK: Scrolled to middle of content tests
 
+  func testVisibleItemsContextAfterMetricsChange() {
+    let anchorLayoutItem = verticalVisibleItemsProvider.detailsForVisibleItems(
+      surroundingPreviouslyVisibleLayoutItem: LayoutItem(
+        itemType: .monthHeader(Month(era: 1, year: 2020, month: 03, isInGregorianCalendar: true)),
+        frame: CGRect(x: 0, y: 200, width: 320, height: 50)),
+      offset: CGPoint(x: 0, y: 150))
+      .centermostLayoutItem
+    let details = verticalShortDayAspectRatioVisibleItemsProvider.detailsForVisibleItems(
+      surroundingPreviouslyVisibleLayoutItem: anchorLayoutItem,
+      offset: CGPoint(x: 0, y: 150))
+
+    let expectedVisibleItemDescriptions: Set<String> = [
+      "[itemType: .layoutItemType(.day(2020-03-02)), frame: (50.5, 371.5, 36.0, 18.0)]",
+      "[itemType: .layoutItemType(.dayOfWeekInMonth(.sixth, 2020-03)), frame: (233.5, 333.5, 36.0, 18.0)]",
+      "[itemType: .layoutItemType(.day(2020-03-17)), frame: (96.5, 447.0, 35.5, 18.0)]",
+      "[itemType: .layoutItemType(.day(2020-02-21)), frame: (233.5, 183.0, 36.0, 17.5)]",
+      "[itemType: .layoutItemType(.day(2020-03-05)), frame: (188.0, 371.5, 35.5, 18.0)]",
+      "[itemType: .layoutItemType(.day(2020-02-25)), frame: (96.5, 220.5, 35.5, 18.0)]",
+      "[itemType: .daysOfWeekRowSeparator(2020-3), frame: (-0.0, 350.5, 320.0, 1.0)]",
+      "[itemType: .layoutItemType(.day(2020-02-09)), frame: (5.0, 145.0, 35.5, 18.0)]",
+      "[itemType: .layoutItemType(.day(2020-02-19)), frame: (142.0, 183.0, 36.0, 17.5)]",
+      "[itemType: .layoutItemType(.day(2020-03-29)), frame: (5.0, 523.0, 35.5, 17.5)]",
+      "[itemType: .layoutItemType(.day(2020-02-28)), frame: (233.5, 220.5, 36.0, 18.0)]",
+      "[itemType: .layoutItemType(.day(2020-03-24)), frame: (96.5, 485.0, 35.5, 18.0)]",
+      "[itemType: .layoutItemType(.day(2020-02-16)), frame: (5.0, 183.0, 35.5, 17.5)]",
+      "[itemType: .layoutItemType(.day(2020-02-22)), frame: (279.5, 183.0, 35.5, 17.5)]",
+      "[itemType: .layoutItemType(.day(2020-03-08)), frame: (5.0, 409.5, 35.5, 17.5)]",
+      "[itemType: .layoutItemType(.dayOfWeekInMonth(.third, 2020-03)), frame: (96.5, 333.5, 35.5, 18.0)]",
+      "[itemType: .layoutItemType(.day(2020-02-18)), frame: (96.5, 183.0, 35.5, 17.5)]",
+      "[itemType: .daysOfWeekRowSeparator(2020-4), frame: (0.0, 652.5, 320.0, 1.0)]",
+      "[itemType: .layoutItemType(.day(2020-03-15)), frame: (5.0, 447.0, 35.5, 18.0)]",
+      "[itemType: .layoutItemType(.day(2020-03-04)), frame: (142.0, 371.5, 36.0, 18.0)]",
+      "[itemType: .layoutItemType(.day(2020-03-11)), frame: (142.0, 409.5, 36.0, 17.5)]",
+      "[itemType: .layoutItemType(.monthHeader(2020-04)), frame: (0.0, 555.5, 320.0, 50.0)]",
+      "[itemType: .layoutItemType(.dayOfWeekInMonth(.first, 2020-03)), frame: (5.0, 333.5, 35.5, 18.0)]",
+      "[itemType: .layoutItemType(.day(2020-03-07)), frame: (279.5, 371.5, 35.5, 18.0)]",
+      "[itemType: .layoutItemType(.day(2020-03-28)), frame: (279.5, 485.0, 35.5, 18.0)]",
+      "[itemType: .layoutItemType(.day(2020-02-29)), frame: (279.5, 220.5, 35.5, 18.0)]",
+      "[itemType: .layoutItemType(.day(2020-02-13)), frame: (188.0, 145.0, 35.5, 18.0)]",
+      "[itemType: .layoutItemType(.day(2020-02-17)), frame: (50.5, 183.0, 36.0, 17.5)]",
+      "[itemType: .layoutItemType(.dayOfWeekInMonth(.fifth, 2020-03)), frame: (188.0, 333.5, 35.5, 18.0)]",
+      "[itemType: .layoutItemType(.day(2020-02-23)), frame: (5.0, 220.5, 35.5, 18.0)]",
+      "[itemType: .layoutItemType(.monthHeader(2020-03)), frame: (0.0, 253.5, 320.0, 50.0)]",
+      "[itemType: .layoutItemType(.day(2020-03-18)), frame: (142.0, 447.0, 36.0, 18.0)]",
+      "[itemType: .layoutItemType(.day(2020-03-01)), frame: (5.0, 371.5, 35.5, 18.0)]",
+      "[itemType: .layoutItemType(.day(2020-03-20)), frame: (233.5, 447.0, 36.0, 18.0)]",
+      "[itemType: .layoutItemType(.day(2020-03-31)), frame: (96.5, 523.0, 35.5, 17.5)]",
+      "[itemType: .layoutItemType(.day(2020-03-10)), frame: (96.5, 409.5, 35.5, 17.5)]",
+      "[itemType: .layoutItemType(.day(2020-03-22)), frame: (5.0, 485.0, 35.5, 18.0)]",
+      "[itemType: .layoutItemType(.day(2020-02-24)), frame: (50.5, 220.5, 36.0, 18.0)]",
+      "[itemType: .layoutItemType(.day(2020-03-26)), frame: (188.0, 485.0, 35.5, 18.0)]",
+      "[itemType: .layoutItemType(.day(2020-02-12)), frame: (142.0, 145.0, 36.0, 18.0)]",
+      "[itemType: .layoutItemType(.day(2020-03-30)), frame: (50.5, 523.0, 36.0, 17.5)]",
+      "[itemType: .layoutItemType(.day(2020-03-16)), frame: (50.5, 447.0, 36.0, 18.0)]",
+      "[itemType: .layoutItemType(.day(2020-02-14)), frame: (233.5, 145.0, 36.0, 18.0)]",
+      "[itemType: .layoutItemType(.dayOfWeekInMonth(.second, 2020-03)), frame: (50.5, 333.5, 36.0, 18.0)]",
+      "[itemType: .layoutItemType(.day(2020-03-09)), frame: (50.5, 409.5, 36.0, 17.5)]",
+      "[itemType: .layoutItemType(.day(2020-02-20)), frame: (188.0, 183.0, 35.5, 17.5)]",
+      "[itemType: .layoutItemType(.day(2020-02-11)), frame: (96.5, 145.0, 35.5, 18.0)]",
+      "[itemType: .layoutItemType(.day(2020-03-06)), frame: (233.5, 371.5, 36.0, 18.0)]",
+      "[itemType: .layoutItemType(.day(2020-02-15)), frame: (279.5, 145.0, 35.5, 18.0)]",
+      "[itemType: .layoutItemType(.day(2020-02-26)), frame: (142.0, 220.5, 36.0, 18.0)]",
+      "[itemType: .layoutItemType(.day(2020-02-10)), frame: (50.5, 145.0, 36.0, 18.0)]",
+      "[itemType: .layoutItemType(.day(2020-03-25)), frame: (142.0, 485.0, 36.0, 18.0)]",
+      "[itemType: .layoutItemType(.day(2020-02-27)), frame: (188.0, 220.5, 35.5, 18.0)]",
+      "[itemType: .layoutItemType(.day(2020-03-27)), frame: (233.5, 485.0, 36.0, 18.0)]",
+      "[itemType: .layoutItemType(.day(2020-03-03)), frame: (96.5, 371.5, 35.5, 18.0)]",
+      "[itemType: .layoutItemType(.day(2020-03-19)), frame: (188.0, 447.0, 35.5, 18.0)]",
+      "[itemType: .layoutItemType(.day(2020-03-21)), frame: (279.5, 447.0, 35.5, 18.0)]",
+      "[itemType: .layoutItemType(.day(2020-03-12)), frame: (188.0, 409.5, 35.5, 17.5)]",
+      "[itemType: .layoutItemType(.day(2020-03-13)), frame: (233.5, 409.5, 36.0, 17.5)]",
+      "[itemType: .dayRange(2020-03-11, 2020-04-05), frame: (5.0, 409.5, 310.0, 320.0)]",
+      "[itemType: .layoutItemType(.dayOfWeekInMonth(.last, 2020-03)), frame: (279.5, 333.5, 35.5, 18.0)]",
+      "[itemType: .layoutItemType(.day(2020-03-14)), frame: (279.5, 409.5, 35.5, 17.5)]",
+      "[itemType: .layoutItemType(.dayOfWeekInMonth(.fourth, 2020-03)), frame: (142.0, 333.5, 36.0, 18.0)]",
+      "[itemType: .layoutItemType(.day(2020-03-23)), frame: (50.5, 485.0, 36.0, 18.0)]",
+    ]
+
+    XCTAssert(
+      Set(details.visibleItems.map { $0.description }) == expectedVisibleItemDescriptions,
+      "Unexpected visible items.")
+
+    XCTAssert(
+      details.centermostLayoutItem.description == "[itemType: .layoutItemType(.day(2020-03-04)), frame: (142.0, 371.5, 36.0, 18.0)]",
+      "Unexpected centermost layout item.")
+  }
+
   func testVerticalVisibleItemsContext() {
     let details = verticalVisibleItemsProvider.detailsForVisibleItems(
       surroundingPreviouslyVisibleLayoutItem: LayoutItem(
@@ -1605,6 +1692,20 @@ final class VisibleItemsProviderTests: XCTestCase {
         calendar: calendar,
         visibleDateRange: dateRange,
         monthsLayout: .vertical(options: VerticalMonthsLayoutOptions()))),
+    size: size,
+    layoutMargins: .zero,
+    scale: 2,
+    monthHeaderHeight: 50,
+    backgroundColor: nil)
+
+  private var verticalShortDayAspectRatioVisibleItemsProvider = VisibleItemsProvider(
+    calendar: calendar,
+    content: makeContent(
+      fromBaseContent: CalendarViewContent(
+        calendar: calendar,
+        visibleDateRange: dateRange,
+        monthsLayout: .vertical(options: VerticalMonthsLayoutOptions())))
+      .dayAspectRatio(0.5),
     size: size,
     layoutMargins: .zero,
     scale: 2,


### PR DESCRIPTION
## Details

This PR fixes an issue where the calendar would layout with old metrics (day aspect ratio, vertical / horizontal spacing, etc) on the first layout after changing one of those metrics. This was due to the calendar using an existing, stale layout item as the basis for the new layout pass (due to how the calendar lays out in both directions from an existing, known item). The fix for this is pretty simple - we should just recreate our starting layout item using the latest metrics then layout based on that.

## Related Issue

N/A

## Motivation and Context

Bug fix.

## How Has This Been Tested

Tested in simulator and added a unit test.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
