### PR TITLE
Add support for custom day shape

### DIFF
--- a/Example/HorizonCalendarExample/HorizonCalendarExample.xcodeproj/project.pbxproj
+++ b/Example/HorizonCalendarExample/HorizonCalendarExample.xcodeproj/project.pbxproj
@@ -90,7 +90,9 @@
 				939E69682484CD8E00A8BCC7 /* Products */,
 				939E69902484D11000A8BCC7 /* Frameworks */,
 			);
+			indentWidth = 2;
 			sourceTree = "<group>";
+			tabWidth = 2;
 		};
 		939E69682484CD8E00A8BCC7 /* Products */ = {
 			isa = PBXGroup;

--- a/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/DayRangeSelectionDemoViewController.swift
+++ b/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/DayRangeSelectionDemoViewController.swift
@@ -80,6 +80,9 @@ final class DayRangeSelectionDemoViewController: DemoViewController {
 
       .dayItemProvider { [calendar, dayDateFormatter] day in
         var invariantViewProperties = DayView.InvariantViewProperties.baseInteractive
+        invariantViewProperties.shape = .custom({ bounds in
+          .diamond(bounds: bounds, cornerRadius: 2)
+        })
 
         let isSelectedStyle: Bool
         switch calendarSelection {
@@ -121,4 +124,16 @@ final class DayRangeSelectionDemoViewController: DemoViewController {
   }
   private var calendarSelection: CalendarSelection?
 
+}
+
+private extension UIBezierPath {
+  static func diamond(bounds: CGRect, cornerRadius: CGFloat) -> UIBezierPath {
+    let path = UIBezierPath()
+    path.move(to: CGPoint(x: bounds.midX, y: bounds.minY + cornerRadius))
+    path.addLine(to: CGPoint(x: bounds.maxX - cornerRadius, y: bounds.midY))
+    path.addLine(to: CGPoint(x: bounds.midX, y: bounds.maxY - cornerRadius))
+    path.addLine(to: CGPoint(x: bounds.minX + cornerRadius, y: bounds.midY))
+    path.close()
+    return path
+  }
 }

--- a/Sources/Public/Item Views/DayOfWeekView.swift
+++ b/Sources/Public/Item Views/DayOfWeekView.swift
@@ -75,6 +75,8 @@ public final class DayOfWeekView: UIView {
 
     case .rectangle(let cornerRadius):
       path = UIBezierPath(roundedRect: insetBounds, cornerRadius: cornerRadius).cgPath
+    case .custom(let closure):
+      path = closure(insetBounds).cgPath
     }
 
     backgroundLayer.path = path

--- a/Sources/Public/Item Views/DayView.swift
+++ b/Sources/Public/Item Views/DayView.swift
@@ -101,6 +101,8 @@ public final class DayView: UIView {
 
     case .rectangle(let cornerRadius):
       path = UIBezierPath(roundedRect: insetBounds, cornerRadius: cornerRadius).cgPath
+    case .custom(let closure):
+      path = closure(insetBounds).cgPath
     }
 
     backgroundLayer.path = path

--- a/Sources/Public/Item Views/Shape.swift
+++ b/Sources/Public/Item Views/Shape.swift
@@ -14,9 +14,39 @@
 // limitations under the License.
 
 import CoreGraphics
+import UIKit.UIBezierPath
 
 /// Represents a background or highlight layer shape; used by `DayView` and `DayOfWeekView`.
-public enum Shape: Hashable {
+public enum Shape {
   case circle
   case rectangle(cornerRadius: CGFloat = 0)
+  case custom((CGRect) -> UIBezierPath)
+}
+
+extension Shape: Hashable {
+  public func hash(into hasher: inout Hasher) {
+    switch self {
+    case .circle:
+      break
+    case .rectangle(let cornerRadius):
+      hasher.combine(cornerRadius)
+    case .custom:
+      break
+    }
+  }
+}
+
+extension Shape: Equatable {
+  public static func == (lhs: Shape, rhs: Shape) -> Bool {
+    switch (lhs, rhs) {
+    case (.circle, .circle):
+      return true
+    case (.rectangle, .rectangle):
+      return true
+    case (.custom, .custom):
+      return true
+    default:
+      return false
+    }
+  }
 }


### PR DESCRIPTION
## Details

Adding support for other day view shapes besides circle & rectangle.

<img src=https://user-images.githubusercontent.com/274318/181201589-de840a5d-4142-4ac3-8821-958c7292de1a.png width=240>

## Motivation and Context

We wish to use diamond shape day selector. Rather than adding specific shape needs, this allows defining a closure for any `UIBezierPath` for a given bounds. 

## How Has This Been Tested

Tested in iOS simulator.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
