### PR TITLE
Support the system scroll-to-top gesture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,4 @@ fastlane/test_output
 *.xcuserstate
 xcshareddata
 UserInterfaceState.xcuserstate
+.DS_Store

--- a/Example/HorizonCalendarExample/HorizonCalendarExample/DemoPickerViewController.swift
+++ b/Example/HorizonCalendarExample/HorizonCalendarExample/DemoPickerViewController.swift
@@ -140,7 +140,8 @@ extension DemoPickerViewController: UITableViewDelegate {
         ? .vertical(
           options: VerticalMonthsLayoutOptions(
             pinDaysOfWeekToTop: false,
-            alwaysShowCompleteBoundaryMonths: false))
+            alwaysShowCompleteBoundaryMonths: false,
+            scrollsToFirstMonthOnStatusBarTap: false))
         : .horizontal(
           options: HorizontalMonthsLayoutOptions(
             maximumFullyVisibleMonths: 1.5,

--- a/HorizonCalendar.podspec
+++ b/HorizonCalendar.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name = "HorizonCalendar"
-  spec.version = "1.13.4"
+  spec.version = "1.14.0"
   spec.license = "Apache License, Version 2.0"
   spec.summary = "A declarative, performant, calendar UI component that supports use cases ranging from simple date pickers to fully-featured calendar apps."
 

--- a/HorizonCalendar.xcodeproj/project.pbxproj
+++ b/HorizonCalendar.xcodeproj/project.pbxproj
@@ -618,7 +618,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.13.4;
+				MARKETING_VERSION = 1.14.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.HorizonCalendar;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -652,7 +652,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.13.4;
+				MARKETING_VERSION = 1.14.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.HorizonCalendar;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Sources/Public/CalendarView.swift
+++ b/Sources/Public/CalendarView.swift
@@ -422,7 +422,6 @@ public final class CalendarView: UIView {
 
   private lazy var scrollView: NoContentInsetAdjustmentScrollView = {
     let scrollView = NoContentInsetAdjustmentScrollView()
-    scrollView.scrollsToTop = false
     scrollView.showsVerticalScrollIndicator = false
     scrollView.showsHorizontalScrollIndicator = false
     scrollView.delegate = self
@@ -762,7 +761,7 @@ public final class CalendarView: UIView {
     case (.before, .after), (.after, .before):
       finalizeScrollingTowardItem(for: scrollToItemContext)
 
-      // Force layout immdiately to prevent the overshoot from being visible to the user.
+      // Force layout immediately to prevent the overshoot from being visible to the user.
       setNeedsLayout()
       layoutIfNeeded()
 
@@ -988,6 +987,23 @@ extension CalendarView: UIScrollViewDelegate {
         velocity: velocity.x,
         pageSize: pageSize)
     }
+  }
+
+  @available(
+    *,
+    deprecated,
+    message: "Do not invoke this function directly, as it is only intended to be called from the internal implementation of `CalendarView`. This will be removed in a future major release.")
+  public func scrollViewShouldScrollToTop(_ scrollView: UIScrollView) -> Bool {
+    if content.monthsLayout.scrollsToFirstMonthOnStatusBarTap {
+      let firstMonth = content.monthRange.lowerBound
+      let firstDate = calendar.firstDate(of: firstMonth)
+      scroll(
+        toMonthContaining: firstDate,
+        scrollPosition: .firstFullyVisiblePosition(padding: 0),
+        animated: true)
+    }
+
+    return false
   }
 
 }

--- a/Sources/Public/MonthsLayout.swift
+++ b/Sources/Public/MonthsLayout.swift
@@ -64,6 +64,13 @@ public enum MonthsLayout {
 
     return true
   }
+
+  var scrollsToFirstMonthOnStatusBarTap: Bool {
+    switch self {
+    case .vertical(let options): return options.scrollsToFirstMonthOnStatusBarTap
+    case .horizontal: return false
+    }
+  }
 }
 
 // MARK: Equatable
@@ -94,9 +101,16 @@ public struct VerticalMonthsLayoutOptions: Equatable {
   ///   The default value is `false`.
   ///   - alwaysShowCompleteBoundaryMonths: Whether the calendar will always show complete months, even if the visible
   ///   date range does not start on the first date or end on the last date of a month. The default value is `true`.
-  public init(pinDaysOfWeekToTop: Bool = false, alwaysShowCompleteBoundaryMonths: Bool = true) {
+  ///   - scrollsToFirstMonthOnStatusBarTap: Whether the calendar should scroll to the first month when the system
+  ///   status bar is tapped. The default value is `false`.
+  public init(
+    pinDaysOfWeekToTop: Bool = false,
+    alwaysShowCompleteBoundaryMonths: Bool = true,
+    scrollsToFirstMonthOnStatusBarTap: Bool = false)
+  {
     self.pinDaysOfWeekToTop = pinDaysOfWeekToTop
     self.alwaysShowCompleteBoundaryMonths = alwaysShowCompleteBoundaryMonths
+    self.scrollsToFirstMonthOnStatusBarTap = scrollsToFirstMonthOnStatusBarTap
   }
 
   // MARK: Public
@@ -107,6 +121,9 @@ public struct VerticalMonthsLayoutOptions: Equatable {
   /// Whether the calendar will always show complete months at the calendar's boundaries, even if the visible date range does not start
   /// on the first date or end on the last date of a month.
   public let alwaysShowCompleteBoundaryMonths: Bool
+
+  /// Whether the calendar should scroll to the first month when the system status bar is tapped.
+  public let scrollsToFirstMonthOnStatusBarTap: Bool
 
 }
 


### PR DESCRIPTION
## Details

This PR adds support for the system scroll-to-top gesture. Since `HorizonCalendar` handles programmatic scrolling in a custom way, we need to intercept the scroll-to-top request and perform the programmatic scroll ourselves.

## Related Issue

N/A

## Motivation and Context

Airbnb app need

## How Has This Been Tested

Demo app

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
