### PR TITLE
Fix navigation bar transparency

### DIFF
--- a/Sources/Public/CalendarView.swift
+++ b/Sources/Public/CalendarView.swift
@@ -57,8 +57,11 @@ public final class CalendarView: UIView {
       backgroundColor = .white
     }
 
-    installDoubleLayoutPassSizingLabel()
+    // Must be the first subview so that `UINavigationController` can monitor its scroll position
+    // and make navigation bars opaque on scroll.
     addSubview(scrollView)
+
+    installDoubleLayoutPassSizingLabel()
 
     setContent(initialContent)
 

--- a/Sources/Public/CalendarView.swift
+++ b/Sources/Public/CalendarView.swift
@@ -59,7 +59,7 @@ public final class CalendarView: UIView {
 
     // Must be the first subview so that `UINavigationController` can monitor its scroll position
     // and make navigation bars opaque on scroll.
-    addSubview(scrollView)
+    insertSubview(scrollView, at: 0)
 
     installDoubleLayoutPassSizingLabel()
 


### PR DESCRIPTION
## Details

This fixes navigation bar transparency (when scrolling). This regression was introduced when I added a double-layout-pass sizing `UILabel` to make working with horizontal calendars easier (in https://github.com/airbnb/HorizonCalendar/pull/150). UIKit seems to only observe the scroll position of the first subview of a view, so if the label is subview 0 and the scroll view is subview 1, then the navigation bar doesn't adjust its transparency on scroll. This wasn't an issue on iOS 14, but iOS 15 seems to change the nav bar style a bit.

| Before | After |
| ---- | ---- |
|  ![Simulator Screen Shot - iPhone 13 Pro - 2022-08-22 at 12 51 27](https://user-images.githubusercontent.com/746571/186007521-2ac01f6e-64e2-49a2-be8b-c64392044f3e.png)| ![Simulator Screen Shot - iPhone 13 Pro - 2022-08-22 at 12 51 02](https://user-images.githubusercontent.com/746571/186007556-17737edb-435e-4363-a4b3-02187478864e.png) | 

## Related Issue

N/A

## Motivation and Context

A bug I noticed in the example app.

## How Has This Been Tested

Example app

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
