### PR TITLE
Use displayScale instead of UIScreen APIs

### DIFF
--- a/HorizonCalendar.podspec
+++ b/HorizonCalendar.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name = "HorizonCalendar"
-  spec.version = "1.14.0"
+  spec.version = "1.14.1"
   spec.license = "Apache License, Version 2.0"
   spec.summary = "A declarative, performant, calendar UI component that supports use cases ranging from simple date pickers to fully-featured calendar apps."
 

--- a/HorizonCalendar.xcodeproj/project.pbxproj
+++ b/HorizonCalendar.xcodeproj/project.pbxproj
@@ -618,7 +618,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.14.0;
+				MARKETING_VERSION = 1.14.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.HorizonCalendar;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -652,7 +652,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.14.0;
+				MARKETING_VERSION = 1.14.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.HorizonCalendar;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Sources/Internal/ScreenPixelAlignment.swift
+++ b/Sources/Internal/ScreenPixelAlignment.swift
@@ -23,7 +23,7 @@ extension CGFloat {
   }
   
   /// Tests `self` for approximate equality using the threshold value. For example, 1.48 equals 1.52 if the threshold is 0.05.
-  /// `threshold` will be treated as a postive value by taking its absolute value.
+  /// `threshold` will be treated as a positive value by taking its absolute value.
   func isEqual(to rhs: CGFloat, threshold: CGFloat) -> Bool {
     abs(self - rhs) <= abs(threshold)
   }

--- a/Sources/Public/CalendarView.swift
+++ b/Sources/Public/CalendarView.swift
@@ -452,7 +452,11 @@ public final class CalendarView: UIView {
   }
 
   private var scale: CGFloat {
-    window?.screen.scale ?? UIScreen.main.scale
+    let scale = traitCollection.displayScale
+    // The documentation mentions that 0 is a possible value, so we guard against this.
+    // It's unclear whether values between 0 and 1 are possible, otherwise `max(scale, 1)` would
+    // suffice.
+    return scale > 0 ? scale : 1
   }
 
   private var scrollMetricsMutator: ScrollMetricsMutator {


### PR DESCRIPTION
## Details

`UIScreen.main` is being deprecated in iOS 16. We should be able to just use the trait collection's `displayScale` property. All seems to work correctly in my testing.

## Related Issue

N/A

## Motivation and Context

Adopting latest APIs.

## How Has This Been Tested

Example app

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
