### PR TITLE
Support animated setContent updates

### DIFF
--- a/HorizonCalendar.podspec
+++ b/HorizonCalendar.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name = "HorizonCalendar"
-  spec.version = "1.14.1"
+  spec.version = "1.14.2"
   spec.license = "Apache License, Version 2.0"
   spec.summary = "A declarative, performant, calendar UI component that supports use cases ranging from simple date pickers to fully-featured calendar apps."
 

--- a/HorizonCalendar.xcodeproj/project.pbxproj
+++ b/HorizonCalendar.xcodeproj/project.pbxproj
@@ -64,6 +64,7 @@
 		93FA64EE248D7B0100A8B7B1 /* DayHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93FA64ED248D7B0100A8B7B1 /* DayHelperTests.swift */; };
 		93FA64F0248D84FE00A8B7B1 /* DayOfWeekPositionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93FA64EF248D84FE00A8B7B1 /* DayOfWeekPositionTests.swift */; };
 		93FA64F2248D93EA00A8B7B1 /* MonthRowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93FA64F1248D93EA00A8B7B1 /* MonthRowTests.swift */; };
+		FD3D9B6128ED2C1500CC6D62 /* UIView+NoAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD3D9B6028ED2C1500CC6D62 /* UIView+NoAnimation.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -137,6 +138,7 @@
 		93FA64ED248D7B0100A8B7B1 /* DayHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DayHelperTests.swift; sourceTree = "<group>"; };
 		93FA64EF248D84FE00A8B7B1 /* DayOfWeekPositionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DayOfWeekPositionTests.swift; sourceTree = "<group>"; };
 		93FA64F1248D93EA00A8B7B1 /* MonthRowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonthRowTests.swift; sourceTree = "<group>"; };
+		FD3D9B6028ED2C1500CC6D62 /* UIView+NoAnimation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+NoAnimation.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -275,6 +277,7 @@
 				939E691C24837E0200A8BCC7 /* VisibleCalendarItem.swift */,
 				939E691A24837E0200A8BCC7 /* VisibleItemsProvider.swift */,
 				933992982736562C00C80380 /* DoubleLayoutPassHelpers.swift */,
+				FD3D9B6028ED2C1500CC6D62 /* UIView+NoAnimation.swift */,
 			);
 			path = Internal;
 			sourceTree = "<group>";
@@ -438,6 +441,7 @@
 				939E69442484784D00A8BCC7 /* Calendar+Helpers.swift in Sources */,
 				939E692824837E0300A8BCC7 /* ItemView.swift in Sources */,
 				9391F15625C097DF001D14A2 /* PaginationHelpers.swift in Sources */,
+				FD3D9B6128ED2C1500CC6D62 /* UIView+NoAnimation.swift in Sources */,
 				93B6D99E24F0C6220027A60C /* InternalAnyCalendarItemModel.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -618,7 +622,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.14.1;
+				MARKETING_VERSION = 1.14.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.HorizonCalendar;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -652,7 +656,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.14.1;
+				MARKETING_VERSION = 1.14.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.HorizonCalendar;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Sources/Internal/ItemViewReuseManager.swift
+++ b/Sources/Internal/ItemViewReuseManager.swift
@@ -28,7 +28,8 @@ final class ItemViewReuseManager {
     viewHandler: (
       ItemView,
       VisibleCalendarItem,
-      _ previousBackingVisibleItem: VisibleCalendarItem?)
+      _ previousBackingVisibleItem: VisibleCalendarItem?,
+      _ isReusedViewSameAsPreviousView: Bool)
       -> Void)
   {
     var visibleItemsDifferencesItemViewDifferentiators = [
@@ -56,7 +57,11 @@ final class ItemViewReuseManager {
       let context = reusedViewContext(
         for: visibleItem,
         unusedPreviouslyVisibleItems: &visibleItemsDifference)
-      viewHandler(context.view, visibleItem, context.previousBackingVisibleItem)
+      viewHandler(
+        context.view,
+        visibleItem,
+        context.previousBackingVisibleItem,
+        context.isReusedViewSameAsPreviousView)
 
       visibleItemsDifferencesItemViewDifferentiators[differentiator] = visibleItemsDifference
     }
@@ -78,6 +83,7 @@ final class ItemViewReuseManager {
 
     let view: ItemView
     let previousBackingVisibleItem: VisibleCalendarItem?
+    let isReusedViewSameAsPreviousView: Bool
 
     if let previouslyVisibleItems = visibleItemsForItemViewDifferentiators[differentiator] {
       if previouslyVisibleItems.contains(visibleItem) {
@@ -92,6 +98,7 @@ final class ItemViewReuseManager {
 
         view = previousView
         previousBackingVisibleItem = visibleItem
+        isReusedViewSameAsPreviousView = true
 
         visibleItemsForItemViewDifferentiators[differentiator]?.remove(visibleItem)
         viewsForVisibleItems.removeValue(forKey: visibleItem)
@@ -108,6 +115,7 @@ final class ItemViewReuseManager {
 
           view = previousView
           previousBackingVisibleItem = previouslyVisibleItem
+          isReusedViewSameAsPreviousView = false
 
           unusedPreviouslyVisibleItems.remove(previouslyVisibleItem)
 
@@ -117,6 +125,7 @@ final class ItemViewReuseManager {
           // No previously-visible item is available for reuse, so create a new view.
           view = ItemView(initialCalendarItemModel: visibleItem.calendarItemModel)
           previousBackingVisibleItem = nil
+          isReusedViewSameAsPreviousView = false
         }
       }
     }
@@ -124,6 +133,7 @@ final class ItemViewReuseManager {
       // No previously-visible item is available for reuse, so create a new view.
       view = ItemView(initialCalendarItemModel: visibleItem.calendarItemModel)
       previousBackingVisibleItem = nil
+      isReusedViewSameAsPreviousView = false
     }
 
     let newVisibleItems = visibleItemsForItemViewDifferentiators[differentiator] ?? []
@@ -131,7 +141,10 @@ final class ItemViewReuseManager {
     visibleItemsForItemViewDifferentiators[differentiator]?.insert(visibleItem)
     viewsForVisibleItems[visibleItem] = view
 
-    return ReusedViewContext(view: view, previousBackingVisibleItem: previousBackingVisibleItem)
+    return ReusedViewContext(
+      view: view,
+      previousBackingVisibleItem: previousBackingVisibleItem,
+      isReusedViewSameAsPreviousView: isReusedViewSameAsPreviousView)
   }
 
 }
@@ -141,4 +154,5 @@ final class ItemViewReuseManager {
 private struct ReusedViewContext {
   let view: ItemView
   let previousBackingVisibleItem: VisibleCalendarItem?
+  let isReusedViewSameAsPreviousView: Bool
 }

--- a/Sources/Internal/UIView+NoAnimation.swift
+++ b/Sources/Internal/UIView+NoAnimation.swift
@@ -1,0 +1,31 @@
+// Created by Bryan Keller on 10/4/22.
+// Copyright © 2022 Airbnb Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import UIKit
+
+extension UIView {
+
+  static func conditionallyPerformWithoutAnimation(
+    when condition: Bool,
+    _ actions: () -> Void)
+  {
+    if condition {
+      UIView.performWithoutAnimation(actions)
+    } else {
+      actions()
+    }
+  }
+
+}

--- a/Sources/Public/CalendarView.swift
+++ b/Sources/Public/CalendarView.swift
@@ -627,14 +627,14 @@ public final class CalendarView: UIView {
 
     reuseManager.viewsForVisibleItems(
       visibleItems,
-      viewHandler: { view, visibleItem, previousBackingVisibleItem in
-        if view.superview == nil {
-          UIView.performWithoutAnimation {
+      viewHandler: { view, visibleItem, previousBackingVisibleItem, isReusedViewSameAsPreviousView in
+        UIView.conditionallyPerformWithoutAnimation(when: !isReusedViewSameAsPreviousView) {
+          if view.superview == nil {
             scrollView.addSubview(view)
           }
-        }
 
-        configureView(view, with: visibleItem)
+          configureView(view, with: visibleItem)
+        }
 
         visibleViewsForVisibleItems[visibleItem] = view
 
@@ -652,16 +652,13 @@ public final class CalendarView: UIView {
   private func configureView(_ view: ItemView, with visibleItem: VisibleCalendarItem) {
     view.calendarItemModel = visibleItem.calendarItemModel
 
-    // Update the visibility
-    UIView.performWithoutAnimation {
-      view.frame = visibleItem.frame.alignedToPixels(forScreenWithScale: scale)
-      view.layer.zPosition = visibleItem.itemType.zPosition
+    view.frame = visibleItem.frame.alignedToPixels(forScreenWithScale: scale)
+    view.layer.zPosition = visibleItem.itemType.zPosition
 
-      if traitCollection.layoutDirection == .rightToLeft {
-        view.transform = .init(scaleX: -1, y: 1)
-      } else {
-        view.transform = .identity
-      }
+    if traitCollection.layoutDirection == .rightToLeft {
+      view.transform = .init(scaleX: -1, y: 1)
+    } else {
+      view.transform = .identity
     }
 
     view.isUserInteractionEnabled = visibleItem.itemType.isUserInteractionEnabled

--- a/Tests/ItemViewReuseManagerTests.swift
+++ b/Tests/ItemViewReuseManagerTests.swift
@@ -58,10 +58,13 @@ final class ItemViewReuseManagerTests: XCTestCase {
 
     reuseManager.viewsForVisibleItems(
       visibleItems,
-      viewHandler: { _, _, previousBackingItem in
+      viewHandler: { _, _, previousBackingItem, isReusedViewSameAsPreviousView in
         XCTAssert(
           previousBackingItem == nil,
           "Previous backing item should be nil since there are no views to reuse.")
+        XCTAssert(
+          !isReusedViewSameAsPreviousView,
+          "isReusedViewSameAsPreviousView should be false when no view was reused.")
       })
   }
 
@@ -98,18 +101,21 @@ final class ItemViewReuseManagerTests: XCTestCase {
     let subsequentVisibleItems = initialVisibleItems
 
     // Populate the reuse manager with the initial visible items
-    reuseManager.viewsForVisibleItems(initialVisibleItems, viewHandler: { _, _, _ in })
+    reuseManager.viewsForVisibleItems(initialVisibleItems, viewHandler: { _, _, _, _ in })
 
     // Ensure all views are reused by using the exact same previous views
     reuseManager.viewsForVisibleItems(
       subsequentVisibleItems,
-      viewHandler: { _, item, previousBackingItem in
+      viewHandler: { _, item, previousBackingItem, isReusedViewSameAsPreviousView in
         XCTAssert(
           item == previousBackingItem,
           """
             Expected the new item to be identical to the previous backing item, since the subsequent
             visible items are identical to the initial visible items.
           """)
+        XCTAssert(
+          isReusedViewSameAsPreviousView,
+          "isReusedViewSameAsPreviousView should be true when the same view was reused.")
       })
   }
 
@@ -173,12 +179,12 @@ final class ItemViewReuseManagerTests: XCTestCase {
     ]
 
     // Populate the reuse manager with the initial visible items
-    reuseManager.viewsForVisibleItems(initialVisibleItems, viewHandler: { _, _, _ in })
+    reuseManager.viewsForVisibleItems(initialVisibleItems, viewHandler: { _, _, _, _ in })
 
     // Ensure all views are reused given the subsequent visible items
     reuseManager.viewsForVisibleItems(
       subsequentVisibleItems,
-      viewHandler: { _, item, previousBackingItem in
+      viewHandler: { _, item, previousBackingItem, _ in
         XCTAssert(
           item.calendarItemModel.itemViewDifferentiator == previousBackingItem?.calendarItemModel.itemViewDifferentiator,
           """
@@ -264,12 +270,12 @@ final class ItemViewReuseManagerTests: XCTestCase {
     ]
 
     // Populate the reuse manager with the initial visible items
-    reuseManager.viewsForVisibleItems(initialVisibleItems, viewHandler: { _, _, _ in })
+    reuseManager.viewsForVisibleItems(initialVisibleItems, viewHandler: { _, _, _, _ in })
 
     // Ensure the correct subset of views are reused given the subsequent visible items
     reuseManager.viewsForVisibleItems(
       subsequentVisibleItems,
-      viewHandler: { _, item, previousBackingItem in
+      viewHandler: { _, item, previousBackingItem, isReusedViewSameAsPreviousView in
         guard
           case .itemModel(let opaqueCalendarItemModel) = item.calendarItemModel,
           let itemModel = opaqueCalendarItemModel as? MockCalendarItemModel
@@ -287,10 +293,16 @@ final class ItemViewReuseManagerTests: XCTestCase {
               Expected the new item to have the same reuse identifier as the previous backing item,
               since it was reused.
             """)
+          XCTAssert(
+            !isReusedViewSameAsPreviousView,
+            "isReusedViewSameAsPreviousView should be false when a different view was reused.")
         default:
           XCTAssert(
             previousBackingItem == nil,
             "Previous backing item should be nil since there are no views to reuse.")
+          XCTAssert(
+            !isReusedViewSameAsPreviousView,
+            "isReusedViewSameAsPreviousView should be false when a different view was reused.")
         }
       })
   }
@@ -400,14 +412,14 @@ final class ItemViewReuseManagerTests: XCTestCase {
     ]
 
     // Populate the reuse manager with the initial visible items
-    reuseManager.viewsForVisibleItems(initialVisibleItems, viewHandler: { _, _, _ in })
+    reuseManager.viewsForVisibleItems(initialVisibleItems, viewHandler: { _, _, _, _ in })
 
     // Ensure the correct subset of views are reused given the subsequent visible items
     var reuseCountsForDifferentiators = [_CalendarItemViewDifferentiator: Int]()
     var newViewCountsForDifferentiators = [_CalendarItemViewDifferentiator: Int]()
     reuseManager.viewsForVisibleItems(
       subsequentVisibleItems,
-      viewHandler: { _, item, previousBackingItem in
+      viewHandler: { _, item, previousBackingItem, _ in
         if previousBackingItem != nil {
           let reuseCount = (reuseCountsForDifferentiators[item.calendarItemModel.itemViewDifferentiator] ?? 0) + 1
           reuseCountsForDifferentiators[item.calendarItemModel.itemViewDifferentiator] = reuseCount

--- a/Tests/LegacyItemViewReuseManagerTests.swift
+++ b/Tests/LegacyItemViewReuseManagerTests.swift
@@ -58,7 +58,7 @@ final class LegacyItemViewReuseManagerTests: XCTestCase {
 
     reuseManager.viewsForVisibleItems(
       visibleItems,
-      viewHandler: { _, _, previousBackingItem in
+      viewHandler: { _, _, previousBackingItem, _ in
         XCTAssert(
           previousBackingItem == nil,
           "Previous backing item should be nil since there are no views to reuse.")
@@ -98,12 +98,12 @@ final class LegacyItemViewReuseManagerTests: XCTestCase {
     let subsequentVisibleItems = initialVisibleItems
 
     // Populate the reuse manager with the initial visible items
-    reuseManager.viewsForVisibleItems(initialVisibleItems, viewHandler: { _, _, _ in })
+    reuseManager.viewsForVisibleItems(initialVisibleItems, viewHandler: { _, _, _, _ in })
 
     // Ensure all views are reused by using the exact same previous views
     reuseManager.viewsForVisibleItems(
       subsequentVisibleItems,
-      viewHandler: { _, item, previousBackingItem in
+      viewHandler: { _, item, previousBackingItem, _ in
         XCTAssert(
           item == previousBackingItem,
           """
@@ -173,12 +173,12 @@ final class LegacyItemViewReuseManagerTests: XCTestCase {
     ]
 
     // Populate the reuse manager with the initial visible items
-    reuseManager.viewsForVisibleItems(initialVisibleItems, viewHandler: { _, _, _ in })
+    reuseManager.viewsForVisibleItems(initialVisibleItems, viewHandler: { _, _, _, _ in })
 
     // Ensure all views are reused given the subsequent visible items
     reuseManager.viewsForVisibleItems(
       subsequentVisibleItems,
-      viewHandler: { _, item, previousBackingItem in
+      viewHandler: { _, item, previousBackingItem, _ in
         XCTAssert(
           item.calendarItemModel.reuseIdentifier == previousBackingItem?.calendarItemModel.reuseIdentifier,
           """
@@ -264,12 +264,12 @@ final class LegacyItemViewReuseManagerTests: XCTestCase {
     ]
 
     // Populate the reuse manager with the initial visible items
-    reuseManager.viewsForVisibleItems(initialVisibleItems, viewHandler: { _, _, _ in })
+    reuseManager.viewsForVisibleItems(initialVisibleItems, viewHandler: { _, _, _, _ in })
 
     // Ensure the correct subset of views are reused given the subsequent visible items
     reuseManager.viewsForVisibleItems(
       subsequentVisibleItems,
-      viewHandler: { _, item, previousBackingItem in
+      viewHandler: { _, item, previousBackingItem, _ in
         switch item.calendarItemModel.reuseIdentifier {
         case "item_type_1", "item_type_3":
           XCTAssert(
@@ -391,14 +391,14 @@ final class LegacyItemViewReuseManagerTests: XCTestCase {
     ]
 
     // Populate the reuse manager with the initial visible items
-    reuseManager.viewsForVisibleItems(initialVisibleItems, viewHandler: { _, _, _ in })
+    reuseManager.viewsForVisibleItems(initialVisibleItems, viewHandler: { _, _, _, _ in })
 
     // Ensure the correct subset of views are reused given the subsequent visible items
     var reuseCountsForReuseIDs = [String: Int]()
     var newViewCountsForReuseIDs = [String: Int]()
     reuseManager.viewsForVisibleItems(
       subsequentVisibleItems,
-      viewHandler: { _, item, previousBackingItem in
+      viewHandler: { _, item, previousBackingItem, _ in
         if previousBackingItem != nil {
           let reuseCount = (reuseCountsForReuseIDs[item.calendarItemModel.reuseIdentifier] ?? 0) + 1
           reuseCountsForReuseIDs[item.calendarItemModel.reuseIdentifier] = reuseCount


### PR DESCRIPTION
## Details

This PR enables us to animate some content update changes by calling `layoutIfNeeded` in a `UIView` animation block. For example, a vertical spacing between weeks can now be animated. We won't animate views that are moving due to view reuse. We also avoid animating views that are being added to the view hierarchy for the first time (existing behavior).

## Related Issue

N/A

## Motivation and Context

Better animation support.

## How Has This Been Tested

Example app in simulator.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
