### PR TITLE
Add CalendarItemModel convenience factory functions

### DIFF
--- a/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/DayRangeSelectionDemoViewController.swift
+++ b/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/DayRangeSelectionDemoViewController.swift
@@ -97,7 +97,7 @@ final class DayRangeSelectionDemoViewController: DemoViewController {
 
         let date = calendar.date(from: day.components)
 
-        return CalendarItemModel<DayView>(
+        return DayView.calendarItemModel(
           invariantViewProperties: invariantViewProperties,
           viewModel: .init(
             dayText: "\(day.day)",
@@ -106,7 +106,7 @@ final class DayRangeSelectionDemoViewController: DemoViewController {
       }
 
       .dayRangeItemProvider(for: dateRanges) { dayRangeLayoutContext in
-        CalendarItemModel<DayRangeIndicatorView>(
+        DayRangeIndicatorView.calendarItemModel(
           invariantViewProperties: .init(),
           viewModel: .init(
             framesOfDaysToHighlight: dayRangeLayoutContext.daysAndFrames.map { $0.frame }))

--- a/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/PartialMonthVisibilityDemoViewController.swift
+++ b/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/PartialMonthVisibilityDemoViewController.swift
@@ -52,7 +52,7 @@ final class PartialMonthVisibilityDemoViewController: DemoViewController {
           invariantViewProperties.backgroundShapeDrawingConfig.fillColor = .blue.withAlphaComponent(0.15)
         }
 
-        return CalendarItemModel<DayView>(
+        return DayView.calendarItemModel(
           invariantViewProperties: invariantViewProperties,
           viewModel: .init(
             dayText: "\(day.day)",

--- a/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/SelectedDayTooltipDemoViewController.swift
+++ b/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/SelectedDayTooltipDemoViewController.swift
@@ -69,7 +69,7 @@ final class SelectedDayTooltipDemoViewController: DemoViewController {
           invariantViewProperties.backgroundShapeDrawingConfig.fillColor = .blue.withAlphaComponent(0.15)
         }
 
-        return CalendarItemModel<DayView>(
+        return DayView.calendarItemModel(
           invariantViewProperties: invariantViewProperties,
           viewModel: .init(
             dayText: "\(day.day)",
@@ -78,7 +78,7 @@ final class SelectedDayTooltipDemoViewController: DemoViewController {
       }
 
       .overlayItemProvider(for: overlaidItemLocations) { overlayLayoutContext in
-        CalendarItemModel<TooltipView>(
+        TooltipView.calendarItemModel(
           invariantViewProperties: .init(),
           viewModel: .init(
             frameOfTooltippedItem: overlayLayoutContext.overlaidItemFrame,

--- a/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/SingleDaySelectionDemoViewController.swift
+++ b/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/SingleDaySelectionDemoViewController.swift
@@ -75,7 +75,7 @@ final class SingleDaySelectionDemoViewController: DemoViewController {
           invariantViewProperties.backgroundShapeDrawingConfig.fillColor = .blue.withAlphaComponent(0.15)
         }
 
-        return CalendarItemModel<DayView>(
+        return DayView.calendarItemModel(
           invariantViewProperties: invariantViewProperties,
           viewModel: .init(
             dayText: "\(day.day)",

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ Now that we have a type conforming to `CalendarItemViewRepresentable`, we can us
   return CalendarViewContent(...)
 
     .dayItemProvider { day in
-      CalendarItemModel<DayLabel>(
+      DayLabel.calendarItemModel(
         invariantViewProperties: .init(
           font: UIFont.systemFont(ofSize: 18), 
           textColor: .darkGray,
@@ -381,7 +381,7 @@ Last, we need to return a `CalendarItemModel` representing our `DayRangeIndicato
     ...
     
     .dayRangeItemProvider(for: [dateRangeToHighlight]) { dayRangeLayoutContext in
-      CalendarItemModel<DayRangeIndicatorView>(
+      DayRangeIndicatorView.calendarItemModel(
         invariantViewProperties: .init(indicatorColor: UIColor.blue.withAlphaComponent(0.15)),
         viewModel: .init(framesOfDaysToHighlight: dayRangeLayoutContext.daysAndFrames.map { $0.frame }))
     }
@@ -538,7 +538,7 @@ Last, we need to return a `CalendarItemModel` representing our `TooltipView` fro
     ...
     
     .overlayItemProvider(for: [overlaidItemLocation]) { overlayLayoutContext in
-      CalendarItemModel<TooltipView>(
+      TooltipView.calendarItemModel(
         invariantViewProperties: .init(
           backgroundColor: .white, 
           borderColor: .black, 
@@ -584,7 +584,7 @@ The day selection handler closure is invoked whenever a day in the calendar is s
         invariantViewProperties.backgroundColor = .blue
       }
       
-      return CalendarItemModel<DayLabel>(
+      return DayLabel.calendarItemModel(
         invariantViewProperties: invariantViewProperties,
         viewModel: .init(day: day))
   }

--- a/Sources/Public/CalendarItemModel.swift
+++ b/Sources/Public/CalendarItemModel.swift
@@ -30,14 +30,15 @@ public struct CalendarItemModel<ViewRepresentable>: AnyCalendarItemModel where
 
   // MARK: Lifecycle
 
-  /// Initializes a new `CalendarItemModel`.
+  /// Initializes a new `CalendarItemModel` that can be returned from the various item-provider `CalendarViewContent`
+  /// closures.
   ///
   /// - Parameters:
   ///   - invariantViewProperties: A type containing all of the immutable / view-model-independent properties necessary to
   ///   initialize a `ViewType`. Use this to configure appearance options that do not change based on the data in the `viewModel`.
   ///   For example, you might pass a type that contains properties to configure a `UILabel`'s `textAlignment`, `textColor`,
-  ///   and `font`, assuming none of those things change in response to `viewModel` updates.
-  ///   - viewModel: A type containing all of the variable data necessary to update an instance of`ViewType`. Use this to specify
+  ///   and `font`, assuming none of those values change in response to `viewModel` updates.
+  ///   - viewModel: A type containing all of the variable data necessary to update an instance of `ViewType`. Use this to specify
   ///   the dynamic, data-driven parts of the view.
   public init(
     invariantViewProperties: ViewRepresentable.InvariantViewProperties,
@@ -83,5 +84,28 @@ public struct CalendarItemModel<ViewRepresentable>: AnyCalendarItemModel where
 
   private let invariantViewProperties: ViewRepresentable.InvariantViewProperties
   private let viewModel: ViewRepresentable.ViewModel
+
+}
+
+// MARK: UIKit Convenience Factory
+
+extension CalendarItemViewRepresentable {
+
+  /// Creates a `CalendarItemModel` that can be returned from the various item-provider `CalendarViewContent` closures.
+  ///
+  /// - Parameters:
+  ///   - invariantViewProperties: A type containing all of the immutable / view-model-independent properties necessary to
+  ///   initialize a `ViewType`. Use this to configure appearance options that do not change based on the data in the `viewModel`.
+  ///   For example, you might pass a type that contains properties to configure a `UILabel`'s `textAlignment`, `textColor`,
+  ///   and `font`, assuming none of those values change in response to `viewModel` updates.
+  ///   - viewModel: A type containing all of the variable data necessary to update an instance of `ViewType`. Use this to specify
+  ///   the dynamic, data-driven parts of the view.
+  public static func calendarItemModel(
+    invariantViewProperties: InvariantViewProperties,
+    viewModel: ViewModel)
+    -> CalendarItemModel<Self>
+  {
+    CalendarItemModel<Self>(invariantViewProperties: invariantViewProperties, viewModel: viewModel)
+  }
 
 }

--- a/Sources/Public/CalendarViewContent.swift
+++ b/Sources/Public/CalendarViewContent.swift
@@ -65,7 +65,7 @@ public final class CalendarViewContent {
     monthHeaderItemProvider = { month in
       let firstDateInMonth = calendar.firstDate(of: month)
       let monthText = monthHeaderDateFormatter.string(from: firstDateInMonth)
-      let itemModel = CalendarItemModel<MonthHeaderView>(
+      let itemModel = MonthHeaderView.calendarItemModel(
         invariantViewProperties: .base,
         viewModel: .init(monthText: monthText, accessibilityLabel: monthText))
       return .itemModel(itemModel)
@@ -73,7 +73,7 @@ public final class CalendarViewContent {
 
     dayOfWeekItemProvider = { _, weekdayIndex in
       let dayOfWeekText = monthHeaderDateFormatter.veryShortStandaloneWeekdaySymbols[weekdayIndex]
-      let itemModel = CalendarItemModel<DayOfWeekView>(
+      let itemModel = DayOfWeekView.calendarItemModel(
         invariantViewProperties: .base,
         viewModel: .init(dayOfWeekText: dayOfWeekText, accessibilityLabel: dayOfWeekText))
       return .itemModel(itemModel)
@@ -89,7 +89,7 @@ public final class CalendarViewContent {
 
     dayItemProvider = { day in
       let date = calendar.startDate(of: day)
-      let itemModel = CalendarItemModel<DayView>(
+      let itemModel = DayView.calendarItemModel(
         invariantViewProperties: .baseNonInteractive,
         viewModel: .init(
           dayText: "\(day.day)",

--- a/Tests/VisibleItemsProviderTests.swift
+++ b/Tests/VisibleItemsProviderTests.swift
@@ -1764,7 +1764,7 @@ final class VisibleItemsProviderTests: XCTestCase {
       static func setViewModel(_ viewModel: Int, on view: MockView) { }
     }
 
-    return CalendarItemModel<MockView>(invariantViewProperties: 0, viewModel: 0)
+    return MockView.calendarItemModel(invariantViewProperties: 0, viewModel: 0)
   }
 
   private static func makeContent(


### PR DESCRIPTION
## Details

This adds some convenience factory functions for creating instances of `CalendarItemModel`. The main benefit of this is that autocomplete works much better.

## Related Issue

N/A

## Motivation and Context

Better autocomplete and preparation for SwiftUI support coming in the next PR.

## How Has This Been Tested

Example app.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
