### PR TITLE
Bk/month background api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/airbnb/HorizonCalendar/compare/v1.15.0...HEAD)
 
+### Added
+- Added support for month backgrounds, enabling things like grid lines and colored backgrounds for months
+
 ### Changed
 - Removed spaces from folder names within the `Sources` folder to reduce the chance of sensitive 🥺 build systems complaining or breaking
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Features:
 - Specify custom views (`UIView` or SwiftUI `View`) for individual days, month headers, and days of the week
 - Specify custom views (`UIView` or SwiftUI `View`) to highlight date ranges
 - Specify custom views (`UIView` or SwiftUI `View`) to overlay parts of the calendar, enabling features like tooltips
+- Specify custom views (`UIView` or SwiftUI `View`) for month background decorations (colors, grids, etc.)
 - A day selection handler to monitor when a day is tapped
 - Customizable layout metrics
 - Pin the days-of-the-week row to the top

--- a/Sources/Internal/SubviewInsertionIndexTracker.swift
+++ b/Sources/Internal/SubviewInsertionIndexTracker.swift
@@ -25,6 +25,17 @@ final class SubviewInsertionIndexTracker {
   {
     let index: Int
     switch itemType {
+    case .monthBackground:
+      index = monthBackgroundItemsEndIndex
+      monthBackgroundItemsEndIndex += 1
+      dayRangeItemsEndIndex += 1
+      mainItemsEndIndex += 1
+      daysOfWeekRowSeparatorItemsEndIndex += 1
+      overlayItemsEndIndex += 1
+      pinnedDaysOfWeekRowBackgroundEndIndex += 1
+      pinnedDaysOfWeekRowSeparatorEndIndex += 1
+      pinnedDayOfWeekItemsEndIndex += 1
+    
     case .dayRange:
       index = dayRangeItemsEndIndex
       dayRangeItemsEndIndex += 1
@@ -80,6 +91,7 @@ final class SubviewInsertionIndexTracker {
 
   // MARK: Private
 
+  private var monthBackgroundItemsEndIndex = 0
   private var dayRangeItemsEndIndex = 0
   private var mainItemsEndIndex = 0
   private var daysOfWeekRowSeparatorItemsEndIndex = 0

--- a/Sources/Internal/VisibleItem.swift
+++ b/Sources/Internal/VisibleItem.swift
@@ -80,6 +80,7 @@ extension VisibleItem {
 
   enum ItemType: Equatable, Hashable {
     case layoutItemType(LayoutItem.ItemType)
+    case monthBackground(Month)
     case pinnedDayOfWeek(DayOfWeekPosition)
     case pinnedDaysOfWeekRowBackground
     case pinnedDaysOfWeekRowSeparator
@@ -92,6 +93,8 @@ extension VisibleItem {
       case .layoutItemType: return true
       case .pinnedDayOfWeek: return true
       case .pinnedDaysOfWeekRowBackground: return true
+
+      case .monthBackground: return false
       case .pinnedDaysOfWeekRowSeparator: return false
       case .daysOfWeekRowSeparator: return false
       case .dayRange: return false

--- a/Tests/SubviewsManagerTests.swift
+++ b/Tests/SubviewsManagerTests.swift
@@ -136,26 +136,14 @@ extension VisibleItem.ItemType: Comparable {
 
   private var relativeDistanceFromBack: Int {
     switch self {
-    case .dayRange:
-      return 0
-
-    case .layoutItemType:
-      return 1
-
-    case .daysOfWeekRowSeparator:
-      return 2
-
-    case .overlayItem:
-      return 3
-
-    case .pinnedDaysOfWeekRowBackground:
-      return 4
-
-    case .pinnedDaysOfWeekRowSeparator:
-      return 5
-
-    case .pinnedDayOfWeek:
-      return 6
+    case .monthBackground: return 0
+    case .dayRange: return 1
+    case .layoutItemType: return 2
+    case .daysOfWeekRowSeparator: return 3
+    case .overlayItem: return 4
+    case .pinnedDaysOfWeekRowBackground: return 5
+    case .pinnedDaysOfWeekRowSeparator: return 6
+    case .pinnedDayOfWeek: return 7
     }
   }
 

--- a/Tests/VisibleItemsProviderTests.swift
+++ b/Tests/VisibleItemsProviderTests.swift
@@ -360,6 +360,9 @@ final class VisibleItemsProviderTests: XCTestCase {
       "[itemType: .layoutItemType(.day(2020-03-14)), frame: (279.5, 409.5, 35.5, 17.5)]",
       "[itemType: .layoutItemType(.dayOfWeekInMonth(.fourth, 2020-03)), frame: (142.0, 333.5, 36.0, 18.0)]",
       "[itemType: .layoutItemType(.day(2020-03-23)), frame: (50.5, 485.0, 36.0, 18.0)]",
+      "[itemType: .monthBackground(2020-03), frame: (-0.0, 246.0, 320.0, 302.0)]",
+      "[itemType: .monthBackground(2020-02), frame: (0.0, -56.0, 320.0, 302.0)]",
+      "[itemType: .monthBackground(2020-04), frame: (0.0, 548.0, 320.0, 302.5)]",
     ]
 
     XCTAssert(
@@ -429,6 +432,9 @@ final class VisibleItemsProviderTests: XCTestCase {
       "[itemType: .layoutItemType(.day(2020-03-04)), frame: (142.0, 335.5, 36.0, 36.0)]",
       "[itemType: .daysOfWeekRowSeparator(2020-4), frame: (0.0, 724.0, 320.0, 1.0)]",
       "[itemType: .daysOfWeekRowSeparator(2020-3), frame: (0.0, 314.5, 320.0, 1.0)]",
+      "[itemType: .monthBackground(2020-04), frame: (0.0, 602.0, 320.0, 409.0)]",
+      "[itemType: .monthBackground(2020-03), frame: (0.0, 192.5, 320.0, 409.5)]",
+      "[itemType: .monthBackground(2020-02), frame: (0.0, -217.0, 320.0, 409.5)]",
     ]
 
     XCTAssert(
@@ -496,6 +502,8 @@ final class VisibleItemsProviderTests: XCTestCase {
       "[itemType: .layoutItemType(.monthHeader(2020-06)), frame: (0.0, 450.0, 320.0, 50.0)]",
       "[itemType: .pinnedDaysOfWeekRowBackground, frame: (0.0, 450.0, 320.0, 35.5)]",
       "[itemType: .pinnedDaysOfWeekRowSeparator, frame: (0.0, 484.5, 320.0, 1.0)]",
+      "[itemType: .monthBackground(2020-07), frame: (0.0, 796.0, 320.0, 353.5)]",
+      "[itemType: .monthBackground(2020-06), frame: (0.0, 442.5, 320.0, 353.5)]",
     ]
 
     XCTAssert(
@@ -544,6 +552,8 @@ final class VisibleItemsProviderTests: XCTestCase {
       "[itemType: .layoutItemType(.day(2020-02-01)), frame: (279.5, 578.0, 35.5, 35.5)]",
       "[itemType: .daysOfWeekRowSeparator(2020-2), frame: (0.0, 557.0, 320.0, 1.0)]",
       "[itemType: .daysOfWeekRowSeparator(2020-1), frame: (0.0, 314.5, 320.0, 1.0)]",
+      "[itemType: .monthBackground(2020-02), frame: (0.0, 434.5, 320.0, 409.5)]",
+      "[itemType: .monthBackground(2020-01), frame: (0.0, 192.5, 320.0, 242.0)]",
     ]
 
     XCTAssert(
@@ -615,6 +625,8 @@ final class VisibleItemsProviderTests: XCTestCase {
       "[itemType: .layoutItemType(.day(2020-04-18)), frame: (197.0, 238.5, 33.0, 33.0)]",
       "[itemType: .daysOfWeekRowSeparator(2020-5), frame: (250.0, 112.0, 300.0, 1.0)]",
       "[itemType: .daysOfWeekRowSeparator(2020-4), frame: (-65.0, 112.0, 300.0, 1.0)]",
+      "[itemType: .monthBackground(2020-04), frame: (-72.5, -51.5, 315.0, 480.0)]",
+      "[itemType: .monthBackground(2020-05), frame: (242.5, -25.0, 315.0, 480.0)]",
     ]
 
     XCTAssert(
@@ -684,6 +696,8 @@ final class VisibleItemsProviderTests: XCTestCase {
       "[itemType: .layoutItemType(.day(2020-05-15)), frame: (233.5, 270.5, 36.0, 36.0)]",
       "[itemType: .layoutItemType(.day(2020-05-19)), frame: (96.5, 326.5, 35.5, 35.5)]",
       "[itemType: .daysOfWeekRowSeparator(2020-6), frame: (0.0, 603.5, 320.0, 1.0)]",
+      "[itemType: .monthBackground(2020-05), frame: (0.0, 16.0, 320.0, 465.0)]",
+      "[itemType: .monthBackground(2020-06), frame: (0.0, 481.0, 320.0, 409.5)]",
     ]
 
     XCTAssert(
@@ -748,6 +762,8 @@ final class VisibleItemsProviderTests: XCTestCase {
       "[itemType: .layoutItemType(.monthHeader(2020-01)), frame: (0.0, 0.0, 300.0, 50.0)]",
       "[itemType: .daysOfWeekRowSeparator(2020-1), frame: (0.0, 112.0, 300.0, 1.0)]",
       "[itemType: .daysOfWeekRowSeparator(2020-2), frame: (315.0, 112.0, 300.0, 1.0)]",
+      "[itemType: .monthBackground(2020-02), frame: (307.5, -51.5, 315.0, 480.0)]",
+      "[itemType: .monthBackground(2020-01), frame: (-7.5, -51.5, 315.0, 480.0)]",
     ]
 
     XCTAssert(
@@ -808,6 +824,8 @@ final class VisibleItemsProviderTests: XCTestCase {
       "[itemType: .layoutItemType(.dayOfWeekInMonth(.fifth, 2020-01)), frame: (188.0, 80.0, 35.5, 35.5)]",
       "[itemType: .daysOfWeekRowSeparator(2020-1), frame: (0.0, 114.5, 320.0, 1.0)]",
       "[itemType: .daysOfWeekRowSeparator(2020-2), frame: (0.0, 524.0, 320.0, 1.0)]",
+      "[itemType: .monthBackground(2020-02), frame: (0.0, 402.0, 320.0, 409.0)]",
+      "[itemType: .monthBackground(2020-01), frame: (0.0, -7.5, 320.0, 409.5)]",
     ]
 
     XCTAssert(
@@ -874,6 +892,8 @@ final class VisibleItemsProviderTests: XCTestCase {
       "[itemType: .layoutItemType(.day(2020-01-12)), frame: (5.0, 236.5, 35.5, 35.5)]",
       "[itemType: .pinnedDaysOfWeekRowBackground, frame: (0.0, 50.0, 320.0, 35.5)]",
       "[itemType: .pinnedDaysOfWeekRowSeparator, frame: (0.0, 84.5, 320.0, 1.0)]",
+      "[itemType: .monthBackground(2020-02), frame: (0.0, 391.0, 320.0, 353.5)]",
+      "[itemType: .monthBackground(2020-01), frame: (0.0, 37.5, 320.0, 353.5)]",
     ]
 
     XCTAssert(
@@ -908,6 +928,7 @@ final class VisibleItemsProviderTests: XCTestCase {
       "[itemType: .layoutItemType(.dayOfWeekInMonth(.sixth, 2020-12)), frame: (233.5, 770.0, 36.0, 35.5)]",
       "[itemType: .layoutItemType(.day(2020-12-01)), frame: (96.5, 825.5, 35.5, 36.0)]",
       "[itemType: .daysOfWeekRowSeparator(2020-12), frame: (0.0, 804.5, 320.0, 1.0)]",
+      "[itemType: .monthBackground(2020-12), frame: (0.0, 682.5, 320.0, 186.5)]",
     ]
 
     XCTAssert(
@@ -978,6 +999,8 @@ final class VisibleItemsProviderTests: XCTestCase {
       "[itemType: .layoutItemType(.day(2020-12-27)), frame: (1205.0, 344.5, 33.0, 32.5)]",
       "[itemType: .daysOfWeekRowSeparator(2020-11), frame: (885.0, 112.0, 300.0, 1.0)]",
       "[itemType: .daysOfWeekRowSeparator(2020-12), frame: (1200.0, 112.0, 300.0, 1.0)]",
+      "[itemType: .monthBackground(2020-11), frame: (877.5, -51.5, 315.0, 480.0)]",
+      "[itemType: .monthBackground(2020-12), frame: (1192.5, -51.5, 315.0, 480.0)]",
     ]
 
     XCTAssert(
@@ -1778,6 +1801,7 @@ final class VisibleItemsProviderTests: XCTestCase {
       .horizontalDayMargin(10)
       .daysOfTheWeekRowSeparator(options: .init(height: 1, color: .gray))
       .monthHeaderItemProvider  { _ in mockCalendarItemModel }
+      .monthBackgroundItemProvider { _ in mockCalendarItemModel }
       .dayOfWeekItemProvider { _, _ in mockCalendarItemModel }
       .dayItemProvider { _ in mockCalendarItemModel }
       .dayRangeItemProvider(
@@ -1822,6 +1846,8 @@ extension VisibleItem: CustomStringConvertible {
       itemTypeText = ".daysOfWeekRowSeparator(\(month.year)-\(month.month))"
     case .dayRange(let dayRange):
       itemTypeText = ".dayRange(\(dayRange.lowerBound), \(dayRange.upperBound))"
+    case .monthBackground(let month):
+      itemTypeText = ".monthBackground(\(month.description))"
     case .overlayItem(let overlaidItemLocation):
       let calendar = Calendar(identifier: .gregorian)
       let itemLocationText: String


### PR DESCRIPTION
## Details

This PR adds support for month backgrounds - a way to add additional decoration behind a month's contents. This paves the path for features like colored backgrounds or grid lines.

![image](https://user-images.githubusercontent.com/746571/210974634-a5a4b8a2-28d7-4ac3-a83a-233069c41ed1.png)

## Related Issue

N/A

## Motivation and Context

Support grid lines and other month decorations

## How Has This Been Tested

Example project and a less-generic version of this code has been tested in the Airbnb app for the new host calendar (which uses grid lines)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
