### PR TITLE
Add a dayRange property to DayRangeLayoutContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added support for month backgrounds, enabling things like grid lines and colored backgrounds for months
+- Added a `dayRange` property to `CalendarViewContent.DayRangeLayoutContext`
 
 ### Changed
 - Removed spaces from folder names within the `Sources` folder to reduce the chance of sensitive 🥺 build systems complaining or breaking

--- a/Sources/Internal/VisibleItemsProvider.swift
+++ b/Sources/Internal/VisibleItemsProvider.swift
@@ -817,6 +817,7 @@ final class VisibleItemsProvider {
 
     let frame = dayRangeLayoutContext.frame
     let dayRangeLayoutContext = CalendarViewContent.DayRangeLayoutContext(
+      dayRange: dayRange,
       daysAndFrames: dayRangeLayoutContext.daysAndFrames,
       boundingUnionRectOfDayFrames: dayRangeLayoutContext.boundingUnionRectOfDayFrames)
 

--- a/Sources/Public/CalendarViewContent.swift
+++ b/Sources/Public/CalendarViewContent.swift
@@ -399,10 +399,14 @@ extension CalendarViewContent {
   /// The layout context for a day range, containing information about the frames of days in the day range and the bounding rect (union)
   /// of those frames. This can be used in a custom day range view to draw the day range in the correct location.
   public struct DayRangeLayoutContext {
+    /// The day range that this layout context describes.
+    public let dayRange: DayRange
+
     /// An ordered list of tuples containing day and day frame pairs.
     ///
     /// Each frame represents the frame of an individual day in the day range in the coordinate system of
-    /// `boundingUnionRectOfDayFrames`.
+    /// `boundingUnionRectOfDayFrames`. If a day range extends beyond the `visibleDateRange`, this array will only
+    /// contain the day-frame pairs for the visible portion of the day range.
     public let daysAndFrames: [(day: Day, frame: CGRect)]
 
     /// A rectangle that perfectly contains all day frames in `daysAndFrames`. In other words, it is the union of all day frames in


### PR DESCRIPTION
## Details

Developers should be able to see which day range a particular invocation of the `dayRangeItemProvider` closure is for. In most cases, one could simply inspect the `daysAndFrames` array and look at the first and last day to derive the original day range, but this doesn't work if the day range is partially visible due to it extending beyond the first / last visible date in the calendar.

## Related Issue

N/A

## Motivation and Context

Airbnb host calendar needs to be able to look up some info from the model layer for a particular day range.

## How Has This Been Tested

Example apo

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
