### PR TITLE
Bk/day background api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added support for month backgrounds, enabling things like grid lines and colored backgrounds for months
 - Added a `dayRange` property to `CalendarViewContent.DayRangeLayoutContext`
+- Added support for day backgrounds, enabling developers to add visual decoration behind individual days. These decoration views also appear behind any day range indicators, making it possible to have a day range indicator appear between the day's number and any background decoration.
 
 ### Changed
 - Removed spaces from folder names within the `Sources` folder to reduce the chance of sensitive 🥺 build systems complaining or breaking

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Features:
 - Specify custom views (`UIView` or SwiftUI `View`) to highlight date ranges
 - Specify custom views (`UIView` or SwiftUI `View`) to overlay parts of the calendar, enabling features like tooltips
 - Specify custom views (`UIView` or SwiftUI `View`) for month background decorations (colors, grids, etc.)
+- Specify custom views (`UIView` or SwiftUI `View`) for day background decorations (colors, patterns, etc.)
 - A day selection handler to monitor when a day is tapped
 - Customizable layout metrics
 - Pin the days-of-the-week row to the top

--- a/Sources/Internal/Dictionary+MutatingValueForKey.swift
+++ b/Sources/Internal/Dictionary+MutatingValueForKey.swift
@@ -30,4 +30,19 @@ extension Dictionary {
     }
   }
 
+  // If a value exists for the specified key, it will be returned without invoking
+  // `missingValueProvider`. If a value does not exist for the specified key, then it will be
+  // created and stored in the dictionary by invoking `missingValueProvider`.
+  //
+  // Useful when a dictionary is used as a cache.
+  mutating func optionalValue(for key: Key, missingValueProvider: () -> Value?) -> Value? {
+    if let value = self[key] {
+      return value
+    } else {
+      let value = missingValueProvider()
+      self[key] = value
+      return value
+    }
+  }
+
 }

--- a/Sources/Internal/SubviewInsertionIndexTracker.swift
+++ b/Sources/Internal/SubviewInsertionIndexTracker.swift
@@ -35,6 +35,17 @@ final class SubviewInsertionIndexTracker {
       pinnedDaysOfWeekRowBackgroundEndIndex += 1
       pinnedDaysOfWeekRowSeparatorEndIndex += 1
       pinnedDayOfWeekItemsEndIndex += 1
+
+    case .dayBackground:
+      index = dayBackgroundItemsEndIndex
+      dayBackgroundItemsEndIndex += 1
+      dayRangeItemsEndIndex += 1
+      mainItemsEndIndex += 1
+      daysOfWeekRowSeparatorItemsEndIndex += 1
+      overlayItemsEndIndex += 1
+      pinnedDaysOfWeekRowBackgroundEndIndex += 1
+      pinnedDaysOfWeekRowSeparatorEndIndex += 1
+      pinnedDayOfWeekItemsEndIndex += 1
     
     case .dayRange:
       index = dayRangeItemsEndIndex
@@ -92,6 +103,7 @@ final class SubviewInsertionIndexTracker {
   // MARK: Private
 
   private var monthBackgroundItemsEndIndex = 0
+  private var dayBackgroundItemsEndIndex = 0
   private var dayRangeItemsEndIndex = 0
   private var mainItemsEndIndex = 0
   private var daysOfWeekRowSeparatorItemsEndIndex = 0

--- a/Sources/Internal/VisibleItem.swift
+++ b/Sources/Internal/VisibleItem.swift
@@ -80,6 +80,7 @@ extension VisibleItem {
 
   enum ItemType: Equatable, Hashable {
     case layoutItemType(LayoutItem.ItemType)
+    case dayBackground(Day)
     case monthBackground(Month)
     case pinnedDayOfWeek(DayOfWeekPosition)
     case pinnedDaysOfWeekRowBackground
@@ -94,6 +95,7 @@ extension VisibleItem {
       case .pinnedDayOfWeek: return true
       case .pinnedDaysOfWeekRowBackground: return true
 
+      case .dayBackground: return false
       case .monthBackground: return false
       case .pinnedDaysOfWeekRowSeparator: return false
       case .daysOfWeekRowSeparator: return false

--- a/Sources/Internal/VisibleItemsProvider.swift
+++ b/Sources/Internal/VisibleItemsProvider.swift
@@ -701,6 +701,22 @@ final class VisibleItemsProvider {
               previousCalendarItemModelCache?[itemType] ?? content.dayItemProvider(day)
             })
 
+          // Handle the optional day background for this day
+          let dayBackgroundItemModel = calendarItemModelCache.optionalValue(
+            for: .dayBackground(day),
+            missingValueProvider: {
+              previousCalendarItemModelCache?[.dayBackground(day)]
+                ?? content.dayBackgroundItemProvider?(day)
+            })
+          if let dayBackgroundItemModel = dayBackgroundItemModel {
+            visibleItems.insert(
+              VisibleItem(
+                calendarItemModel: dayBackgroundItemModel,
+                itemType: .dayBackground(day),
+                frame: layoutItem.frame))
+          }
+
+          // Handle any day ranges that contain this day
           handleDayRangesContaining(
             day,
             withFrame: layoutItem.frame,

--- a/Sources/Public/CalendarViewContent.swift
+++ b/Sources/Public/CalendarViewContent.swift
@@ -267,6 +267,30 @@ public final class CalendarViewContent {
     return self
   }
 
+  /// Configures the day background item provider.
+  ///
+  /// `CalendarView` invokes the provided `dayBackgroundItemProvider` for each day being displayed. The
+  /// `CalendarItemModel`s that you return will be used to create the background views for each day in `CalendarView`. If a
+  /// particular day does not have a background view, return `nil` for that day.
+  ///
+  /// If you don't configure a day background item provider via this function, then days will not have additional background decoration.
+  ///
+  /// - Parameters:
+  ///   - dayBackgroundItemProvider: A closure (that is retained) that returns a `CalendarItemModel` representing the
+  ///   background of a single day in the calendar.
+  ///   - day: The `Day` for which to provide a day background item.
+  /// - Returns: A mutated `CalendarViewContent` instance with a new day background item provider.
+  public func dayBackgroundItemProvider(
+    _ dayBackgroundItemProvider: @escaping (_ day: Day) -> AnyCalendarItemModel?)
+    -> CalendarViewContent
+  {
+    self.dayBackgroundItemProvider = {
+      guard let dayBackgroundItemModel = dayBackgroundItemProvider($0) else { return nil }
+      return .itemModel(dayBackgroundItemModel)
+    }
+    return self
+  }
+
   /// Configures the month background item provider.
   ///
   /// `CalendarView` invokes the provided `monthBackgroundItemProvider` for each month being displayed. The
@@ -382,6 +406,7 @@ public final class CalendarViewContent {
     _ weekdayIndex: Int)
     -> InternalAnyCalendarItemModel
   var dayItemProvider: (Day) -> InternalAnyCalendarItemModel
+  var dayBackgroundItemProvider: ((Day) -> InternalAnyCalendarItemModel?)?
   var monthBackgroundItemProvider: ((MonthLayoutContext) -> InternalAnyCalendarItemModel?)?
   var dayRangesAndItemProvider: (
     dayRanges: Set<DayRange>,

--- a/Tests/SubviewsManagerTests.swift
+++ b/Tests/SubviewsManagerTests.swift
@@ -137,13 +137,14 @@ extension VisibleItem.ItemType: Comparable {
   private var relativeDistanceFromBack: Int {
     switch self {
     case .monthBackground: return 0
-    case .dayRange: return 1
-    case .layoutItemType: return 2
-    case .daysOfWeekRowSeparator: return 3
-    case .overlayItem: return 4
-    case .pinnedDaysOfWeekRowBackground: return 5
-    case .pinnedDaysOfWeekRowSeparator: return 6
-    case .pinnedDayOfWeek: return 7
+    case .dayBackground: return 1
+    case .dayRange: return 2
+    case .layoutItemType: return 3
+    case .daysOfWeekRowSeparator: return 4
+    case .overlayItem: return 5
+    case .pinnedDaysOfWeekRowBackground: return 6
+    case .pinnedDaysOfWeekRowSeparator: return 7
+    case .pinnedDayOfWeek: return 8
     }
   }
 

--- a/Tests/VisibleItemsProviderTests.swift
+++ b/Tests/VisibleItemsProviderTests.swift
@@ -363,6 +363,24 @@ final class VisibleItemsProviderTests: XCTestCase {
       "[itemType: .monthBackground(2020-03), frame: (-0.0, 246.0, 320.0, 302.0)]",
       "[itemType: .monthBackground(2020-02), frame: (0.0, -56.0, 320.0, 302.0)]",
       "[itemType: .monthBackground(2020-04), frame: (0.0, 548.0, 320.0, 302.5)]",
+      "[itemType: .dayBackground(2020-03-14), frame: (279.5, 409.5, 35.5, 17.5)]",
+      "[itemType: .dayBackground(2020-03-11), frame: (142.0, 409.5, 36.0, 17.5)]",
+      "[itemType: .dayBackground(2020-03-19), frame: (188.0, 447.0, 35.5, 18.0)]",
+      "[itemType: .dayBackground(2020-03-13), frame: (233.5, 409.5, 36.0, 17.5)]",
+      "[itemType: .dayBackground(2020-03-12), frame: (188.0, 409.5, 35.5, 17.5)]",
+      "[itemType: .dayBackground(2020-02-17), frame: (50.5, 183.0, 36.0, 17.5)]",
+      "[itemType: .dayBackground(2020-02-11), frame: (96.5, 145.0, 35.5, 18.0)]",
+      "[itemType: .dayBackground(2020-02-19), frame: (142.0, 183.0, 36.0, 17.5)]",
+      "[itemType: .dayBackground(2020-02-14), frame: (233.5, 145.0, 36.0, 18.0)]",
+      "[itemType: .dayBackground(2020-03-18), frame: (142.0, 447.0, 36.0, 18.0)]",
+      "[itemType: .dayBackground(2020-02-18), frame: (96.5, 183.0, 35.5, 17.5)]",
+      "[itemType: .dayBackground(2020-02-15), frame: (279.5, 145.0, 35.5, 18.0)]",
+      "[itemType: .dayBackground(2020-03-15), frame: (5.0, 447.0, 35.5, 18.0)]",
+      "[itemType: .dayBackground(2020-02-16), frame: (5.0, 183.0, 35.5, 17.5)]",
+      "[itemType: .dayBackground(2020-03-17), frame: (96.5, 447.0, 35.5, 18.0)]",
+      "[itemType: .dayBackground(2020-03-16), frame: (50.5, 447.0, 36.0, 18.0)]",
+      "[itemType: .dayBackground(2020-02-12), frame: (142.0, 145.0, 36.0, 18.0)]",
+      "[itemType: .dayBackground(2020-02-13), frame: (188.0, 145.0, 35.5, 18.0)]",
     ]
 
     XCTAssert(
@@ -435,6 +453,15 @@ final class VisibleItemsProviderTests: XCTestCase {
       "[itemType: .monthBackground(2020-04), frame: (0.0, 602.0, 320.0, 409.0)]",
       "[itemType: .monthBackground(2020-03), frame: (0.0, 192.5, 320.0, 409.5)]",
       "[itemType: .monthBackground(2020-02), frame: (0.0, -217.0, 320.0, 409.5)]",
+      "[itemType: .dayBackground(2020-03-17), frame: (96.5, 447.0, 35.5, 36.0)]",
+      "[itemType: .dayBackground(2020-03-14), frame: (279.5, 391.5, 35.5, 35.5)]",
+      "[itemType: .dayBackground(2020-03-12), frame: (188.0, 391.5, 35.5, 35.5)]",
+      "[itemType: .dayBackground(2020-03-19), frame: (188.0, 447.0, 35.5, 36.0)]",
+      "[itemType: .dayBackground(2020-03-13), frame: (233.5, 391.5, 36.0, 35.5)]",
+      "[itemType: .dayBackground(2020-03-18), frame: (142.0, 447.0, 36.0, 36.0)]",
+      "[itemType: .dayBackground(2020-03-11), frame: (142.0, 391.5, 36.0, 35.5)]",
+      "[itemType: .dayBackground(2020-03-16), frame: (50.5, 447.0, 36.0, 36.0)]",
+      "[itemType: .dayBackground(2020-03-15), frame: (5.0, 447.0, 35.5, 36.0)]",
     ]
 
     XCTAssert(
@@ -504,6 +531,15 @@ final class VisibleItemsProviderTests: XCTestCase {
       "[itemType: .pinnedDaysOfWeekRowSeparator, frame: (0.0, 484.5, 320.0, 1.0)]",
       "[itemType: .monthBackground(2020-07), frame: (0.0, 796.0, 320.0, 353.5)]",
       "[itemType: .monthBackground(2020-06), frame: (0.0, 442.5, 320.0, 353.5)]",
+      "[itemType: .dayBackground(2020-06-14), frame: (5.0, 641.5, 35.5, 35.5)]",
+      "[itemType: .dayBackground(2020-06-17), frame: (142.0, 641.5, 36.0, 35.5)]",
+      "[itemType: .dayBackground(2020-06-15), frame: (50.5, 641.5, 36.0, 35.5)]",
+      "[itemType: .dayBackground(2020-06-13), frame: (279.5, 585.5, 35.5, 36.0)]",
+      "[itemType: .dayBackground(2020-06-12), frame: (233.5, 585.5, 36.0, 36.0)]",
+      "[itemType: .dayBackground(2020-06-11), frame: (188.0, 585.5, 35.5, 36.0)]",
+      "[itemType: .dayBackground(2020-06-16), frame: (96.5, 641.5, 35.5, 35.5)]",
+      "[itemType: .dayBackground(2020-06-18), frame: (188.0, 641.5, 35.5, 35.5)]",
+      "[itemType: .dayBackground(2020-06-19), frame: (233.5, 641.5, 36.0, 35.5)]",
     ]
 
     XCTAssert(
@@ -627,6 +663,17 @@ final class VisibleItemsProviderTests: XCTestCase {
       "[itemType: .daysOfWeekRowSeparator(2020-4), frame: (-65.0, 112.0, 300.0, 1.0)]",
       "[itemType: .monthBackground(2020-04), frame: (-72.5, -51.5, 315.0, 480.0)]",
       "[itemType: .monthBackground(2020-05), frame: (242.5, -25.0, 315.0, 480.0)]",
+      "[itemType: .dayBackground(2020-05-17), frame: (255.0, 291.5, 33.0, 33.0)]",
+      "[itemType: .dayBackground(2020-05-11), frame: (298.0, 238.5, 32.5, 33.0)]",
+      "[itemType: .dayBackground(2020-04-16), frame: (111.5, 238.5, 33.0, 33.0)]",
+      "[itemType: .dayBackground(2020-04-15), frame: (68.5, 238.5, 33.0, 33.0)]",
+      "[itemType: .dayBackground(2020-04-18), frame: (197.0, 238.5, 33.0, 33.0)]",
+      "[itemType: .dayBackground(2020-05-13), frame: (383.5, 238.5, 33.0, 33.0)]",
+      "[itemType: .dayBackground(2020-05-12), frame: (340.5, 238.5, 33.0, 33.0)]",
+      "[itemType: .dayBackground(2020-04-17), frame: (154.5, 238.5, 32.5, 33.0)]",
+      "[itemType: .dayBackground(2020-05-19), frame: (340.5, 291.5, 33.0, 33.0)]",
+      "[itemType: .dayBackground(2020-05-18), frame: (298.0, 291.5, 32.5, 33.0)]",
+      "[itemType: .dayBackground(2020-04-11), frame: (197.0, 185.5, 33.0, 33.0)]",
     ]
 
     XCTAssert(
@@ -698,6 +745,15 @@ final class VisibleItemsProviderTests: XCTestCase {
       "[itemType: .daysOfWeekRowSeparator(2020-6), frame: (0.0, 603.5, 320.0, 1.0)]",
       "[itemType: .monthBackground(2020-05), frame: (0.0, 16.0, 320.0, 465.0)]",
       "[itemType: .monthBackground(2020-06), frame: (0.0, 481.0, 320.0, 409.5)]",
+      "[itemType: .dayBackground(2020-05-15), frame: (233.5, 270.5, 36.0, 36.0)]",
+      "[itemType: .dayBackground(2020-05-19), frame: (96.5, 326.5, 35.5, 35.5)]",
+      "[itemType: .dayBackground(2020-05-18), frame: (50.5, 326.5, 36.0, 35.5)]",
+      "[itemType: .dayBackground(2020-05-14), frame: (188.0, 270.5, 35.5, 36.0)]",
+      "[itemType: .dayBackground(2020-05-17), frame: (5.0, 326.5, 35.5, 35.5)]",
+      "[itemType: .dayBackground(2020-05-12), frame: (96.5, 270.5, 35.5, 36.0)]",
+      "[itemType: .dayBackground(2020-05-16), frame: (279.5, 270.5, 35.5, 36.0)]",
+      "[itemType: .dayBackground(2020-05-13), frame: (142.0, 270.5, 36.0, 36.0)]",
+      "[itemType: .dayBackground(2020-05-11), frame: (50.5, 270.5, 36.0, 36.0)]",
     ]
 
     XCTAssert(
@@ -764,6 +820,15 @@ final class VisibleItemsProviderTests: XCTestCase {
       "[itemType: .daysOfWeekRowSeparator(2020-2), frame: (315.0, 112.0, 300.0, 1.0)]",
       "[itemType: .monthBackground(2020-02), frame: (307.5, -51.5, 315.0, 480.0)]",
       "[itemType: .monthBackground(2020-01), frame: (-7.5, -51.5, 315.0, 480.0)]",
+      "[itemType: .dayBackground(2020-02-15), frame: (577.0, 238.5, 33.0, 33.0)]",
+      "[itemType: .dayBackground(2020-02-13), frame: (491.5, 238.5, 33.0, 33.0)]",
+      "[itemType: .dayBackground(2020-02-14), frame: (534.5, 238.5, 32.5, 33.0)]",
+      "[itemType: .dayBackground(2020-02-19), frame: (448.5, 291.5, 33.0, 33.0)]",
+      "[itemType: .dayBackground(2020-02-17), frame: (363.0, 291.5, 32.5, 33.0)]",
+      "[itemType: .dayBackground(2020-02-18), frame: (405.5, 291.5, 33.0, 33.0)]",
+      "[itemType: .dayBackground(2020-02-16), frame: (320.0, 291.5, 33.0, 33.0)]",
+      "[itemType: .dayBackground(2020-02-11), frame: (405.5, 238.5, 33.0, 33.0)]",
+      "[itemType: .dayBackground(2020-02-12), frame: (448.5, 238.5, 33.0, 33.0)]",
     ]
 
     XCTAssert(
@@ -826,6 +891,15 @@ final class VisibleItemsProviderTests: XCTestCase {
       "[itemType: .daysOfWeekRowSeparator(2020-2), frame: (0.0, 524.0, 320.0, 1.0)]",
       "[itemType: .monthBackground(2020-02), frame: (0.0, 402.0, 320.0, 409.0)]",
       "[itemType: .monthBackground(2020-01), frame: (0.0, -7.5, 320.0, 409.5)]",
+      "[itemType: .dayBackground(2020-01-13), frame: (50.5, 247.0, 36.0, 36.0)]",
+      "[itemType: .dayBackground(2020-01-11), frame: (279.5, 191.5, 35.5, 35.5)]",
+      "[itemType: .dayBackground(2020-01-15), frame: (142.0, 247.0, 36.0, 36.0)]",
+      "[itemType: .dayBackground(2020-01-18), frame: (279.5, 247.0, 35.5, 36.0)]",
+      "[itemType: .dayBackground(2020-01-16), frame: (188.0, 247.0, 35.5, 36.0)]",
+      "[itemType: .dayBackground(2020-01-17), frame: (233.5, 247.0, 36.0, 36.0)]",
+      "[itemType: .dayBackground(2020-01-14), frame: (96.5, 247.0, 35.5, 36.0)]",
+      "[itemType: .dayBackground(2020-01-12), frame: (5.0, 247.0, 35.5, 36.0)]",
+      "[itemType: .dayBackground(2020-01-19), frame: (5.0, 303.0, 35.5, 35.5)]",
     ]
 
     XCTAssert(
@@ -894,6 +968,15 @@ final class VisibleItemsProviderTests: XCTestCase {
       "[itemType: .pinnedDaysOfWeekRowSeparator, frame: (0.0, 84.5, 320.0, 1.0)]",
       "[itemType: .monthBackground(2020-02), frame: (0.0, 391.0, 320.0, 353.5)]",
       "[itemType: .monthBackground(2020-01), frame: (0.0, 37.5, 320.0, 353.5)]",
+      "[itemType: .dayBackground(2020-01-17), frame: (233.5, 236.5, 36.0, 35.5)]",
+      "[itemType: .dayBackground(2020-01-19), frame: (5.0, 292.0, 35.5, 36.0)]",
+      "[itemType: .dayBackground(2020-01-15), frame: (142.0, 236.5, 36.0, 35.5)]",
+      "[itemType: .dayBackground(2020-01-12), frame: (5.0, 236.5, 35.5, 35.5)]",
+      "[itemType: .dayBackground(2020-01-13), frame: (50.5, 236.5, 36.0, 35.5)]",
+      "[itemType: .dayBackground(2020-01-16), frame: (188.0, 236.5, 35.5, 35.5)]",
+      "[itemType: .dayBackground(2020-01-18), frame: (279.5, 236.5, 35.5, 35.5)]",
+      "[itemType: .dayBackground(2020-01-11), frame: (279.5, 180.5, 35.5, 36.0)]",
+      "[itemType: .dayBackground(2020-01-14), frame: (96.5, 236.5, 35.5, 35.5)]",
     ]
 
     XCTAssert(
@@ -1001,6 +1084,16 @@ final class VisibleItemsProviderTests: XCTestCase {
       "[itemType: .daysOfWeekRowSeparator(2020-12), frame: (1200.0, 112.0, 300.0, 1.0)]",
       "[itemType: .monthBackground(2020-11), frame: (877.5, -51.5, 315.0, 480.0)]",
       "[itemType: .monthBackground(2020-12), frame: (1192.5, -51.5, 315.0, 480.0)]",
+      "[itemType: .dayBackground(2020-11-19), frame: (1061.5, 238.5, 33.0, 33.0)]",
+      "[itemType: .dayBackground(2020-11-12), frame: (1061.5, 185.5, 33.0, 33.0)]",
+      "[itemType: .dayBackground(2020-12-14), frame: (1248.0, 238.5, 32.5, 33.0)]",
+      "[itemType: .dayBackground(2020-12-13), frame: (1205.0, 238.5, 33.0, 33.0)]",
+      "[itemType: .dayBackground(2020-11-18), frame: (1018.5, 238.5, 33.0, 33.0)]",
+      "[itemType: .dayBackground(2020-11-17), frame: (975.5, 238.5, 33.0, 33.0)]",
+      "[itemType: .dayBackground(2020-11-13), frame: (1104.5, 185.5, 32.5, 33.0)]",
+      "[itemType: .dayBackground(2020-11-14), frame: (1147.0, 185.5, 33.0, 33.0)]",
+      "[itemType: .dayBackground(2020-11-11), frame: (1018.5, 185.5, 33.0, 33.0)]",
+      "[itemType: .dayBackground(2020-12-15), frame: (1290.5, 238.5, 33.0, 33.0)]",
     ]
 
     XCTAssert(
@@ -1804,6 +1897,14 @@ final class VisibleItemsProviderTests: XCTestCase {
       .monthBackgroundItemProvider { _ in mockCalendarItemModel }
       .dayOfWeekItemProvider { _, _ in mockCalendarItemModel }
       .dayItemProvider { _ in mockCalendarItemModel }
+      .dayBackgroundItemProvider { day in
+        // Just test a few backgrounds to make sure they're working correctly
+        if day.day > 10 && day.day < 20 {
+          return mockCalendarItemModel
+        } else {
+          return nil
+        }
+      }
       .dayRangeItemProvider(
         for: [
           calendar.date(from: DateComponents(year: 2020, month: 03, day: 11))!
@@ -1846,6 +1947,8 @@ extension VisibleItem: CustomStringConvertible {
       itemTypeText = ".daysOfWeekRowSeparator(\(month.year)-\(month.month))"
     case .dayRange(let dayRange):
       itemTypeText = ".dayRange(\(dayRange.lowerBound), \(dayRange.upperBound))"
+    case .dayBackground(let day):
+      itemTypeText = ".dayBackground(\(day))"
     case .monthBackground(let month):
       itemTypeText = ".monthBackground(\(month.description))"
     case .overlayItem(let overlaidItemLocation):


### PR DESCRIPTION
## Details

This PR adds a day background item provider API. This allows people to add some decoration behind an individual day (and also below the day range indicator layer). Why do we need this? Consider this Airbnb host calendar design:

![image](https://user-images.githubusercontent.com/746571/212132729-bf651022-226a-4e9f-aa31-52faa34de36c.png)

With a day background API, we can implement this whole thing like this:

<img width="1062" alt="image" src="https://user-images.githubusercontent.com/746571/212132803-f03c665f-6b61-4533-aed2-0dd7a399bac2.png">

## Related Issue

N/A

## Motivation and Context

Enable some more advanced layering of views

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
