### PR TITLE
Prevent programmatic scroll cancellation on content update

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -13,12 +13,12 @@ jobs:
 
     strategy:
       matrix:
-        destination: ['platform=iOS Simulator,OS=11.0,name=iPhone 8', 'platform=iOS Simulator,OS=16.0,name=iPhone 14']
+        destination: ['platform=iOS Simulator,OS=11.0,name=iPhone 8', 'platform=iOS Simulator,OS=16.2,name=iPhone 14']
 
     steps:
     - uses: actions/checkout@v2
     - name: Build
       run: xcodebuild clean build -scheme HorizonCalendar
     - name: Run tests
-      run: xcodebuild clean test -project HorizonCalendar.xcodeproj -scheme HorizonCalendar -destination "name=iPhone 8,OS=16.0"
+      run: xcodebuild clean test -project HorizonCalendar.xcodeproj -scheme HorizonCalendar -destination "name=iPhone 8,OS=16.2"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a `dayRange` property to `CalendarViewContent.DayRangeLayoutContext`
 - Added support for day backgrounds, enabling developers to add visual decoration behind individual days. These decoration views also appear behind any day range indicators, making it possible to have a day range indicator appear between the day's number and any background decoration.
 
+### Fixed
+- Fixed an issue that caused an in-flight programmatic scroll to be cancelled if `setContent` was called
+
 ### Changed
 - Removed spaces from folder names within the `Sources` folder to reduce the chance of sensitive 🥺 build systems complaining or breaking
 
@@ -32,7 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated README.md and the example app to use the new convenience function for creating `CalendarItemModel`s
 - Improved the highlight-state animation for the default `DayView`, improving perceived responsiveness
 - Renamed the internal type `VisibleCalendarItem` to `VisibleItem` for brevity
-- Switched from relying on `layer.zPosition` to control item view z-axis ordering, to inserting subviews in the correct order of the scroll view's subviews array.
+- Switched from relying on `layer.zPosition` to control item view z-axis ordering, to inserting subviews in the correct order of the scroll view's subviews array
 - Optimized view reuse code by hiding and unhiding views, rather than adding and removing subviews. This was made possible by the aforementioned z-axis ordering refactor.
 
 ## [v1.14.0](https://github.com/airbnb/HorizonCalendar/compare/v1.13.0...v1.14.0) - 2022-08-18

--- a/Sources/Public/CalendarView.swift
+++ b/Sources/Public/CalendarView.swift
@@ -234,12 +234,19 @@ public final class CalendarView: UIView {
   /// - Parameters:
   ///   - content: The content to use when rendering `CalendarView`.
   public func setContent(_ content: CalendarViewContent) {
+    let oldContent = self.content
+
     if let contentBackgroundColor = content.backgroundColor {
       backgroundColor = contentBackgroundColor
     }
 
     _visibleItemsProvider = nil
-    scrollToItemContext = nil
+
+    // We only need to clear the `scrollToItemContext` if the monthsLayout changed or the visible
+    // day range changed.
+    if content.monthsLayout != oldContent.monthsLayout || content.dayRange != oldContent.dayRange {
+      scrollToItemContext = nil
+    }
 
     let isAnchorLayoutItemValid: Bool
     switch anchorLayoutItem?.itemType {
@@ -262,8 +269,6 @@ public final class CalendarView: UIView {
     } else {
       scrollView.decelerationRate = .normal
     }
-
-    let oldContent = self.content
 
     if
       oldContent.monthsLayout != content.monthsLayout ||


### PR DESCRIPTION
## Details

If a programmatic scroll animation is in-flight and `setContent` is called, then the scroll animation will be cancelled. We only need to clear the `scrollToItemContext` for certain kinds of content updates. This PR fixes that.

## Related Issue

N/A

## Motivation and Context

Notices an issue in the Airbnb app.

## How Has This Been Tested

Airbnb app, example project.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
