### PR TITLE
Fix z-index of pinned days of week row separator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed an issue that caused an in-flight programmatic scroll to be cancelled if `setContent` was called
+- Fixed an issue that caused the pinned days-of-the-week row separator to appear at the wrong z-position 
 
 ### Changed
 - Removed spaces from folder names within the `Sources` folder to reduce the chance of sensitive 🥺 build systems complaining or breaking

--- a/Sources/Internal/SubviewInsertionIndexTracker.swift
+++ b/Sources/Internal/SubviewInsertionIndexTracker.swift
@@ -33,8 +33,8 @@ final class SubviewInsertionIndexTracker {
       daysOfWeekRowSeparatorItemsEndIndex += 1
       overlayItemsEndIndex += 1
       pinnedDaysOfWeekRowBackgroundEndIndex += 1
-      pinnedDaysOfWeekRowSeparatorEndIndex += 1
       pinnedDayOfWeekItemsEndIndex += 1
+      pinnedDaysOfWeekRowSeparatorEndIndex += 1
 
     case .dayBackground:
       index = dayBackgroundItemsEndIndex
@@ -44,8 +44,8 @@ final class SubviewInsertionIndexTracker {
       daysOfWeekRowSeparatorItemsEndIndex += 1
       overlayItemsEndIndex += 1
       pinnedDaysOfWeekRowBackgroundEndIndex += 1
-      pinnedDaysOfWeekRowSeparatorEndIndex += 1
       pinnedDayOfWeekItemsEndIndex += 1
+      pinnedDaysOfWeekRowSeparatorEndIndex += 1
     
     case .dayRange:
       index = dayRangeItemsEndIndex
@@ -54,8 +54,8 @@ final class SubviewInsertionIndexTracker {
       daysOfWeekRowSeparatorItemsEndIndex += 1
       overlayItemsEndIndex += 1
       pinnedDaysOfWeekRowBackgroundEndIndex += 1
-      pinnedDaysOfWeekRowSeparatorEndIndex += 1
       pinnedDayOfWeekItemsEndIndex += 1
+      pinnedDaysOfWeekRowSeparatorEndIndex += 1
 
     case .layoutItemType:
       index = mainItemsEndIndex
@@ -63,38 +63,38 @@ final class SubviewInsertionIndexTracker {
       daysOfWeekRowSeparatorItemsEndIndex += 1
       overlayItemsEndIndex += 1
       pinnedDaysOfWeekRowBackgroundEndIndex += 1
-      pinnedDaysOfWeekRowSeparatorEndIndex += 1
       pinnedDayOfWeekItemsEndIndex += 1
+      pinnedDaysOfWeekRowSeparatorEndIndex += 1
 
     case .daysOfWeekRowSeparator:
       index = daysOfWeekRowSeparatorItemsEndIndex
       daysOfWeekRowSeparatorItemsEndIndex += 1
       overlayItemsEndIndex += 1
       pinnedDaysOfWeekRowBackgroundEndIndex += 1
-      pinnedDaysOfWeekRowSeparatorEndIndex += 1
       pinnedDayOfWeekItemsEndIndex += 1
+      pinnedDaysOfWeekRowSeparatorEndIndex += 1
 
     case .overlayItem:
       index = overlayItemsEndIndex
       overlayItemsEndIndex += 1
       pinnedDaysOfWeekRowBackgroundEndIndex += 1
-      pinnedDaysOfWeekRowSeparatorEndIndex += 1
       pinnedDayOfWeekItemsEndIndex += 1
+      pinnedDaysOfWeekRowSeparatorEndIndex += 1
 
     case .pinnedDaysOfWeekRowBackground:
       index = pinnedDaysOfWeekRowBackgroundEndIndex
       pinnedDaysOfWeekRowBackgroundEndIndex += 1
-      pinnedDaysOfWeekRowSeparatorEndIndex += 1
       pinnedDayOfWeekItemsEndIndex += 1
-
-    case .pinnedDaysOfWeekRowSeparator:
-      index = pinnedDaysOfWeekRowSeparatorEndIndex
       pinnedDaysOfWeekRowSeparatorEndIndex += 1
-      pinnedDayOfWeekItemsEndIndex += 1
 
     case .pinnedDayOfWeek:
       index = pinnedDayOfWeekItemsEndIndex
       pinnedDayOfWeekItemsEndIndex += 1
+      pinnedDaysOfWeekRowSeparatorEndIndex += 1
+
+    case .pinnedDaysOfWeekRowSeparator:
+      index = pinnedDaysOfWeekRowSeparatorEndIndex
+      pinnedDaysOfWeekRowSeparatorEndIndex += 1
     }
 
     return index
@@ -109,7 +109,7 @@ final class SubviewInsertionIndexTracker {
   private var daysOfWeekRowSeparatorItemsEndIndex = 0
   private var overlayItemsEndIndex = 0
   private var pinnedDaysOfWeekRowBackgroundEndIndex = 0
-  private var pinnedDaysOfWeekRowSeparatorEndIndex = 0
   private var pinnedDayOfWeekItemsEndIndex = 0
+  private var pinnedDaysOfWeekRowSeparatorEndIndex = 0
 
 }

--- a/Tests/SubviewsManagerTests.swift
+++ b/Tests/SubviewsManagerTests.swift
@@ -143,8 +143,8 @@ extension VisibleItem.ItemType: Comparable {
     case .daysOfWeekRowSeparator: return 4
     case .overlayItem: return 5
     case .pinnedDaysOfWeekRowBackground: return 6
-    case .pinnedDaysOfWeekRowSeparator: return 7
-    case .pinnedDayOfWeek: return 8
+    case .pinnedDayOfWeek: return 7
+    case .pinnedDaysOfWeekRowSeparator: return 8
     }
   }
 


### PR DESCRIPTION
## Details

This fixes a regression that caused the pinned days-of-the-week row separator to appear at the wrong z-position.

<img width="777" alt="image" src="https://user-images.githubusercontent.com/746571/214370388-c071539c-7c1a-480d-b840-e3d184645749.png">

## Related Issue

N/A

## Motivation and Context

Bug fix

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
