### PR TITLE
Bk/improve accessibility focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed an issue that caused an in-flight programmatic scroll to be cancelled if `setContent` was called
-- Fixed an issue that caused the pinned days-of-the-week row separator to appear at the wrong z-position 
+- Fixed an issue that caused the pinned days-of-the-week row separator to appear at the wrong z-position
+- Fixed an issue that caused accessibility focus to shift to an unexpected location after some types of content updates occurred
 
 ### Changed
 - Removed spaces from folder names within the `Sources` folder to reduce the chance of sensitive 🥺 build systems complaining or breaking

--- a/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/DayRangeSelectionDemoViewController.swift
+++ b/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/DayRangeSelectionDemoViewController.swift
@@ -40,18 +40,6 @@ final class DayRangeSelectionDemoViewController: DemoViewController {
       }
 
       self.calendarView.setContent(self.makeContent())
-
-      if
-        UIAccessibility.isVoiceOverRunning,
-        let selectedDate = self.calendar.date(from: day.components)
-      {
-        // Forcing layout is necessary to guarantee that the view will be ready to receive
-        // accessibility focus.
-        self.calendarView.layoutIfNeeded()
-        let accessibilityElementToFocus = self.calendarView.accessibilityElementForVisibleDate(
-          selectedDate)
-        UIAccessibility.post(notification: .screenChanged, argument: accessibilityElementToFocus)
-      }
     }
   }
 

--- a/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/PartialMonthVisibilityDemoViewController.swift
+++ b/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/PartialMonthVisibilityDemoViewController.swift
@@ -18,15 +18,6 @@ final class PartialMonthVisibilityDemoViewController: DemoViewController {
 
       self.selectedDate = self.calendar.date(from: day.components)
       self.calendarView.setContent(self.makeContent())
-
-      if UIAccessibility.isVoiceOverRunning, let selectedDate = self.selectedDate {
-        // Forcing layout is necessary to guarantee that the view will be ready to receive
-        // accessibility focus.
-        self.calendarView.layoutIfNeeded()
-        let accessibilityElementToFocus = self.calendarView.accessibilityElementForVisibleDate(
-          selectedDate)
-        UIAccessibility.post(notification: .screenChanged, argument: accessibilityElementToFocus)
-      }
     }
   }
 

--- a/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/SelectedDayTooltipDemoViewController.swift
+++ b/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/SelectedDayTooltipDemoViewController.swift
@@ -30,15 +30,6 @@ final class SelectedDayTooltipDemoViewController: DemoViewController {
 
       self.selectedDate = self.calendar.date(from: day.components)
       self.calendarView.setContent(self.makeContent())
-
-      if UIAccessibility.isVoiceOverRunning, let selectedDate = self.selectedDate {
-        // Forcing layout is necessary to guarantee that the view will be ready to receive
-        // accessibility focus.
-        self.calendarView.layoutIfNeeded()
-        let accessibilityElementToFocus = self.calendarView.accessibilityElementForVisibleDate(
-          selectedDate)
-        UIAccessibility.post(notification: .screenChanged, argument: accessibilityElementToFocus)
-      }
     }
   }
 

--- a/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/SingleDaySelectionDemoViewController.swift
+++ b/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/SingleDaySelectionDemoViewController.swift
@@ -41,15 +41,6 @@ final class SingleDaySelectionDemoViewController: DemoViewController {
 
       self.selectedDate = self.calendar.date(from: day.components)
       self.calendarView.setContent(self.makeContent())
-
-      if UIAccessibility.isVoiceOverRunning, let selectedDate = self.selectedDate {
-        // Forcing layout is necessary to guarantee that the view will be ready to receive
-        // accessibility focus.
-        self.calendarView.layoutIfNeeded()
-        let accessibilityElementToFocus = self.calendarView.accessibilityElementForVisibleDate(
-          selectedDate)
-        UIAccessibility.post(notification: .screenChanged, argument: accessibilityElementToFocus)
-      }
     }
   }
 

--- a/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/SwiftUIItemModelsDemoViewController.swift
+++ b/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/SwiftUIItemModelsDemoViewController.swift
@@ -31,15 +31,6 @@ final class SwiftUIItemModelsDemoViewController: DemoViewController {
 
       self.selectedDate = self.calendar.date(from: day.components)
       self.calendarView.setContent(self.makeContent())
-
-      if UIAccessibility.isVoiceOverRunning, let selectedDate = self.selectedDate {
-        // Forcing layout is necessary to guarantee that the view will be ready to receive
-        // accessibility focus.
-        self.calendarView.layoutIfNeeded()
-        let accessibilityElementToFocus = self.calendarView.accessibilityElementForVisibleDate(
-          selectedDate)
-        UIAccessibility.post(notification: .screenChanged, argument: accessibilityElementToFocus)
-      }
     }
   }
 


### PR DESCRIPTION
## Details

Accessibility focus would sometimes shift to a different item after calling `setContent`. The reason for this is because an item might be reused under the hood, taking the accessibility focus to a different / unexpected view. This PR ensures that we maintain our _expected_ focus location / view, even after views are reused.

## Related Issue

N/A

## Motivation and Context

Bug fix

## How Has This Been Tested

Example project

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
