### PR TITLE
Add month grid background view and demo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for month backgrounds, enabling things like grid lines and colored backgrounds for months
 - Added a `dayRange` property to `CalendarViewContent.DayRangeLayoutContext`
 - Added support for day backgrounds, enabling developers to add visual decoration behind individual days. These decoration views also appear behind any day range indicators, making it possible to have a day range indicator appear between the day's number and any background decoration.
+- Added `MonthGridBackgroundView`, a view that can be used with the `monthBackgroundItemProvider` to add grid lines between the days in a month
 
 ### Fixed
 - Fixed an issue that caused an in-flight programmatic scroll to be cancelled if `setContent` was called

--- a/Example/HorizonCalendarExample/HorizonCalendarExample.xcodeproj/project.pbxproj
+++ b/Example/HorizonCalendarExample/HorizonCalendarExample.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		93AF5545248DCC8900BDB0FF /* DayRangeIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93AF5544248DCC8900BDB0FF /* DayRangeIndicatorView.swift */; };
 		FDA0FB3528F5EFD90066DEFA /* SwiftUIDayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDA0FB3428F5EFD90066DEFA /* SwiftUIDayView.swift */; };
 		FDA0FB3728F5EFF60066DEFA /* SwiftUIItemModelsDemoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDA0FB3628F5EFF60066DEFA /* SwiftUIItemModelsDemoViewController.swift */; };
+		FDD8EE7429885AF500F6EC9D /* MonthBackgroundDemoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDD8EE7329885AF500F6EC9D /* MonthBackgroundDemoViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -59,6 +60,7 @@
 		93AF5544248DCC8900BDB0FF /* DayRangeIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DayRangeIndicatorView.swift; sourceTree = "<group>"; };
 		FDA0FB3428F5EFD90066DEFA /* SwiftUIDayView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftUIDayView.swift; sourceTree = "<group>"; };
 		FDA0FB3628F5EFF60066DEFA /* SwiftUIItemModelsDemoViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftUIItemModelsDemoViewController.swift; sourceTree = "<group>"; };
+		FDD8EE7329885AF500F6EC9D /* MonthBackgroundDemoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonthBackgroundDemoViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -83,6 +85,7 @@
 				938176A4249B828600E18FA3 /* LargeDayRangeDemoViewController.swift */,
 				9381769E249B79DC00E18FA3 /* ScrollToDayWithAnimationDemoViewController.swift */,
 				93A7258D24A1F26C00B4F08F /* PartialMonthVisibilityDemoViewController.swift */,
+				FDD8EE7329885AF500F6EC9D /* MonthBackgroundDemoViewController.swift */,
 				FDA0FB3628F5EFF60066DEFA /* SwiftUIItemModelsDemoViewController.swift */,
 			);
 			path = "Demo View Controllers";
@@ -212,6 +215,7 @@
 				9381769F249B79DC00E18FA3 /* ScrollToDayWithAnimationDemoViewController.swift in Sources */,
 				93AF5545248DCC8900BDB0FF /* DayRangeIndicatorView.swift in Sources */,
 				938176A5249B828600E18FA3 /* LargeDayRangeDemoViewController.swift in Sources */,
+				FDD8EE7429885AF500F6EC9D /* MonthBackgroundDemoViewController.swift in Sources */,
 				939E696B2484CD8E00A8BCC7 /* AppDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Example/HorizonCalendarExample/HorizonCalendarExample/DayRangeIndicatorView.swift
+++ b/Example/HorizonCalendarExample/HorizonCalendarExample/DayRangeIndicatorView.swift
@@ -36,21 +36,14 @@ final class DayRangeIndicatorView: UIView {
 
   // MARK: Internal
 
-  var framesOfDaysToHighlight = [CGRect]() {
-    didSet {
-      guard framesOfDaysToHighlight != oldValue else { return }
-      setNeedsDisplay()
-    }
-  }
-
   override func draw(_ rect: CGRect) {
     let context = UIGraphicsGetCurrentContext()
     context?.setFillColor(indicatorColor.cgColor)
 
     if traitCollection.layoutDirection == .rightToLeft {
-      transform = .init(scaleX: -1, y: 1)
-    } else {
-      transform = .identity
+      context?.translateBy(x: bounds.midX, y: bounds.midY)
+      context?.scaleBy(x: -1, y: 1)
+      context?.translateBy(x: -bounds.midX, y: -bounds.midY)
     }
 
     // Get frames of day rows in the range
@@ -72,6 +65,20 @@ final class DayRangeIndicatorView: UIView {
       let roundedRectanglePath = UIBezierPath(roundedRect: dayRowFrame, cornerRadius: cornerRadius)
       context?.addPath(roundedRectanglePath.cgPath)
       context?.fillPath()
+    }
+  }
+
+  override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+    super.traitCollectionDidChange(previousTraitCollection)
+    setNeedsDisplay()
+  }
+
+  // MARK: Fileprivate
+
+  fileprivate var framesOfDaysToHighlight = [CGRect]() {
+    didSet {
+      guard framesOfDaysToHighlight != oldValue else { return }
+      setNeedsDisplay()
     }
   }
 

--- a/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/MonthBackgroundDemoViewController.swift
+++ b/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/MonthBackgroundDemoViewController.swift
@@ -1,0 +1,54 @@
+// Created by Bryan Keller on 1/30/23.
+// Copyright © 2023 Airbnb Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import HorizonCalendar
+import UIKit
+
+final class MonthBackgroundDemoViewController: DemoViewController {
+
+  // MARK: Internal
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+
+    title = "Month Grid Background"
+  }
+
+  override func makeContent() -> CalendarViewContent {
+    let startDate = calendar.date(from: DateComponents(year: 2020, month: 01, day: 01))!
+    let endDate = calendar.date(from: DateComponents(year: 2021, month: 12, day: 31))!
+
+    return CalendarViewContent(
+      calendar: calendar,
+      visibleDateRange: startDate...endDate,
+      monthsLayout: monthsLayout)
+
+      .interMonthSpacing(24)
+      .verticalDayMargin(8)
+      .horizontalDayMargin(8)
+
+      .monthBackgroundItemProvider { monthLayoutContext in
+        MonthGridBackgroundView.calendarItemModel(
+          invariantViewProperties: .init(horizontalDayMargin: 8, verticalDayMargin: 8),
+          viewModel: .init(framesOfDays: monthLayoutContext.daysAndFrames.map { $0.frame }))
+      }
+  }
+
+  // MARK: Private
+
+  private var selectedDate: Date?
+
+}
+

--- a/Example/HorizonCalendarExample/HorizonCalendarExample/DemoPickerViewController.swift
+++ b/Example/HorizonCalendarExample/HorizonCalendarExample/DemoPickerViewController.swift
@@ -65,6 +65,7 @@ final class DemoPickerViewController: UIViewController {
       ("Large Day Range", LargeDayRangeDemoViewController.self),
       ("Scroll to Day With Animation", ScrollToDayWithAnimationDemoViewController.self),
       ("Partial Month Visibility", PartialMonthVisibilityDemoViewController.self),
+      ("Month Grid Background", MonthBackgroundDemoViewController.self),
       ("SwiftUI Day and Month View", SwiftUIItemModelsDemoViewController.self),
     ]
 
@@ -75,6 +76,7 @@ final class DemoPickerViewController: UIViewController {
       ("Selected Day Tooltip", SelectedDayTooltipDemoViewController.self),
       ("Large Day Range", LargeDayRangeDemoViewController.self),
       ("Scroll to Day With Animation", ScrollToDayWithAnimationDemoViewController.self),
+      ("Month Grid Background", MonthBackgroundDemoViewController.self),
       ("SwiftUI Day and Month View", SwiftUIItemModelsDemoViewController.self),
     ]
 

--- a/Example/HorizonCalendarExample/HorizonCalendarExample/TooltipView.swift
+++ b/Example/HorizonCalendarExample/HorizonCalendarExample/TooltipView.swift
@@ -47,18 +47,6 @@ final class TooltipView: UIView {
 
   // MARK: Internal
 
-  var frameOfTooltippedItem: CGRect? {
-    didSet {
-      guard frameOfTooltippedItem != oldValue else { return }
-      setNeedsLayout()
-    }
-  }
-
-  var text: String {
-    get { label.text ?? "" }
-    set { label.text = newValue }
-  }
-
   override func layoutSubviews() {
     super.layoutSubviews()
 
@@ -88,6 +76,20 @@ final class TooltipView: UIView {
 
     backgroundView.frame = frame
     label.center = backgroundView.center
+  }
+
+  // MARK: Fileprivate
+
+  fileprivate var frameOfTooltippedItem: CGRect? {
+    didSet {
+      guard frameOfTooltippedItem != oldValue else { return }
+      setNeedsLayout()
+    }
+  }
+
+  fileprivate var text: String {
+    get { label.text ?? "" }
+    set { label.text = newValue }
   }
 
   // MARK: Private

--- a/HorizonCalendar.xcodeproj/project.pbxproj
+++ b/HorizonCalendar.xcodeproj/project.pbxproj
@@ -67,6 +67,7 @@
 		FD2C7DC52922C75800B54C1D /* CHANGELOG.md in Resources */ = {isa = PBXBuildFile; fileRef = FD2C7DC42922C75700B54C1D /* CHANGELOG.md */; };
 		FD3D9B6128ED2C1500CC6D62 /* UIView+NoAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD3D9B6028ED2C1500CC6D62 /* UIView+NoAnimation.swift */; };
 		FD9CDA90293B5E4D00A77188 /* SubviewInsertionIndexTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD9CDA8F293B5E4D00A77188 /* SubviewInsertionIndexTracker.swift */; };
+		FDD8EE7829886E2200F6EC9D /* MonthGridBackgroundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDD8EE7729886E2200F6EC9D /* MonthGridBackgroundView.swift */; };
 		FDE2893C28F8A6D50020EBF1 /* SwiftUIWrapperView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDE2893B28F8A6D50020EBF1 /* SwiftUIWrapperView.swift */; };
 /* End PBXBuildFile section */
 
@@ -144,6 +145,7 @@
 		FD2C7DC42922C75700B54C1D /* CHANGELOG.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = CHANGELOG.md; sourceTree = "<group>"; };
 		FD3D9B6028ED2C1500CC6D62 /* UIView+NoAnimation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+NoAnimation.swift"; sourceTree = "<group>"; };
 		FD9CDA8F293B5E4D00A77188 /* SubviewInsertionIndexTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubviewInsertionIndexTracker.swift; sourceTree = "<group>"; };
+		FDD8EE7729886E2200F6EC9D /* MonthGridBackgroundView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MonthGridBackgroundView.swift; sourceTree = "<group>"; };
 		FDE2893B28F8A6D50020EBF1 /* SwiftUIWrapperView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftUIWrapperView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -181,6 +183,7 @@
 				9321957D26EEB44C0001C7E9 /* DayOfWeekView.swift */,
 				932FC00D26ED5191005E39A6 /* DayView.swift */,
 				9321958126EEB6AB0001C7E9 /* DrawingConfig.swift */,
+				FDD8EE7729886E2200F6EC9D /* MonthGridBackgroundView.swift */,
 				9321958326EEB97F0001C7E9 /* MonthHeaderView.swift */,
 				9321957F26EEB6330001C7E9 /* Shape.swift */,
 				FDE2893B28F8A6D50020EBF1 /* SwiftUIWrapperView.swift */,
@@ -432,6 +435,7 @@
 				93061FFE24F1AE1700177ECC /* CalendarViewContent+CalendarItem.swift in Sources */,
 				939E693E24846A6600A8BCC7 /* Month.swift in Sources */,
 				939E692E24837E0300A8BCC7 /* ScrollToItemContext.swift in Sources */,
+				FDD8EE7829886E2200F6EC9D /* MonthGridBackgroundView.swift in Sources */,
 				9321958426EEB97F0001C7E9 /* MonthHeaderView.swift in Sources */,
 				932FC01126ED6C49005E39A6 /* UIEdgeInsets+Hashable.swift in Sources */,
 				939E693824837E8700A8BCC7 /* CalendarViewScrollPosition.swift in Sources */,

--- a/Sources/Public/ItemViews/MonthGridBackgroundView.swift
+++ b/Sources/Public/ItemViews/MonthGridBackgroundView.swift
@@ -1,0 +1,125 @@
+// Created by Bryan Keller on 1/30/23.
+// Copyright © 2023 Airbnb Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import UIKit
+
+// MARK: - MonthGridBackgroundView
+
+/// A background grid view that draws separator lines between all days in a month. 
+public final class MonthGridBackgroundView: UIView {
+
+  // MARK: Lifecycle
+
+  fileprivate init(invariantViewProperties: InvariantViewProperties) {
+    self.invariantViewProperties = invariantViewProperties
+    super.init(frame: .zero)
+    backgroundColor = .clear
+  }
+
+  required init?(coder _: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  // MARK: Public
+
+  public override func draw(_: CGRect) {
+    let context = UIGraphicsGetCurrentContext()
+    context?.setLineWidth(invariantViewProperties.lineWidth)
+    context?.setStrokeColor(invariantViewProperties.color.cgColor)
+
+    if traitCollection.layoutDirection == .rightToLeft {
+      transform = .init(scaleX: -1, y: 1)
+    } else {
+      transform = .identity
+    }
+
+    for dayFrame in framesOfDays {
+      let gridRect = CGRect(
+        x: dayFrame.minX - (invariantViewProperties.horizontalDayMargin / 2),
+        y: dayFrame.minY - (invariantViewProperties.verticalDayMargin / 2),
+        width: dayFrame.width + invariantViewProperties.horizontalDayMargin,
+        height: dayFrame.height + invariantViewProperties.verticalDayMargin)
+      context?.stroke(gridRect)
+    }
+  }
+
+  // MARK: Fileprivate
+
+  fileprivate var framesOfDays = [CGRect]() {
+    didSet {
+      guard framesOfDays != oldValue else { return }
+      setNeedsDisplay()
+    }
+  }
+
+  // MARK: Private
+
+  private let invariantViewProperties: InvariantViewProperties
+
+}
+
+// MARK: CalendarItemViewRepresentable
+
+extension MonthGridBackgroundView: CalendarItemViewRepresentable {
+
+  public struct InvariantViewProperties: Hashable {
+
+    // MARK: Lifecycle
+
+    public init(
+      lineWidth: CGFloat = 1,
+      color: UIColor = .lightGray,
+      horizontalDayMargin: CGFloat,
+      verticalDayMargin: CGFloat)
+    {
+      self.lineWidth = lineWidth
+      self.color = color
+      self.horizontalDayMargin = horizontalDayMargin
+      self.verticalDayMargin = verticalDayMargin
+    }
+
+    // MARK: Internal
+
+    var lineWidth: CGFloat
+    var color: UIColor
+    var horizontalDayMargin: CGFloat
+    var verticalDayMargin: CGFloat
+  }
+
+  public struct ViewModel: Equatable {
+
+    // MARK: Lifecycle
+
+    public init(framesOfDays: [CGRect]) {
+      self.framesOfDays = framesOfDays
+    }
+
+    // MARK: Internal
+
+    let framesOfDays: [CGRect]
+  }
+
+  public static func makeView(
+    withInvariantViewProperties invariantViewProperties: InvariantViewProperties)
+    -> MonthGridBackgroundView
+  {
+    MonthGridBackgroundView(invariantViewProperties: invariantViewProperties)
+  }
+
+  public static func setViewModel(_ viewModel: ViewModel, on view: MonthGridBackgroundView) {
+    view.framesOfDays = viewModel.framesOfDays
+  }
+
+}

--- a/Sources/Public/ItemViews/MonthGridBackgroundView.swift
+++ b/Sources/Public/ItemViews/MonthGridBackgroundView.swift
@@ -40,9 +40,9 @@ public final class MonthGridBackgroundView: UIView {
     context?.setStrokeColor(invariantViewProperties.color.cgColor)
 
     if traitCollection.layoutDirection == .rightToLeft {
-      transform = .init(scaleX: -1, y: 1)
-    } else {
-      transform = .identity
+      context?.translateBy(x: bounds.midX, y: bounds.midY)
+      context?.scaleBy(x: -1, y: 1)
+      context?.translateBy(x: -bounds.midX, y: -bounds.midY)
     }
 
     for dayFrame in framesOfDays {
@@ -53,6 +53,11 @@ public final class MonthGridBackgroundView: UIView {
         height: dayFrame.height + invariantViewProperties.verticalDayMargin)
       context?.stroke(gridRect)
     }
+  }
+
+  public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+    super.traitCollectionDidChange(previousTraitCollection)
+    setNeedsDisplay()
   }
 
   // MARK: Fileprivate


### PR DESCRIPTION
## Details

Adds a MonthGridBackgroundView so people can easily add grid lines to their calendar (with the new monthBackgroundItemProvider API).

I'm going to do a follow-up PR with updates to documentation. There are a few things I want to change (including some updated screenshots).

| Grid |
|----|
| ![Simulator Screen Shot - iPhone 14 Pro - 2023-01-30 at 13 32 10](https://user-images.githubusercontent.com/746571/215599739-e7c7248c-c16f-42f2-9bab-527ced61a9f3.png) |

## Related Issue

N/A

## Motivation and Context

Grid are a common use case, so providing a default view seems helpful!

## How Has This Been Tested

Example app

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
