### PR TITLE
Bk/calendar view representable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/airbnb/HorizonCalendar/compare/v1.16.0...HEAD)
 
+### Added
+- Added `MonthsLayout.vertical` and `MonthsLayout.horizontal` as more concise alternatives to `MonthsLayout.vertical(options: .init())` and `MonthsLayout.horizontal(options: .init())`, respectively
+- Added `CalendarViewRepresentable` enabling developers to use `CalendarView` from SwiftUI
+
 ### Changed
 - Removed all deprecated code, simplifying the public API in preparation for a 2.0 release
 - Renamed `viewModel` to `content`, since it's a less-overloaded term
 - Changed `monthDayInsets` to take `NSDirectionalEdgeInsets`, rather than `UIEdgeInsets`
 - Un-nested some types to make them fit better with an upcoming SwiftUI API
 - Updated the default `HorizontalMonthLayoutOptions` to use a `restingPosition` of `.atLeadingEdgeOfEachMonth`, which is probably what most people want
-- Added `MonthsLayout.vertical` and `MonthsLayout.horizontal` as more concise alternatives to `MonthsLayout.vertical(options: .init())` and `MonthsLayout.horizontal(options: .init())`, respectively
-- Make more publicly-exposed types conform to `Hashable`, because why not - maybe API consumers want to stick things in a `Set` or `Dictionary`.
-- Allow `CalendarItemViewRepresentable` to have no `Content` type if the conforming view does not depend on any variable data
+- Updated more publicly-exposed types conform to `Hashable`, because why not - maybe API consumers want to stick things in a `Set` or `Dictionary`.
+- Allowed `CalendarItemViewRepresentable` to have no `Content` type if the conforming view does not depend on any variable data
 
 ## [v1.16.0](https://github.com/airbnb/HorizonCalendar/compare/v1.15.0...v1.16.0) - 2023-01-30
 

--- a/Example/HorizonCalendarExample/HorizonCalendarExample.xcodeproj/project.pbxproj
+++ b/Example/HorizonCalendarExample/HorizonCalendarExample.xcodeproj/project.pbxproj
@@ -22,6 +22,8 @@
 		939E69942484D55200A8BCC7 /* HorizonCalendar.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 939E69912484D11000A8BCC7 /* HorizonCalendar.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		93A7258E24A1F26C00B4F08F /* PartialMonthVisibilityDemoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93A7258D24A1F26C00B4F08F /* PartialMonthVisibilityDemoViewController.swift */; };
 		93AF5545248DCC8900BDB0FF /* DayRangeIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93AF5544248DCC8900BDB0FF /* DayRangeIndicatorView.swift */; };
+		FD55C5D7298B138A00A9B5D6 /* SwiftUIScreenDemoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD55C5D6298B138A00A9B5D6 /* SwiftUIScreenDemoViewController.swift */; };
+		FD6E1D1C2991CCDE00B480A6 /* CalendarSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD6E1D1B2991CCDE00B480A6 /* CalendarSelection.swift */; };
 		FDA0FB3528F5EFD90066DEFA /* SwiftUIDayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDA0FB3428F5EFD90066DEFA /* SwiftUIDayView.swift */; };
 		FDA0FB3728F5EFF60066DEFA /* SwiftUIItemModelsDemoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDA0FB3628F5EFF60066DEFA /* SwiftUIItemModelsDemoViewController.swift */; };
 		FDD8EE7429885AF500F6EC9D /* MonthBackgroundDemoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDD8EE7329885AF500F6EC9D /* MonthBackgroundDemoViewController.swift */; };
@@ -58,6 +60,8 @@
 		939E69912484D11000A8BCC7 /* HorizonCalendar.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = HorizonCalendar.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		93A7258D24A1F26C00B4F08F /* PartialMonthVisibilityDemoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PartialMonthVisibilityDemoViewController.swift; sourceTree = "<group>"; };
 		93AF5544248DCC8900BDB0FF /* DayRangeIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DayRangeIndicatorView.swift; sourceTree = "<group>"; };
+		FD55C5D6298B138A00A9B5D6 /* SwiftUIScreenDemoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIScreenDemoViewController.swift; sourceTree = "<group>"; };
+		FD6E1D1B2991CCDE00B480A6 /* CalendarSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarSelection.swift; sourceTree = "<group>"; };
 		FDA0FB3428F5EFD90066DEFA /* SwiftUIDayView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftUIDayView.swift; sourceTree = "<group>"; };
 		FDA0FB3628F5EFF60066DEFA /* SwiftUIItemModelsDemoViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftUIItemModelsDemoViewController.swift; sourceTree = "<group>"; };
 		FDD8EE7329885AF500F6EC9D /* MonthBackgroundDemoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonthBackgroundDemoViewController.swift; sourceTree = "<group>"; };
@@ -87,6 +91,7 @@
 				93A7258D24A1F26C00B4F08F /* PartialMonthVisibilityDemoViewController.swift */,
 				FDD8EE7329885AF500F6EC9D /* MonthBackgroundDemoViewController.swift */,
 				FDA0FB3628F5EFF60066DEFA /* SwiftUIItemModelsDemoViewController.swift */,
+				FD55C5D6298B138A00A9B5D6 /* SwiftUIScreenDemoViewController.swift */,
 			);
 			path = "Demo View Controllers";
 			sourceTree = "<group>";
@@ -114,8 +119,9 @@
 				939E696A2484CD8E00A8BCC7 /* AppDelegate.swift */,
 				9381769B249B74BB00E18FA3 /* DemoPickerViewController.swift */,
 				9381769D249B79CB00E18FA3 /* Demo View Controllers */,
-				FDA0FB3428F5EFD90066DEFA /* SwiftUIDayView.swift */,
+				FD6E1D1B2991CCDE00B480A6 /* CalendarSelection.swift */,
 				93AF5544248DCC8900BDB0FF /* DayRangeIndicatorView.swift */,
+				FDA0FB3428F5EFD90066DEFA /* SwiftUIDayView.swift */,
 				939853512498992E0022A3A1 /* TooltipView.swift */,
 				939E69732484CD9000A8BCC7 /* Assets.xcassets */,
 				939E69752484CD9000A8BCC7 /* LaunchScreen.storyboard */,
@@ -205,6 +211,7 @@
 			files = (
 				93A7258E24A1F26C00B4F08F /* PartialMonthVisibilityDemoViewController.swift in Sources */,
 				FDA0FB3728F5EFF60066DEFA /* SwiftUIItemModelsDemoViewController.swift in Sources */,
+				FD6E1D1C2991CCDE00B480A6 /* CalendarSelection.swift in Sources */,
 				939E696F2484CD8E00A8BCC7 /* SingleDaySelectionDemoViewController.swift in Sources */,
 				938176A3249B7F0800E18FA3 /* SelectedDayTooltipDemoViewController.swift in Sources */,
 				FDA0FB3528F5EFD90066DEFA /* SwiftUIDayView.swift in Sources */,
@@ -216,6 +223,7 @@
 				93AF5545248DCC8900BDB0FF /* DayRangeIndicatorView.swift in Sources */,
 				938176A5249B828600E18FA3 /* LargeDayRangeDemoViewController.swift in Sources */,
 				FDD8EE7429885AF500F6EC9D /* MonthBackgroundDemoViewController.swift in Sources */,
+				FD55C5D7298B138A00A9B5D6 /* SwiftUIScreenDemoViewController.swift in Sources */,
 				939E696B2484CD8E00A8BCC7 /* AppDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -285,7 +293,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -340,7 +348,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;
@@ -357,7 +365,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = C835JB7RUE;
 				INFOPLIST_FILE = HorizonCalendarExample/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -376,7 +384,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = C835JB7RUE;
 				INFOPLIST_FILE = HorizonCalendarExample/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Example/HorizonCalendarExample/HorizonCalendarExample/CalendarSelection.swift
+++ b/Example/HorizonCalendarExample/HorizonCalendarExample/CalendarSelection.swift
@@ -1,0 +1,21 @@
+// Created by Bryan Keller on 2/6/23.
+// Copyright © 2023 Airbnb Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import HorizonCalendar
+
+enum CalendarSelection {
+  case singleDay(Day)
+  case dayRange(DayRange)
+}

--- a/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/DayRangeSelectionDemoViewController.swift
+++ b/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/DayRangeSelectionDemoViewController.swift
@@ -16,7 +16,7 @@
 import HorizonCalendar
 import UIKit
 
-final class DayRangeSelectionDemoViewController: DemoViewController {
+final class DayRangeSelectionDemoViewController: BaseDemoViewController {
 
   // MARK: Internal
 
@@ -105,10 +105,6 @@ final class DayRangeSelectionDemoViewController: DemoViewController {
 
   // MARK: Private
 
-  private enum CalendarSelection {
-    case singleDay(Day)
-    case dayRange(DayRange)
-  }
   private var calendarSelection: CalendarSelection?
 
 }

--- a/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/DemoViewController.swift
+++ b/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/DemoViewController.swift
@@ -4,7 +4,20 @@
 import HorizonCalendar
 import UIKit
 
-class DemoViewController: UIViewController {
+// MARK: - DemoViewController
+
+protocol DemoViewController: UIViewController {
+
+  init(monthsLayout: MonthsLayout)
+
+  var calendar: Calendar { get }
+  var monthsLayout: MonthsLayout { get }
+
+}
+
+// MARK: - BaseDemoViewController
+
+class BaseDemoViewController: UIViewController, DemoViewController {
 
   // MARK: Lifecycle
 

--- a/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/LargeDayRangeDemoViewController.swift
+++ b/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/LargeDayRangeDemoViewController.swift
@@ -16,7 +16,7 @@
 import HorizonCalendar
 import UIKit
 
-final class LargeDayRangeDemoViewController: DemoViewController {
+final class LargeDayRangeDemoViewController: BaseDemoViewController {
 
   // MARK: Internal
 

--- a/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/MonthBackgroundDemoViewController.swift
+++ b/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/MonthBackgroundDemoViewController.swift
@@ -16,7 +16,7 @@
 import HorizonCalendar
 import UIKit
 
-final class MonthBackgroundDemoViewController: DemoViewController {
+final class MonthBackgroundDemoViewController: BaseDemoViewController {
 
   // MARK: Internal
 

--- a/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/PartialMonthVisibilityDemoViewController.swift
+++ b/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/PartialMonthVisibilityDemoViewController.swift
@@ -4,7 +4,7 @@
 import HorizonCalendar
 import UIKit
 
-final class PartialMonthVisibilityDemoViewController: DemoViewController {
+final class PartialMonthVisibilityDemoViewController: BaseDemoViewController {
 
   // MARK: Internal
 

--- a/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/ScrollToDayWithAnimationDemoViewController.swift
+++ b/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/ScrollToDayWithAnimationDemoViewController.swift
@@ -16,7 +16,7 @@
 import HorizonCalendar
 import UIKit
 
-final class ScrollToDayWithAnimationDemoViewController: DemoViewController {
+final class ScrollToDayWithAnimationDemoViewController: BaseDemoViewController {
 
   override func viewDidLoad() {
     super.viewDidLoad()

--- a/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/SelectedDayTooltipDemoViewController.swift
+++ b/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/SelectedDayTooltipDemoViewController.swift
@@ -16,7 +16,7 @@
 import HorizonCalendar
 import UIKit
 
-final class SelectedDayTooltipDemoViewController: DemoViewController {
+final class SelectedDayTooltipDemoViewController: BaseDemoViewController {
 
   // MARK: Internal
 

--- a/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/SingleDaySelectionDemoViewController.swift
+++ b/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/SingleDaySelectionDemoViewController.swift
@@ -16,7 +16,7 @@
 import HorizonCalendar
 import UIKit
 
-final class SingleDaySelectionDemoViewController: DemoViewController {
+final class SingleDaySelectionDemoViewController: BaseDemoViewController {
 
   // MARK: Lifecycle
 

--- a/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/SwiftUIItemModelsDemoViewController.swift
+++ b/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/SwiftUIItemModelsDemoViewController.swift
@@ -17,7 +17,7 @@ import HorizonCalendar
 import UIKit
 import SwiftUI
 
-final class SwiftUIItemModelsDemoViewController: DemoViewController {
+final class SwiftUIItemModelsDemoViewController: BaseDemoViewController {
 
   // MARK: Internal
 

--- a/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/SwiftUIScreenDemoViewController.swift
+++ b/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/SwiftUIScreenDemoViewController.swift
@@ -99,13 +99,15 @@ struct SwiftUIScreenDemo: View {
       let monthHeaderText = monthDateFormatter.string(from: calendar.date(from: month.components)!)
       if case .vertical = monthsLayout {
         return HStack {
-          Text(monthHeaderText).font(.title2)
+          Text(monthHeaderText)
+            .font(.title2)
           Spacer()
         }
         .padding()
         .calendarItemModel
       } else {
-        return Text(monthHeaderText).font(.title2)
+        return Text(monthHeaderText)
+          .font(.title2)
           .padding()
           .calendarItemModel
       }

--- a/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/SwiftUIScreenDemoViewController.swift
+++ b/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/SwiftUIScreenDemoViewController.swift
@@ -1,0 +1,176 @@
+// Created by Bryan Keller on 2/1/23.
+// Copyright © 2023 Airbnb Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import HorizonCalendar
+import SwiftUI
+
+// MARK: - SwiftUIScreenDemoViewController
+
+final class SwiftUIScreenDemoViewController: UIViewController, DemoViewController {
+
+  // MARK: Lifecycle
+
+  init(monthsLayout: MonthsLayout) {
+    self.monthsLayout = monthsLayout
+    super.init(nibName: nil, bundle: nil)
+  }
+
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  // MARK: Internal
+
+  let calendar = Calendar.current
+  let monthsLayout: MonthsLayout
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+
+    title = "SwiftUI Screen"
+
+    let hostingController = UIHostingController(
+      rootView: SwiftUIScreenDemo(calendar: calendar, monthsLayout: monthsLayout))
+    addChild(hostingController)
+
+    view.addSubview(hostingController.view)
+    hostingController.view.translatesAutoresizingMaskIntoConstraints = false
+    NSLayoutConstraint.activate([
+      hostingController.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+      hostingController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+      hostingController.view.topAnchor.constraint(equalTo: view.topAnchor),
+      hostingController.view.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+    ])
+
+    hostingController.didMove(toParent: self)
+  }
+
+}
+
+// MARK: - SwiftUIScreenDemo
+
+struct SwiftUIScreenDemo: View {
+
+  // MARK: Lifecycle
+
+  init(calendar: Calendar, monthsLayout: MonthsLayout) {
+    self.calendar = calendar
+    self.monthsLayout = monthsLayout
+
+    let startDate = calendar.date(from: DateComponents(year: 2023, month: 01, day: 01))!
+    let endDate = calendar.date(from: DateComponents(year: 2026, month: 12, day: 31))!
+    visibleDateRange = startDate...endDate
+
+    monthDateFormatter = DateFormatter()
+    monthDateFormatter.calendar = calendar
+    monthDateFormatter.locale = calendar.locale
+    monthDateFormatter.dateFormat = DateFormatter.dateFormat(
+      fromTemplate: "MMMM yyyy",
+      options: 0,
+      locale: calendar.locale ?? Locale.current)
+  }
+
+  // MARK: Internal
+
+  var body: some View {
+    CalendarViewRepresentable(
+      calendar: calendar,
+      visibleDateRange: visibleDateRange,
+      monthsLayout: monthsLayout,
+      dataDependency: calendarSelection)
+
+    .verticalDayMargin(8)
+    .horizontalDayMargin(8)
+    .interMonthSpacing(16)
+
+    .monthHeaderItemProvider { month in
+      let monthHeaderText = monthDateFormatter.string(from: calendar.date(from: month.components)!)
+      if case .vertical = monthsLayout {
+        return HStack {
+          Text(monthHeaderText).font(.title2)
+          Spacer()
+        }
+        .padding()
+        .calendarItemModel
+      } else {
+        return Text(monthHeaderText).font(.title2)
+          .padding()
+          .calendarItemModel
+      }
+    }
+
+    .dayItemProvider { day in
+      let isSelected: Bool
+      switch calendarSelection {
+      case .singleDay(let selectedDay):
+        isSelected = day == selectedDay
+      case .dayRange(let selectedDayRange):
+        isSelected = day == selectedDayRange.lowerBound || day == selectedDayRange.upperBound
+      case .none:
+        isSelected = false
+      }
+      return SwiftUIDayView(dayNumber: day.day, isSelected: isSelected)
+        .calendarItemModel
+    }
+
+    .dayRangeItemProvider(for: selectedDateRanges) { dayRangeLayoutContext in
+      let framesOfDaysToHighlight = dayRangeLayoutContext.daysAndFrames.map { $0.frame }
+      // UIKit view
+      return DayRangeIndicatorView.calendarItemModel(
+        invariantViewProperties: .init(indicatorColor: UIColor(.accentColor.opacity(0.3))),
+        content: .init(framesOfDaysToHighlight: framesOfDaysToHighlight))
+    }
+
+    .onDaySelection { day in
+      switch calendarSelection {
+      case .singleDay(let selectedDay):
+        if day > selectedDay {
+          calendarSelection = .dayRange(selectedDay...day)
+        } else {
+          calendarSelection = .singleDay(day)
+        }
+      case .none, .dayRange:
+        calendarSelection = .singleDay(day)
+      }
+    }
+  }
+
+  // MARK: Private
+
+  private let calendar: Calendar
+  private let monthsLayout: MonthsLayout
+  private let visibleDateRange: ClosedRange<Date>
+
+  private let monthDateFormatter: DateFormatter
+
+  @State private var calendarSelection: CalendarSelection?
+
+  private var selectedDateRanges: Set<ClosedRange<Date>> {
+    guard case .dayRange(let selectedDayRange) = calendarSelection else { return [] }
+    let selectedStartDate = calendar.date(from: selectedDayRange.lowerBound.components)!
+    let selectedEndDate = calendar.date(from: selectedDayRange.upperBound.components)!
+    return [selectedStartDate...selectedEndDate]
+  }
+
+}
+
+// MARK: - SwiftUIScreenDemo_Previews
+
+struct SwiftUIScreenDemo_Previews: PreviewProvider {
+  static var previews: some View {
+    SwiftUIScreenDemo(calendar: Calendar.current, monthsLayout: .vertical)
+    SwiftUIScreenDemo(calendar: Calendar.current, monthsLayout: .horizontal)
+  }
+}

--- a/Example/HorizonCalendarExample/HorizonCalendarExample/DemoPickerViewController.swift
+++ b/Example/HorizonCalendarExample/HorizonCalendarExample/DemoPickerViewController.swift
@@ -67,6 +67,7 @@ final class DemoPickerViewController: UIViewController {
       ("Partial Month Visibility", PartialMonthVisibilityDemoViewController.self),
       ("Month Grid Background", MonthBackgroundDemoViewController.self),
       ("SwiftUI Day and Month View", SwiftUIItemModelsDemoViewController.self),
+      ("SwiftUI Screen", SwiftUIScreenDemoViewController.self),
     ]
 
   private let horizontalDemoDestinations: [(name: String, destinationType: DemoViewController.Type)] =
@@ -78,6 +79,7 @@ final class DemoPickerViewController: UIViewController {
       ("Scroll to Day With Animation", ScrollToDayWithAnimationDemoViewController.self),
       ("Month Grid Background", MonthBackgroundDemoViewController.self),
       ("SwiftUI Day and Month View", SwiftUIItemModelsDemoViewController.self),
+      ("SwiftUI Screen", SwiftUIScreenDemoViewController.self),
     ]
 
   private lazy var tableView: UITableView = {

--- a/Example/HorizonCalendarExample/HorizonCalendarExample/SwiftUIDayView.swift
+++ b/Example/HorizonCalendarExample/HorizonCalendarExample/SwiftUIDayView.swift
@@ -23,21 +23,13 @@ struct SwiftUIDayView: View {
 
   var body: some View {
     ZStack(alignment: .center) {
-      if #available(iOS 15.0, *) {
-        Circle()
-          .strokeBorder(isSelected ? Color(UIColor.blue) : .clear, lineWidth: 1)
-          .background {
-            Circle()
-              .foregroundColor(
-                (isSelected ? Color(UIColor.blue.withAlphaComponent(0.15)) : .clear))
-          }
-          .aspectRatio(1, contentMode: .fill)
-      } else {
-        Circle()
-          .foregroundColor(
-            (isSelected ? Color(UIColor.blue.withAlphaComponent(0.15)) : .clear))
-          .aspectRatio(1, contentMode: .fill)
-      }
+      Circle()
+        .strokeBorder(isSelected ? Color.accentColor : .clear, lineWidth: 2)
+        .background {
+          Circle()
+            .foregroundColor(isSelected ? .white : .clear)
+        }
+        .aspectRatio(1, contentMode: .fill)
       Text("\(dayNumber)").foregroundColor(Color(UIColor.label))
     }
   }

--- a/HorizonCalendar.xcodeproj/project.pbxproj
+++ b/HorizonCalendar.xcodeproj/project.pbxproj
@@ -65,6 +65,7 @@
 		FD6E1CFC298D94DC00B480A6 /* MonthLayoutContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD6E1CF7298D94DC00B480A6 /* MonthLayoutContext.swift */; };
 		FD6E1CFD298D94DC00B480A6 /* OverlaidItemLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD6E1CF8298D94DC00B480A6 /* OverlaidItemLocation.swift */; };
 		FD6E1CFE298D94DC00B480A6 /* DayRangeLayoutContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD6E1CF9298D94DC00B480A6 /* DayRangeLayoutContext.swift */; };
+		FD6E1D1A2991C50100B480A6 /* CalendarViewRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD6E1D192991C50100B480A6 /* CalendarViewRepresentable.swift */; };
 		FD8CF37A2988A06C00D0482D /* MonthGridBackgroundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD8CF3792988A06C00D0482D /* MonthGridBackgroundView.swift */; };
 		FD9CDA90293B5E4D00A77188 /* SubviewInsertionIndexTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD9CDA8F293B5E4D00A77188 /* SubviewInsertionIndexTracker.swift */; };
 		FDB6D6BD298CB1A600A17668 /* Hasher+CGRect.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDB6D6BC298CB1A600A17668 /* Hasher+CGRect.swift */; };
@@ -144,6 +145,7 @@
 		FD6E1CF7298D94DC00B480A6 /* MonthLayoutContext.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MonthLayoutContext.swift; sourceTree = "<group>"; };
 		FD6E1CF8298D94DC00B480A6 /* OverlaidItemLocation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OverlaidItemLocation.swift; sourceTree = "<group>"; };
 		FD6E1CF9298D94DC00B480A6 /* DayRangeLayoutContext.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DayRangeLayoutContext.swift; sourceTree = "<group>"; };
+		FD6E1D192991C50100B480A6 /* CalendarViewRepresentable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CalendarViewRepresentable.swift; sourceTree = "<group>"; };
 		FD8CF3792988A06C00D0482D /* MonthGridBackgroundView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MonthGridBackgroundView.swift; sourceTree = "<group>"; };
 		FD9CDA8F293B5E4D00A77188 /* SubviewInsertionIndexTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubviewInsertionIndexTracker.swift; sourceTree = "<group>"; };
 		FDB6D6BC298CB1A600A17668 /* Hasher+CGRect.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Hasher+CGRect.swift"; sourceTree = "<group>"; };
@@ -247,6 +249,7 @@
 				938DA40E24BEEB1A008A3B47 /* CalendarItemViewRepresentable.swift */,
 				939E691724837E0200A8BCC7 /* CalendarView.swift */,
 				939E693524837E8700A8BCC7 /* CalendarViewContent.swift */,
+				FD6E1D192991C50100B480A6 /* CalendarViewRepresentable.swift */,
 				939E693324837E8700A8BCC7 /* CalendarViewScrollPosition.swift */,
 				939E693F24846A8C00A8BCC7 /* Day.swift */,
 				FD6E1CF5298D94DC00B480A6 /* DaysOfTheWeekRowSeparatorOptions.swift */,
@@ -435,6 +438,7 @@
 				9321958226EEB6AB0001C7E9 /* DrawingConfig.swift in Sources */,
 				939E692D24837E0300A8BCC7 /* LayoutItem.swift in Sources */,
 				939E693A24837E8700A8BCC7 /* CalendarViewContent.swift in Sources */,
+				FD6E1D1A2991C50100B480A6 /* CalendarViewRepresentable.swift in Sources */,
 				FDD8EE6E2984C08A00F6EC9D /* ColorViewRepresentable.swift in Sources */,
 				939E692F24837E0300A8BCC7 /* OffScreenCalendarItemAccessibilityElement.swift in Sources */,
 				FDE2893C28F8A6D50020EBF1 /* SwiftUIWrapperView.swift in Sources */,

--- a/Sources/Public/CalendarView.swift
+++ b/Sources/Public/CalendarView.swift
@@ -17,22 +17,23 @@ import UIKit
 
 // MARK: - CalendarView
 
-/// A declarative, performant, calendar UI component that supports use cases ranging from simple date pickers all the way up to
+/// A declarative, performant calendar `UIView` that supports use cases ranging from simple date pickers all the way up to
 /// fully-featured calendar apps. Its declarative API makes updating the calendar straightforward, while also providing many
 /// customization points to support a diverse set of designs and use cases.
 ///
 /// `CalendarView` does not handle any business logic related to day range selection or deselection. Instead, it provides a
 /// single callback for day selection, allowing you to customize selection behavior in any way that you’d like.
 ///
-/// Your business logic should respond to the day selection callback, regenerate `CalendarView` content based on changes to the
+/// Your business logic can respond to the day selection callback, regenerate `CalendarView` content based on changes to the
 /// backing-models for your feature, then set the content on `CalendarView`. This will trigger `CalendarView` to re-render,
 /// reflecting all new changes from the content you provide.
 ///
 /// `CalendarView`’s content contains all information about how to render the calendar (you can think of `CalendarView` as a
-/// pure function of its content). The two most important things provided by the content are:
+/// pure function of its content). The most important things provided by the content are:
 /// * The date range to display
 ///   * e.g. September, 2019 - April, 2020
-/// * The `CalendarItem` to display for each day in the date range
+/// * A months-layout (vertical or horizontal)
+/// * An optional `CalendarItem` to display for each day in the date range if you don't want to use the default day view
 ///   * e.g. a view with a label representing a single day
 public final class CalendarView: UIView {
 

--- a/Sources/Public/CalendarViewRepresentable.swift
+++ b/Sources/Public/CalendarViewRepresentable.swift
@@ -50,7 +50,7 @@ public struct CalendarViewRepresentable: UIViewRepresentable {
     calendar: Calendar = Calendar.current,
     visibleDateRange: ClosedRange<Date>,
     monthsLayout: MonthsLayout,
-    dataDependency: Any? = nil)
+    dataDependency: Any?)
   {
     self.calendar = calendar
     self.visibleDateRange = visibleDateRange

--- a/Sources/Public/CalendarViewRepresentable.swift
+++ b/Sources/Public/CalendarViewRepresentable.swift
@@ -1,0 +1,331 @@
+// Created by Bryan Keller on 2/1/23.
+// Copyright © 2023 Airbnb Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import SwiftUI
+import UIKit
+
+// MARK: - CalendarViewRepresentable
+
+/// A declarative, performant calendar `View` that supports use cases ranging from simple date pickers all the way up to
+/// fully-featured calendar apps. Its declarative API makes updating the calendar straightforward, while also providing many
+/// customization points to support a diverse set of designs and use cases.
+///
+/// `CalendarView` does not handle any business logic related to day range selection or deselection. Instead, it provides a
+/// single callback for day selection, allowing you to customize selection behavior in any way that you’d like.
+///
+/// Your business logic can respond to the day selection callback: update any backing-models for your feature. If those backing models
+/// are inputs to your view (for example, `@State`), then the calendar will re-render with the latest data.
+///
+/// - Note: This `View` wraps a UIKit `CalendarView`, enabling it to be used in a SwiftUI hierarchy.
+@available(iOS 13.0, *)
+public struct CalendarViewRepresentable: UIViewRepresentable {
+
+  // MARK: Lifecycle
+
+  /// Initializes a `CalendarViewRepresentable` with default `CalendarItemModel` providers.
+  ///
+  /// - Parameters:
+  ///   - calendar: The calendar on which all date operations will be performed. Defaults to `Calendar.current` (the system's
+  ///   current calendar).
+  ///   - visibleDateRange: The date range that will be displayed. The dates in this range are interpreted using the provided
+  ///   `calendar`.
+  ///   - monthsLayout: The layout of months - either vertically or horizontally.
+  ///   - dataDependency: Any data or state that, when updated, should cause the calendar to re-render. This is needed because
+  ///   `CalendarView` lazily invokes item provider closures outside of the normal SwiftUI update loop. To ensure that the calendar
+  ///   is updated at the right times, pass in any properties that are accessed in your item provider closures. For example, if a
+  ///   `dayItemProvider` closure accesses a local state variable called `selectedDay`, then pass it in here.
+  public init(
+    calendar: Calendar = Calendar.current,
+    visibleDateRange: ClosedRange<Date>,
+    monthsLayout: MonthsLayout,
+    dataDependency: Any? = nil)
+  {
+    self.calendar = calendar
+    self.visibleDateRange = visibleDateRange
+    self.monthsLayout = monthsLayout
+    self.dataDependency = dataDependency
+  }
+
+  // MARK: Public
+
+  public func makeUIView(context: Context) -> CalendarView {
+    CalendarView(initialContent: makeContent())
+  }
+
+  public func updateUIView(_ calendarView: CalendarView, context: Context) {
+    calendarView.daySelectionHandler = daySelectionHandler
+    calendarView.didScroll = didScroll
+    calendarView.didEndDragging = didEndDragging
+    calendarView.didEndDecelerating = didEndDecelerating
+
+    calendarView.setContent(makeContent())
+  }
+
+  // MARK: Fileprivate
+
+  fileprivate var dayAspectRatio: CGFloat?
+  fileprivate var interMonthSpacing: CGFloat?
+  fileprivate var monthDayInsets: NSDirectionalEdgeInsets?
+  fileprivate var verticalDayMargin: CGFloat?
+  fileprivate var horizontalDayMargin: CGFloat?
+  fileprivate var daysOfTheWeekRowSeparatorOptions: DaysOfTheWeekRowSeparatorOptions?
+
+  fileprivate var monthHeaderItemProvider: ((Month) -> AnyCalendarItemModel)?
+  fileprivate var dayOfWeekItemProvider: ((
+    _ month: Month?,
+    _ weekdayIndex: Int)
+    -> AnyCalendarItemModel)?
+  fileprivate var dayItemProvider: ((Day) -> AnyCalendarItemModel)?
+  fileprivate var dayBackgroundItemProvider: ((Day) -> AnyCalendarItemModel?)?
+  fileprivate var monthBackgroundItemProvider: ((MonthLayoutContext) -> AnyCalendarItemModel?)?
+  fileprivate var dateRangesAndItemProvider: (
+    dayRanges: Set<ClosedRange<Date>>,
+    dayRangeItemProvider: (DayRangeLayoutContext) -> AnyCalendarItemModel)?
+  fileprivate var overlaidItemLocationsAndItemProvider: (
+    overlaidItemLocations: Set<OverlaidItemLocation>,
+    overlayItemProvider: (OverlayLayoutContext) -> AnyCalendarItemModel)?
+
+  fileprivate var daySelectionHandler: ((Day) -> Void)?
+  fileprivate var didScroll: ((_ visibleDayRange: DayRange, _ isUserDragging: Bool) -> Void)?
+  fileprivate var didEndDragging: ((_ visibleDayRange: DayRange, _ willDecelerate: Bool) -> Void)?
+  fileprivate var didEndDecelerating: ((_ visibleDayRange: DayRange) -> Void)?
+
+  // MARK: Private
+
+  private let calendar: Calendar
+  private let visibleDateRange: ClosedRange<Date>
+  private let monthsLayout: MonthsLayout
+  private let dataDependency: Any?
+
+  private func makeContent() -> CalendarViewContent {
+    var content = CalendarViewContent(
+      calendar: calendar,
+      visibleDateRange: visibleDateRange,
+      monthsLayout: monthsLayout)
+
+    if let dayAspectRatio {
+      content = content.dayAspectRatio(dayAspectRatio)
+    }
+
+    if let interMonthSpacing {
+      content = content.interMonthSpacing(interMonthSpacing)
+    }
+
+    if let monthDayInsets {
+      content = content.monthDayInsets(monthDayInsets)
+    }
+
+    if let verticalDayMargin {
+      content = content.verticalDayMargin(verticalDayMargin)
+    }
+
+    if let horizontalDayMargin {
+      content = content.horizontalDayMargin(horizontalDayMargin)
+    }
+
+    content = content.daysOfTheWeekRowSeparator(options: daysOfTheWeekRowSeparatorOptions)
+
+    if let monthHeaderItemProvider {
+      content = content.monthHeaderItemProvider(monthHeaderItemProvider)
+    }
+
+    if let dayOfWeekItemProvider {
+      content = content.dayOfWeekItemProvider(dayOfWeekItemProvider)
+    }
+
+    if let dayItemProvider {
+      content = content.dayItemProvider(dayItemProvider)
+    }
+
+    if let dayBackgroundItemProvider {
+      content = content.dayBackgroundItemProvider(dayBackgroundItemProvider)
+    }
+
+    if let monthBackgroundItemProvider {
+      content = content.monthBackgroundItemProvider(monthBackgroundItemProvider)
+    }
+
+    if let (dateRanges, itemProvider) = dateRangesAndItemProvider {
+      content = content.dayRangeItemProvider(for: dateRanges, itemProvider)
+    }
+
+    if let (itemLocations, itemProvider) = overlaidItemLocationsAndItemProvider {
+      content = content.overlayItemProvider(for: itemLocations, itemProvider)
+    }
+
+    return content
+  }
+
+}
+
+// MARK: Content Modifiers
+
+@available(iOS 13.0, *)
+extension CalendarViewRepresentable {
+
+  public func dayAspectRatio(_ dayAspectRatio: CGFloat) -> Self {
+    var view = self
+    view.dayAspectRatio = dayAspectRatio
+    return view
+  }
+
+  public func interMonthSpacing(_ interMonthSpacing: CGFloat) -> Self {
+    var view = self
+    view.interMonthSpacing = interMonthSpacing
+    return view
+  }
+
+  public func monthDayInsets(_ monthDayInsets: NSDirectionalEdgeInsets) -> Self {
+    var view = self
+    view.monthDayInsets = monthDayInsets
+    return view
+  }
+
+  public func verticalDayMargin(_ verticalDayMargin: CGFloat) -> Self {
+    var view = self
+    view.verticalDayMargin = verticalDayMargin
+    return view
+  }
+
+  public func horizontalDayMargin(_ horizontalDayMargin: CGFloat) -> Self {
+    var view = self
+    view.horizontalDayMargin = horizontalDayMargin
+    return view
+  }
+
+  public func daysOfTheWeekRowSeparator(
+    options daysOfTheWeekRowSeparatorOptions: DaysOfTheWeekRowSeparatorOptions?)
+    -> Self
+  {
+    var view = self
+    view.daysOfTheWeekRowSeparatorOptions = daysOfTheWeekRowSeparatorOptions
+    return view
+  }
+
+  public func monthHeaderItemProvider(
+    _ monthHeaderItemProvider: @escaping (_ month: Month) -> AnyCalendarItemModel)
+    -> Self
+  {
+    var view = self
+    view.monthHeaderItemProvider = monthHeaderItemProvider
+    return view
+  }
+
+  public func dayOfWeekItemProvider(
+    _ dayOfWeekItemProvider: @escaping (
+      _ month: Month?,
+      _ weekdayIndex: Int)
+      -> AnyCalendarItemModel)
+    -> Self
+  {
+    var view = self
+    view.dayOfWeekItemProvider = dayOfWeekItemProvider
+    return view
+  }
+
+  public func dayItemProvider(
+    _ dayItemProvider: @escaping (_ day: Day) -> AnyCalendarItemModel)
+    -> Self
+  {
+    var view = self
+    view.dayItemProvider = dayItemProvider
+    return view
+  }
+
+  public func dayBackgroundItemProvider(
+    _ dayBackgroundItemProvider: @escaping (_ day: Day) -> AnyCalendarItemModel?)
+    -> Self
+  {
+    var view = self
+    view.dayBackgroundItemProvider = dayBackgroundItemProvider
+    return view
+  }
+
+  public func monthBackgroundItemProvider(
+    _ monthBackgroundItemProvider: @escaping (
+      _ monthLayoutContext: MonthLayoutContext)
+      -> AnyCalendarItemModel?)
+    -> Self
+  {
+    var view = self
+    view.monthBackgroundItemProvider = monthBackgroundItemProvider
+    return view
+  }
+
+  public func dayRangeItemProvider(
+    for dateRanges: Set<ClosedRange<Date>>,
+    _ dayRangeItemProvider: @escaping (
+      _ dayRangeLayoutContext: DayRangeLayoutContext)
+    -> AnyCalendarItemModel)
+    -> Self
+  {
+    var view = self
+    view.dateRangesAndItemProvider = (dateRanges, dayRangeItemProvider)
+    return view
+  }
+
+  public func overlayItemProvider(
+    for overlaidItemLocations: Set<OverlaidItemLocation>,
+    _ overlayItemProvider: @escaping (
+      _ overlayLayoutContext: OverlayLayoutContext)
+    -> AnyCalendarItemModel)
+    -> Self
+  {
+    var view = self
+    view.overlaidItemLocationsAndItemProvider = (overlaidItemLocations, overlayItemProvider)
+    return view
+  }
+
+}
+
+// MARK: Event Handlers
+
+@available(iOS 13.0, *)
+extension CalendarViewRepresentable {
+
+  public func onDaySelection(_ daySelectionHandler: @escaping (Day) -> Void) -> Self {
+    var view = self
+    view.daySelectionHandler = daySelectionHandler
+    return view
+  }
+
+  public func onScroll(
+    _ scrollHandler: @escaping (_ visibleDayRange: DayRange,  _ isUserDragging: Bool) -> Void)
+    -> Self
+  {
+    var view = self
+    view.didScroll = scrollHandler
+    return view
+  }
+
+  public func onDragEnd(
+    _ dragEndHandler: @escaping (_ visibleDayRange: DayRange, _ willDecelerate: Bool) -> Void)
+    -> Self
+  {
+    var view = self
+    view.didEndDragging = dragEndHandler
+    return view
+  }
+
+  public func onDeceleratingEnd(
+    _ deceleratingEndHandler: @escaping (_ visibleDayRange: DayRange) -> Void)
+    -> Self
+  {
+    var view = self
+    view.didEndDecelerating = deceleratingEndHandler
+    return view
+  }
+
+}

--- a/Sources/Public/CalendarViewRepresentable.swift
+++ b/Sources/Public/CalendarViewRepresentable.swift
@@ -175,36 +175,78 @@ public struct CalendarViewRepresentable: UIViewRepresentable {
 @available(iOS 13.0, *)
 extension CalendarViewRepresentable {
 
+  /// Configures the aspect ratio of each day.
+  ///
+  /// Values less than 1 will result in rectangular days that are wider than they are tall. Values
+  /// greater than 1 will result in rectangular days that are taller than they are wide. The default value is `1`, which results in square
+  /// views with the same width and height.
+  ///
+  /// - Parameters:
+  ///   - dayAspectRatio: The aspect ratio of each day view.
+  /// - Returns: A mutated `CalendarViewRepresentable` with a new day aspect ratio value.
   public func dayAspectRatio(_ dayAspectRatio: CGFloat) -> Self {
     var view = self
     view.dayAspectRatio = dayAspectRatio
     return view
   }
 
+  /// Configures the amount of spacing, in points, between months. The default value is `0`.
+  ///
+  /// - Parameters:
+  ///   - interMonthSpacing: The amount of spacing, in points, between months.
+  /// - Returns: A mutated `CalendarViewRepresentable` with a new inter-month-spacing value.
   public func interMonthSpacing(_ interMonthSpacing: CGFloat) -> Self {
     var view = self
     view.interMonthSpacing = interMonthSpacing
     return view
   }
 
+  /// Configures the amount to inset days and day-of-week items from the edges of a month. The default value is `.zero`.
+  ///
+  /// - Parameters:
+  ///   - monthDayInsets: The amount to inset days and day-of-week items from the edges of a month.
+  /// - Returns: A mutated `CalendarViewRepresentable` with a new month-day-insets value.
   public func monthDayInsets(_ monthDayInsets: NSDirectionalEdgeInsets) -> Self {
     var view = self
     view.monthDayInsets = monthDayInsets
     return view
   }
 
+  /// Configures the amount of space between two day frames vertically.
+  ///
+  /// If `verticalDayMargin` and `horizontalDayMargin` are the same, then each day will appear to
+  /// have a 1:1 (square) aspect ratio. If `verticalDayMargin` and `horizontalDayMargin` are different, then days can
+  /// appear wider or taller.
+  ///
+  /// - Parameters:
+  ///   - verticalDayMargin: The amount of space between two day frames along the vertical axis.
+  /// - Returns: A mutated `CalendarViewRepresentable` with a new vertical day margin value.
   public func verticalDayMargin(_ verticalDayMargin: CGFloat) -> Self {
     var view = self
     view.verticalDayMargin = verticalDayMargin
     return view
   }
 
+  /// Configures the amount of space between two day frames horizontally.
+  ///
+  /// If `verticalDayMargin` and `horizontalDayMargin` are the same, then each day will appear to
+  /// have a 1:1 (square) aspect ratio. If `verticalDayMargin` and `horizontalDayMargin` are
+  /// different, then days can appear wider or taller.
+  ///
+  /// - Parameters:
+  ///   - horizontalDayMargin: The amount of space between two day frames along the horizontal axis.
+  /// - Returns: A mutated `CalendarViewRepresentable` with a new horizontal day margin value.
   public func horizontalDayMargin(_ horizontalDayMargin: CGFloat) -> Self {
     var view = self
     view.horizontalDayMargin = horizontalDayMargin
     return view
   }
 
+  /// Configures the days-of-the-week row's separator options. The separator appears below the days-of-the-week row.
+  ///
+  /// - Parameters:
+  ///   - options: An instance that has properties to control various aspects of the separator's design.
+  /// - Returns: A mutated `CalendarViewRepresentable` with a days-of-the-week row separator configured.
   public func daysOfTheWeekRowSeparator(
     options daysOfTheWeekRowSeparatorOptions: DaysOfTheWeekRowSeparatorOptions?)
     -> Self
@@ -214,6 +256,20 @@ extension CalendarViewRepresentable {
     return view
   }
 
+  /// Configures the month header item provider.
+  ///
+  /// `CalendarView` invokes the provided `monthHeaderItemProvider` for each month in the range of months being
+  /// displayed. The `CalendarItemModel`s that you return will be used to create the views for each month header in
+  /// `CalendarView`.
+  ///
+  /// If you don't configure your own month header item provider via this function, then a default month header item provider will be
+  /// used.
+  ///
+  /// - Parameters:
+  ///   - monthHeaderItemProvider: A closure (that is retained) that returns a `CalendarItemModel` representing a
+  ///   month header.
+  ///   - month: The `Month` for which to provide a month header item.
+  /// - Returns: A mutated `CalendarViewRepresentable` with a new month header item provider.
   public func monthHeaderItemProvider(
     _ monthHeaderItemProvider: @escaping (_ month: Month) -> AnyCalendarItemModel)
     -> Self
@@ -223,6 +279,21 @@ extension CalendarViewRepresentable {
     return view
   }
 
+  /// Configures the day-of-week item provider.
+  ///
+  /// `CalendarView` invokes the provided `dayOfWeekItemProvider` for each weekday index for the current calendar.
+  /// For example, for the en_US locale, 0 is Sunday, 1 is Monday, and 6 is Saturday. This will be different in some other locales. The
+  /// `CalendarItemModel`s that you return will be used to create the views for each day-of-week view in `CalendarView`.
+  ///
+  /// If you don't configure your own day-of-week item provider via this function, then a default day-of-week item provider will be used.
+  ///
+  /// - Parameters:
+  ///   - dayOfWeekItemProvider: A closure (that is retained) that returns a `CalendarItemModel` representing a
+  ///   day of the week.
+  ///   - month: The month in which the day-of-week item belongs. This parameter will be `nil` if days of the week are pinned to
+  ///   the top of the calendar, since in that scenario, they don't belong to any particular month.
+  ///   - weekdayIndex: The weekday index for which to provide a `CalendarItemModel`.
+  /// - Returns: A mutated `CalendarViewRepresentable` with a new day-of-week item provider.
   public func dayOfWeekItemProvider(
     _ dayOfWeekItemProvider: @escaping (
       _ month: Month?,
@@ -235,6 +306,20 @@ extension CalendarViewRepresentable {
     return view
   }
 
+  /// Configures the day item provider.
+  ///
+  /// `CalendarView` invokes the provided `dayItemProvider` for each day being displayed. The
+  /// `CalendarItemModel`s that you return will be used to create the views for each day in `CalendarView`. In most cases, this
+  /// view should be some kind of label that tells the user the day number of the month. You can also add other decoration, like a badge
+  /// or background, by including it in the view that your `CalendarItemModel` creates.
+  ///
+  /// If you don't configure your own day item provider via this function, then a default day item provider will be used.
+  ///
+  /// - Parameters:
+  ///   - dayItemProvider: A closure (that is retained) that returns a `CalendarItemModel` representing a single day
+  ///   in the calendar.
+  ///   - day: The `Day` for which to provide a day item.
+  /// - Returns: A mutated `CalendarViewRepresentable` with a new day item provider.
   public func dayItemProvider(
     _ dayItemProvider: @escaping (_ day: Day) -> AnyCalendarItemModel)
     -> Self
@@ -244,6 +329,19 @@ extension CalendarViewRepresentable {
     return view
   }
 
+  /// Configures the day background item provider.
+  ///
+  /// `CalendarView` invokes the provided `dayBackgroundItemProvider` for each day being displayed. The
+  /// `CalendarItemModel`s that you return will be used to create the background views for each day in `CalendarView`. If a
+  /// particular day does not have a background view, return `nil` for that day.
+  ///
+  /// If you don't configure a day background item provider via this function, then days will not have additional background decoration.
+  ///
+  /// - Parameters:
+  ///   - dayBackgroundItemProvider: A closure (that is retained) that returns a `CalendarItemModel` representing the
+  ///   background of a single day in the calendar.
+  ///   - day: The `Day` for which to provide a day background item.
+  /// - Returns: A mutated `CalendarViewRepresentable` with a new day background item provider.
   public func dayBackgroundItemProvider(
     _ dayBackgroundItemProvider: @escaping (_ day: Day) -> AnyCalendarItemModel?)
     -> Self
@@ -253,6 +351,22 @@ extension CalendarViewRepresentable {
     return view
   }
 
+  /// Configures the month background item provider.
+  ///
+  /// `CalendarView` invokes the provided `monthBackgroundItemProvider` for each month being displayed. The
+  /// `CalendarItemModel` that you return for each month will be used to create a view that spans the entire frame of that month,
+  /// encapsulating all days, days-of-the-week headers, and the month header. This behavior makes month backgrounds useful for
+  /// things like grid lines or colored backgrounds.
+  ///
+  /// If you don't configure your own month background item provider via this function, then months will not have additional
+  /// background decoration.
+  ///
+  /// - Parameters:
+  ///   - monthBackgroundItemProvider: A closure (that is retained) that returns a `CalendarItemModel` representing the
+  ///   background of a single month in the calendar.
+  ///   - monthLayoutContext: The layout context for the month containing information about the frames of views in that month
+  ///   and the bounds in which your month background will be displayed.
+  /// - Returns: A mutated `CalendarViewRepresentable` with a new month background item provider.
   public func monthBackgroundItemProvider(
     _ monthBackgroundItemProvider: @escaping (
       _ monthLayoutContext: MonthLayoutContext)
@@ -264,6 +378,28 @@ extension CalendarViewRepresentable {
     return view
   }
 
+  /// Configures the day range item provider.
+  ///
+  /// `CalendarView` invokes the provided `dayRangeItemProvider` for each day range in the `dateRanges` set.
+  /// Date ranges will be converted to day ranges by using the `calendar`passed into the `CalendarViewRepresentable`
+  /// initializer. The `CalendarItemModel` that you return for each day range will be used to create a view that spans the entire
+  /// frame encapsulating all days in that day range. This behavior makes day range items useful for things like day range selection
+  /// indicators that might have specific styling requirements for different parts of the selected day range. For example, you might have
+  /// a cross fade in your day range selection indicator view when a day range spans multiple months, or you might have rounded end
+  /// caps for the start and end of a day range.
+  ///
+  /// The views created by the `CalendarItemModel`s provided by this function will be placed at a lower z-index than the layer of
+  /// day items. If you don't configure your own day range item provider via this function, then no day range view will be displayed.
+  ///
+  /// If you don't want to show any day range items, pass in an empty set for the `dateRanges` parameter.
+  ///
+  /// - Parameters:
+  ///   - dateRanges: The date ranges for which `CalendarView` will invoke your day range item provider closure.
+  ///   - dayRangeItemProvider: A closure (that is retained) that returns a `CalendarItemModel` representing a day
+  ///   range in the calendar.
+  ///   - dayRangeLayoutContext: The layout context for the day range containing information about the frames of days and
+  ///   bounds in which your day range item will be displayed.
+  /// - Returns: A mutated `CalendarViewRepresentable` with a new day range item provider.
   public func dayRangeItemProvider(
     for dateRanges: Set<ClosedRange<Date>>,
     _ dayRangeItemProvider: @escaping (
@@ -276,6 +412,22 @@ extension CalendarViewRepresentable {
     return view
   }
 
+  /// Configures the overlay item provider.
+  ///
+  /// `CalendarView` invokes the provided `overlayItemProvider` for each overlaid item location in the
+  /// `overlaidItemLocations` set. All of the layout information needed to create an overlay item is provided via the overlay
+  /// context passed into the `overlayItemProvider` closure. The `CalendarItemModel` that you return for each
+  /// overlaid item location will be used to create a view that spans the visible bounds of the calendar when that overlaid item's location
+  /// is visible. This behavior makes overlay items useful for things like tooltips.
+  ///
+  /// - Parameters:
+  ///   - overlaidItemLocations: The overlaid item locations for which `CalendarView` will invoke your overlay item
+  ///   provider closure.
+  ///   - overlayItemProvider: A closure (that is retained) that returns a `CalendarItemModel` representing an
+  ///   overlay.
+  ///   - overlayLayoutContext: The layout context for the overlaid item location containing information about that location's
+  ///   frame and the bounds in which your overlay item will be displayed.
+  /// - Returns: A mutated `CalendarViewRepresentable` with a new overlay item provider.
   public func overlayItemProvider(
     for overlaidItemLocations: Set<OverlaidItemLocation>,
     _ overlayItemProvider: @escaping (

--- a/Sources/Public/ItemViews/DayOfWeekView.swift
+++ b/Sources/Public/ItemViews/DayOfWeekView.swift
@@ -22,7 +22,7 @@ public final class DayOfWeekView: UIView {
 
   // MARK: Lifecycle
 
-  public init(invariantViewProperties: InvariantViewProperties) {
+  fileprivate init(invariantViewProperties: InvariantViewProperties) {
     self.invariantViewProperties = invariantViewProperties
 
     backgroundLayer = CAShapeLayer()

--- a/Sources/Public/ItemViews/DayView.swift
+++ b/Sources/Public/ItemViews/DayView.swift
@@ -22,7 +22,7 @@ public final class DayView: UIView {
 
   // MARK: Lifecycle
 
-  public init(invariantViewProperties: InvariantViewProperties) {
+  fileprivate init(invariantViewProperties: InvariantViewProperties) {
     self.invariantViewProperties = invariantViewProperties
 
     backgroundLayer = CAShapeLayer()

--- a/Sources/Public/ItemViews/MonthHeaderView.swift
+++ b/Sources/Public/ItemViews/MonthHeaderView.swift
@@ -22,7 +22,7 @@ public final class MonthHeaderView: UIView {
 
   // MARK: Lifecycle
 
-  public init(invariantViewProperties: InvariantViewProperties) {
+  fileprivate init(invariantViewProperties: InvariantViewProperties) {
     self.invariantViewProperties = invariantViewProperties
 
     label = UILabel()


### PR DESCRIPTION
## Details

This PR introduces `CalendarViewRepresentable` - a way to use `CalendarView` from SwiftUI. I also decided to include the public function docs in this PR. They're identical to the ones used by the `CalendarViewContent` modifiers, with minor wording changes to not actually reference `CalendarViewContent`.

Here's a little video demo of what it's like to use this API:

https://user-images.githubusercontent.com/746571/217365304-8580899c-a3b3-4f91-a1fc-6e36e2175ae0.mov

I still need to add documentation in the README.md. Will do in a future PR before the v2.0.0 release.

## Related Issue

https://github.com/airbnb/HorizonCalendar/issues/38

## Motivation and Context

Of course we want great SwiftUI API!

## How Has This Been Tested

Example app

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
