### PR TITLE
ml/Fix no ended state fires for multipleDaySelectionDragHandler

### DIFF
--- a/Sources/Public/CalendarView.swift
+++ b/Sources/Public/CalendarView.swift
@@ -510,7 +510,7 @@ public final class CalendarView: UIView {
 
   private lazy var scrollViewDelegate = ScrollViewDelegate(calendarView: self)
   private lazy var gestureRecognizerDelegate = GestureRecognizerDelegate(calendarView: self)
-
+  
   // Necessary to work around a `UIScrollView` behavior difference on Mac. See `scrollViewDidScroll`
   // and `preventLargeOverScrollIfNeeded` for more context.
   private lazy var isRunningOnMac: Bool = {
@@ -519,7 +519,7 @@ public final class CalendarView: UIView {
         return true
       }
     }
-  
+    
     return false
   }()
 
@@ -1105,7 +1105,7 @@ extension CalendarView {
     guard let element = notification.userInfo?[UIAccessibility.focusedElementUserInfoKey] else {
       return
     }
-
+    
     focusedAccessibilityElement = element
 
     if let contentView = element as? UIView, let itemView = contentView.superview as? ItemView {

--- a/Sources/Public/CalendarView.swift
+++ b/Sources/Public/CalendarView.swift
@@ -941,7 +941,6 @@ public final class CalendarView: UIView {
       newMultipleDaySelectionDay = intersectedDay
 
       lastMultipleDaySelectionDay = newMultipleDaySelectionDay
-      print("===============newMultipleDaySelectionDay: \(newMultipleDaySelectionDay)=================")
       multipleDaySelectionDragHandler?(newMultipleDaySelectionDay, gestureRecognizer.state)
     }
 
@@ -1105,7 +1104,7 @@ extension CalendarView {
     guard let element = notification.userInfo?[UIAccessibility.focusedElementUserInfoKey] else {
       return
     }
-    
+
     focusedAccessibilityElement = element
 
     if let contentView = element as? UIView, let itemView = contentView.superview as? ItemView {

--- a/Sources/Public/CalendarView.swift
+++ b/Sources/Public/CalendarView.swift
@@ -1104,7 +1104,7 @@ extension CalendarView {
     guard let element = notification.userInfo?[UIAccessibility.focusedElementUserInfoKey] else {
       return
     }
-
+    
     focusedAccessibilityElement = element
 
     if let contentView = element as? UIView, let itemView = contentView.superview as? ItemView {

--- a/Sources/Public/CalendarView.swift
+++ b/Sources/Public/CalendarView.swift
@@ -510,7 +510,7 @@ public final class CalendarView: UIView {
 
   private lazy var scrollViewDelegate = ScrollViewDelegate(calendarView: self)
   private lazy var gestureRecognizerDelegate = GestureRecognizerDelegate(calendarView: self)
-  
+
   // Necessary to work around a `UIScrollView` behavior difference on Mac. See `scrollViewDidScroll`
   // and `preventLargeOverScrollIfNeeded` for more context.
   private lazy var isRunningOnMac: Bool = {
@@ -519,7 +519,7 @@ public final class CalendarView: UIView {
         return true
       }
     }
-    
+
     return false
   }()
 
@@ -935,20 +935,24 @@ public final class CalendarView: UIView {
       intersectedDay = day
       break
     }
+    if let intersectedDay = intersectedDay {
+      print("===============intersectedDay: \(intersectedDay)=================")
+    }
 
     let newMultipleDaySelectionDay: Day
     if let intersectedDay, intersectedDay != lastMultipleDaySelectionDay {
       newMultipleDaySelectionDay = intersectedDay
-    } else {
-      return
+
+      lastMultipleDaySelectionDay = newMultipleDaySelectionDay
+      print("===============newMultipleDaySelectionDay: \(newMultipleDaySelectionDay)=================")
+      multipleDaySelectionDragHandler?(newMultipleDaySelectionDay, gestureRecognizer.state)
     }
-
-    lastMultipleDaySelectionDay = newMultipleDaySelectionDay
-
-    multipleDaySelectionDragHandler?(newMultipleDaySelectionDay, gestureRecognizer.state)
 
     switch gestureRecognizer.state {
     case .ended, .cancelled, .failed:
+      if let lastMultipleDaySelectionDay = lastMultipleDaySelectionDay {
+        multipleDaySelectionDragHandler?(lastMultipleDaySelectionDay, gestureRecognizer.state)
+      }
       lastMultipleDaySelectionDay = nil
     default:
       break
@@ -1104,7 +1108,7 @@ extension CalendarView {
     guard let element = notification.userInfo?[UIAccessibility.focusedElementUserInfoKey] else {
       return
     }
-    
+
     focusedAccessibilityElement = element
 
     if let contentView = element as? UIView, let itemView = contentView.superview as? ItemView {
@@ -1266,8 +1270,8 @@ private final class GestureRecognizerDelegate: NSObject, UIGestureRecognizerDele
     shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer)
     -> Bool
   {
-    otherGestureRecognizer === calendarView.scrollView.panGestureRecognizer &&
-      gestureRecognizer.state == .changed
+    return otherGestureRecognizer === calendarView.scrollView.panGestureRecognizer &&
+    (gestureRecognizer.state == .changed || gestureRecognizer.state == .ended)
   }
 
   // MARK: Private

--- a/Sources/Public/CalendarView.swift
+++ b/Sources/Public/CalendarView.swift
@@ -936,12 +936,9 @@ public final class CalendarView: UIView {
       break
     }
 
-    let newMultipleDaySelectionDay: Day
     if let intersectedDay, intersectedDay != lastMultipleDaySelectionDay {
-      newMultipleDaySelectionDay = intersectedDay
-
-      lastMultipleDaySelectionDay = newMultipleDaySelectionDay
-      multipleDaySelectionDragHandler?(newMultipleDaySelectionDay, gestureRecognizer.state)
+      lastMultipleDaySelectionDay = intersectedDay
+      multipleDaySelectionDragHandler?(intersectedDay, gestureRecognizer.state)
     }
 
     switch gestureRecognizer.state {

--- a/Sources/Public/CalendarView.swift
+++ b/Sources/Public/CalendarView.swift
@@ -510,7 +510,6 @@ public final class CalendarView: UIView {
 
   private lazy var scrollViewDelegate = ScrollViewDelegate(calendarView: self)
   private lazy var gestureRecognizerDelegate = GestureRecognizerDelegate(calendarView: self)
-
   // Necessary to work around a `UIScrollView` behavior difference on Mac. See `scrollViewDidScroll`
   // and `preventLargeOverScrollIfNeeded` for more context.
   private lazy var isRunningOnMac: Bool = {
@@ -519,7 +518,6 @@ public final class CalendarView: UIView {
         return true
       }
     }
-
     return false
   }()
 
@@ -935,9 +933,6 @@ public final class CalendarView: UIView {
       intersectedDay = day
       break
     }
-    if let intersectedDay = intersectedDay {
-      print("===============intersectedDay: \(intersectedDay)=================")
-    }
 
     let newMultipleDaySelectionDay: Day
     if let intersectedDay, intersectedDay != lastMultipleDaySelectionDay {
@@ -1108,7 +1103,6 @@ extension CalendarView {
     guard let element = notification.userInfo?[UIAccessibility.focusedElementUserInfoKey] else {
       return
     }
-
     focusedAccessibilityElement = element
 
     if let contentView = element as? UIView, let itemView = contentView.superview as? ItemView {
@@ -1270,8 +1264,8 @@ private final class GestureRecognizerDelegate: NSObject, UIGestureRecognizerDele
     shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer)
     -> Bool
   {
-    return otherGestureRecognizer === calendarView.scrollView.panGestureRecognizer &&
-    (gestureRecognizer.state == .changed || gestureRecognizer.state == .ended)
+    otherGestureRecognizer === calendarView.scrollView.panGestureRecognizer &&
+      gestureRecognizer.state == .changed
   }
 
   // MARK: Private

--- a/Sources/Public/CalendarView.swift
+++ b/Sources/Public/CalendarView.swift
@@ -510,6 +510,7 @@ public final class CalendarView: UIView {
 
   private lazy var scrollViewDelegate = ScrollViewDelegate(calendarView: self)
   private lazy var gestureRecognizerDelegate = GestureRecognizerDelegate(calendarView: self)
+
   // Necessary to work around a `UIScrollView` behavior difference on Mac. See `scrollViewDidScroll`
   // and `preventLargeOverScrollIfNeeded` for more context.
   private lazy var isRunningOnMac: Bool = {
@@ -518,6 +519,7 @@ public final class CalendarView: UIView {
         return true
       }
     }
+  
     return false
   }()
 
@@ -1103,6 +1105,7 @@ extension CalendarView {
     guard let element = notification.userInfo?[UIAccessibility.focusedElementUserInfoKey] else {
       return
     }
+
     focusedAccessibilityElement = element
 
     if let contentView = element as? UIView, let itemView = contentView.superview as? ItemView {


### PR DESCRIPTION
## Details

This change fixed the issue that multipleDaySelectionDragHandler never get called when the gestureRecognizer is in `ended` state. 

## Related Issue

N/A

## Motivation and Context

We need this state to fire in order to let the user know the dragging gesture has been ended.

## How Has This Been Tested

Tested in the app which has been integrated with HorizonCalendar.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
