### PR TITLE
Fix calendar mutli-selecting hidden day views

### DIFF
--- a/Sources/Public/CalendarView.swift
+++ b/Sources/Public/CalendarView.swift
@@ -925,6 +925,7 @@ public final class CalendarView: UIView {
     var intersectedDay: Day?
     for subview in scrollView.subviews {
       guard
+        !subview.isHidden,
         let itemView = subview as? ItemView,
         case .layoutItemType(.day(let day)) = itemView.itemType,
         itemView.frame.contains(locationInScrollView)


### PR DESCRIPTION
## Details

This fixes an issue with the recently-added multiple-day-selection drag handler that caused it to detect a drag gesture over a hidden, not-yet-reused `ItemView`.

## Related Issue

N/A

## Motivation and Context

Bug fix

## How Has This Been Tested

Airbnb app

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
