### PR TITLE
Bk/auto scroll drag gesture

### DIFF
--- a/Sources/Internal/ScrollMetricsMutator.swift
+++ b/Sources/Internal/ScrollMetricsMutator.swift
@@ -76,7 +76,10 @@ final class ScrollMetricsMutator {
 
   func applyOffset(_ offset: CGFloat) {
     let currentOffset = scrollMetricsProvider.offset(for: scrollAxis)
-    scrollMetricsProvider.setOffset(to: currentOffset + offset, for: scrollAxis)
+    let minimumOffset = scrollMetricsProvider.minimumOffset(for: scrollAxis)
+    let maximumOffset = scrollMetricsProvider.maximumOffset(for: scrollAxis)
+    let newOffset = max(minimumOffset, min(currentOffset + offset, maximumOffset))
+    scrollMetricsProvider.setOffset(to: newOffset, for: scrollAxis)
   }
 
   // MARK: Private


### PR DESCRIPTION
## Details

This adds auto-scroll functionality to the multi-day-selection drag gesture. If a user starts a drag gesture, then drags close to the edge of the scrollable content, the calendar will auto-scroll forward or backward in time so that they can reach dates outside of the original viewport.

## Related Issue

N/A

## Motivation and Context

Airbnb app need

## How Has This Been Tested

Tested in simulator and on real iPhone, vertical and horizontal layout.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
