### PR TITLE
Fix stale scroll-to-item context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `CalendarViewRepresentable` enabling developers to use `CalendarView` from SwiftUI
 - Added a `multipleDaySelectionDragHandler`, enabling developers to implement multiple-day-selection via a drag gesture (similar to multi-select in the iOS Photos app)
 
+### Fixed
+- Fixed an issue that could cause the calendar to programmatically scroll to a month or day to which it had previously scrolled. 
+
 ### Changed
 - Removed all deprecated code, simplifying the public API in preparation for a 2.0 release
 - Renamed `viewModel` to `content`, since it's a less-overloaded term

--- a/Sources/Public/CalendarView.swift
+++ b/Sources/Public/CalendarView.swift
@@ -336,16 +336,16 @@ public final class CalendarView: UIView {
     // Cancel in-flight scroll
     scrollView.setContentOffset(scrollView.contentOffset, animated: false)
 
-    scrollToItemContext = ScrollToItemContext(
+    let scrollToItemContext = ScrollToItemContext(
       targetItem: .month(month),
       scrollPosition: scrollPosition,
       animated: animated)
 
     if animated {
+      self.scrollToItemContext = scrollToItemContext
       startScrollingTowardTargetItem()
     } else {
-      setNeedsLayout()
-      layoutIfNeeded()
+      finalizeScrollingTowardItem(for: scrollToItemContext)
     }
   }
 
@@ -377,16 +377,16 @@ public final class CalendarView: UIView {
     // Cancel in-flight scroll
     scrollView.setContentOffset(scrollView.contentOffset, animated: false)
 
-    scrollToItemContext = ScrollToItemContext(
+    let scrollToItemContext = ScrollToItemContext(
       targetItem: .day(day),
       scrollPosition: scrollPosition,
       animated: animated)
 
     if animated {
+      self.scrollToItemContext = scrollToItemContext
       startScrollingTowardTargetItem()
     } else {
-      setNeedsLayout()
-      layoutIfNeeded()
+      finalizeScrollingTowardItem(for: scrollToItemContext)
     }
   }
 
@@ -788,6 +788,11 @@ public final class CalendarView: UIView {
       targetItem: scrollToItemContext.targetItem,
       scrollPosition: scrollToItemContext.scrollPosition,
       animated: false)
+
+    setNeedsLayout()
+    layoutIfNeeded()
+
+    self.scrollToItemContext = nil
   }
 
   @objc


### PR DESCRIPTION
## Details

Fixes an issue that could cause a delayed `layoutIfNeeded` to cause a previous `scrollToItemContext` to be reapplied. What we should do instead is clear the `scrollToItemContext` after a programmatic scroll has been completed.

## Related Issue

N/A

## Motivation and Context

Host calendar bug.

## How Has This Been Tested

Airbnb app, example app.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
