### PR TITLE
Implemented scroll to position in SwiftUI

### DIFF
--- a/Sources/Public/CalendarViewRepresentable.swift
+++ b/Sources/Public/CalendarViewRepresentable.swift
@@ -31,498 +31,510 @@ import UIKit
 /// - Note: This `View` wraps a UIKit `CalendarView`, enabling it to be used in a SwiftUI hierarchy.
 @available(iOS 13.0, *)
 public struct CalendarViewRepresentable: UIViewRepresentable {
-
-  // MARK: Lifecycle
-
-  /// Initializes a `CalendarViewRepresentable` with default `CalendarItemModel` providers.
-  ///
-  /// - Parameters:
-  ///   - calendar: The calendar on which all date operations will be performed. Defaults to `Calendar.current` (the system's
-  ///   current calendar).
-  ///   - visibleDateRange: The date range that will be displayed. The dates in this range are interpreted using the provided
-  ///   `calendar`.
-  ///   - monthsLayout: The layout of months - either vertically or horizontally.
-  ///   - dataDependency: Any data or state that, when updated, should cause the calendar to re-render. This is needed because
-  ///   `CalendarView` lazily invokes item provider closures outside of the normal SwiftUI update loop. To ensure that the calendar
-  ///   is updated at the right times, pass in any properties that are accessed in your item provider closures. For example, if a
-  ///   `dayItemProvider` closure accesses a local state variable called `selectedDay`, then pass it in here.
-  public init(
-    calendar: Calendar = Calendar.current,
-    visibleDateRange: ClosedRange<Date>,
-    monthsLayout: MonthsLayout,
-    dataDependency: Any?)
-  {
-    self.calendar = calendar
-    self.visibleDateRange = visibleDateRange
-    self.monthsLayout = monthsLayout
-    self.dataDependency = dataDependency
-  }
-
-  // MARK: Public
-
-  public func makeUIView(context: Context) -> CalendarView {
-    CalendarView(initialContent: makeContent())
-  }
-
-  public func updateUIView(_ calendarView: CalendarView, context: Context) {
-    calendarView.daySelectionHandler = daySelectionHandler
-    calendarView.multipleDaySelectionDragHandler = multipleDaySelectionDragHandler
-    calendarView.didScroll = didScroll
-    calendarView.didEndDragging = didEndDragging
-    calendarView.didEndDecelerating = didEndDecelerating
-
-    calendarView.setContent(makeContent())
-  }
-
-  // MARK: Fileprivate
-
-  fileprivate var dayAspectRatio: CGFloat?
-  fileprivate var interMonthSpacing: CGFloat?
-  fileprivate var monthDayInsets: NSDirectionalEdgeInsets?
-  fileprivate var verticalDayMargin: CGFloat?
-  fileprivate var horizontalDayMargin: CGFloat?
-  fileprivate var daysOfTheWeekRowSeparatorOptions: DaysOfTheWeekRowSeparatorOptions?
-
-  fileprivate var monthHeaderItemProvider: ((Month) -> AnyCalendarItemModel)?
-  fileprivate var dayOfWeekItemProvider: ((
-    _ month: Month?,
-    _ weekdayIndex: Int)
-    -> AnyCalendarItemModel)?
-  fileprivate var dayItemProvider: ((Day) -> AnyCalendarItemModel)?
-  fileprivate var dayBackgroundItemProvider: ((Day) -> AnyCalendarItemModel?)?
-  fileprivate var monthBackgroundItemProvider: ((MonthLayoutContext) -> AnyCalendarItemModel?)?
-  fileprivate var dateRangesAndItemProvider: (
-    dayRanges: Set<ClosedRange<Date>>,
-    dayRangeItemProvider: (DayRangeLayoutContext) -> AnyCalendarItemModel)?
-  fileprivate var overlaidItemLocationsAndItemProvider: (
-    overlaidItemLocations: Set<OverlaidItemLocation>,
-    overlayItemProvider: (OverlayLayoutContext) -> AnyCalendarItemModel)?
-
-  fileprivate var daySelectionHandler: ((Day) -> Void)?
-  fileprivate var multipleDaySelectionDragHandler: ((Day, UIGestureRecognizer.State) -> Void)?
-  fileprivate var didScroll: ((_ visibleDayRange: DayRange, _ isUserDragging: Bool) -> Void)?
-  fileprivate var didEndDragging: ((_ visibleDayRange: DayRange, _ willDecelerate: Bool) -> Void)?
-  fileprivate var didEndDecelerating: ((_ visibleDayRange: DayRange) -> Void)?
-
-  // MARK: Private
-
-  private let calendar: Calendar
-  private let visibleDateRange: ClosedRange<Date>
-  private let monthsLayout: MonthsLayout
-  private let dataDependency: Any?
-
-  private func makeContent() -> CalendarViewContent {
-    var content = CalendarViewContent(
-      calendar: calendar,
-      visibleDateRange: visibleDateRange,
-      monthsLayout: monthsLayout)
-
-    if let dayAspectRatio {
-      content = content.dayAspectRatio(dayAspectRatio)
+    
+    // MARK: Lifecycle
+    
+    /// Initializes a `CalendarViewRepresentable` with default `CalendarItemModel` providers.
+    ///
+    /// - Parameters:
+    ///   - calendar: The calendar on which all date operations will be performed. Defaults to `Calendar.current` (the system's
+    ///   current calendar).
+    ///   - visibleDateRange: The date range that will be displayed. The dates in this range are interpreted using the provided
+    ///   `calendar`.
+    ///   - monthsLayout: The layout of months - either vertically or horizontally.
+    ///   - dataDependency: Any data or state that, when updated, should cause the calendar to re-render. This is needed because
+    ///   `CalendarView` lazily invokes item provider closures outside of the normal SwiftUI update loop. To ensure that the calendar
+    ///   is updated at the right times, pass in any properties that are accessed in your item provider closures. For example, if a
+    ///   `dayItemProvider` closure accesses a local state variable called `selectedDay`, then pass it in here.
+    public init(
+        calendar: Calendar = Calendar.current,
+        visibleDateRange: ClosedRange<Date>,
+        monthsLayout: MonthsLayout,
+        dataDependency: Any?)
+    {
+        self.calendar = calendar
+        self.visibleDateRange = visibleDateRange
+        self.monthsLayout = monthsLayout
+        self.dataDependency = dataDependency
     }
-
-    if let interMonthSpacing {
-      content = content.interMonthSpacing(interMonthSpacing)
+    
+    // MARK: Public
+    
+    public func scrollToMonthAndDay(date: Date, animated: Bool = true) -> Self {
+        var view = self
+        view.scrollToMonthAndDayHandler = (date, animated)
+        return view
     }
-
-    if let monthDayInsets {
-      content = content.monthDayInsets(monthDayInsets)
+    
+    public func makeUIView(context: Context) -> CalendarView {
+        CalendarView(initialContent: makeContent())
     }
+    
+    public func updateUIView(_ calendarView: CalendarView, context: Context) {
+        calendarView.daySelectionHandler = daySelectionHandler
+        calendarView.multipleDaySelectionDragHandler = multipleDaySelectionDragHandler
+        calendarView.didScroll = didScroll
+        calendarView.didEndDragging = didEndDragging
+        calendarView.didEndDecelerating = didEndDecelerating
 
-    if let verticalDayMargin {
-      content = content.verticalDayMargin(verticalDayMargin)
+        calendarView.setContent(makeContent())
+        
+        if let scrollToMonthAndDayHandler = scrollToMonthAndDayHandler {
+            calendarView.scroll(toMonthContaining: scrollToMonthAndDayHandler.date, scrollPosition: .centered,
+                                animated: scrollToMonthAndDayHandler.animated)
+        }
     }
-
-    if let horizontalDayMargin {
-      content = content.horizontalDayMargin(horizontalDayMargin)
+    
+    // MARK: Fileprivate
+    
+    fileprivate var scrollToMonthAndDayHandler: (date: Date, animated: Bool)?
+    fileprivate var dayAspectRatio: CGFloat?
+    fileprivate var interMonthSpacing: CGFloat?
+    fileprivate var monthDayInsets: NSDirectionalEdgeInsets?
+    fileprivate var verticalDayMargin: CGFloat?
+    fileprivate var horizontalDayMargin: CGFloat?
+    fileprivate var daysOfTheWeekRowSeparatorOptions: DaysOfTheWeekRowSeparatorOptions?
+    
+    fileprivate var monthHeaderItemProvider: ((Month) -> AnyCalendarItemModel)?
+    fileprivate var dayOfWeekItemProvider: ((
+        _ month: Month?,
+        _ weekdayIndex: Int)
+                                            -> AnyCalendarItemModel)?
+    fileprivate var dayItemProvider: ((Day) -> AnyCalendarItemModel)?
+    fileprivate var dayBackgroundItemProvider: ((Day) -> AnyCalendarItemModel?)?
+    fileprivate var monthBackgroundItemProvider: ((MonthLayoutContext) -> AnyCalendarItemModel?)?
+    fileprivate var dateRangesAndItemProvider: (
+        dayRanges: Set<ClosedRange<Date>>,
+        dayRangeItemProvider: (DayRangeLayoutContext) -> AnyCalendarItemModel)?
+    fileprivate var overlaidItemLocationsAndItemProvider: (
+        overlaidItemLocations: Set<OverlaidItemLocation>,
+        overlayItemProvider: (OverlayLayoutContext) -> AnyCalendarItemModel)?
+    
+    fileprivate var daySelectionHandler: ((Day) -> Void)?
+    fileprivate var multipleDaySelectionDragHandler: ((Day, UIGestureRecognizer.State) -> Void)?
+    fileprivate var didScroll: ((_ visibleDayRange: DayRange, _ isUserDragging: Bool) -> Void)?
+    fileprivate var didEndDragging: ((_ visibleDayRange: DayRange, _ willDecelerate: Bool) -> Void)?
+    fileprivate var didEndDecelerating: ((_ visibleDayRange: DayRange) -> Void)?
+    
+    // MARK: Private
+    
+    private let calendar: Calendar
+    private let visibleDateRange: ClosedRange<Date>
+    private let monthsLayout: MonthsLayout
+    private let dataDependency: Any?
+    
+    private func makeContent() -> CalendarViewContent {
+        var content = CalendarViewContent(
+            calendar: calendar,
+            visibleDateRange: visibleDateRange,
+            monthsLayout: monthsLayout)
+        
+        if let dayAspectRatio {
+            content = content.dayAspectRatio(dayAspectRatio)
+        }
+        
+        if let interMonthSpacing {
+            content = content.interMonthSpacing(interMonthSpacing)
+        }
+        
+        if let monthDayInsets {
+            content = content.monthDayInsets(monthDayInsets)
+        }
+        
+        if let verticalDayMargin {
+            content = content.verticalDayMargin(verticalDayMargin)
+        }
+        
+        if let horizontalDayMargin {
+            content = content.horizontalDayMargin(horizontalDayMargin)
+        }
+        
+        content = content.daysOfTheWeekRowSeparator(options: daysOfTheWeekRowSeparatorOptions)
+        
+        if let monthHeaderItemProvider {
+            content = content.monthHeaderItemProvider(monthHeaderItemProvider)
+        }
+        
+        if let dayOfWeekItemProvider {
+            content = content.dayOfWeekItemProvider(dayOfWeekItemProvider)
+        }
+        
+        if let dayItemProvider {
+            content = content.dayItemProvider(dayItemProvider)
+        }
+        
+        if let dayBackgroundItemProvider {
+            content = content.dayBackgroundItemProvider(dayBackgroundItemProvider)
+        }
+        
+        if let monthBackgroundItemProvider {
+            content = content.monthBackgroundItemProvider(monthBackgroundItemProvider)
+        }
+        
+        if let (dateRanges, itemProvider) = dateRangesAndItemProvider {
+            content = content.dayRangeItemProvider(for: dateRanges, itemProvider)
+        }
+        
+        if let (itemLocations, itemProvider) = overlaidItemLocationsAndItemProvider {
+            content = content.overlayItemProvider(for: itemLocations, itemProvider)
+        }
+        
+        return content
     }
-
-    content = content.daysOfTheWeekRowSeparator(options: daysOfTheWeekRowSeparatorOptions)
-
-    if let monthHeaderItemProvider {
-      content = content.monthHeaderItemProvider(monthHeaderItemProvider)
-    }
-
-    if let dayOfWeekItemProvider {
-      content = content.dayOfWeekItemProvider(dayOfWeekItemProvider)
-    }
-
-    if let dayItemProvider {
-      content = content.dayItemProvider(dayItemProvider)
-    }
-
-    if let dayBackgroundItemProvider {
-      content = content.dayBackgroundItemProvider(dayBackgroundItemProvider)
-    }
-
-    if let monthBackgroundItemProvider {
-      content = content.monthBackgroundItemProvider(monthBackgroundItemProvider)
-    }
-
-    if let (dateRanges, itemProvider) = dateRangesAndItemProvider {
-      content = content.dayRangeItemProvider(for: dateRanges, itemProvider)
-    }
-
-    if let (itemLocations, itemProvider) = overlaidItemLocationsAndItemProvider {
-      content = content.overlayItemProvider(for: itemLocations, itemProvider)
-    }
-
-    return content
-  }
-
+    
 }
 
 // MARK: Content Modifiers
 
 @available(iOS 13.0, *)
 extension CalendarViewRepresentable {
-
-  /// Configures the aspect ratio of each day.
-  ///
-  /// Values less than 1 will result in rectangular days that are wider than they are tall. Values
-  /// greater than 1 will result in rectangular days that are taller than they are wide. The default value is `1`, which results in square
-  /// views with the same width and height.
-  ///
-  /// - Parameters:
-  ///   - dayAspectRatio: The aspect ratio of each day view.
-  /// - Returns: A mutated `CalendarViewRepresentable` with a new day aspect ratio value.
-  public func dayAspectRatio(_ dayAspectRatio: CGFloat) -> Self {
-    var view = self
-    view.dayAspectRatio = dayAspectRatio
-    return view
-  }
-
-  /// Configures the amount of spacing, in points, between months. The default value is `0`.
-  ///
-  /// - Parameters:
-  ///   - interMonthSpacing: The amount of spacing, in points, between months.
-  /// - Returns: A mutated `CalendarViewRepresentable` with a new inter-month-spacing value.
-  public func interMonthSpacing(_ interMonthSpacing: CGFloat) -> Self {
-    var view = self
-    view.interMonthSpacing = interMonthSpacing
-    return view
-  }
-
-  /// Configures the amount to inset days and day-of-week items from the edges of a month. The default value is `.zero`.
-  ///
-  /// - Parameters:
-  ///   - monthDayInsets: The amount to inset days and day-of-week items from the edges of a month.
-  /// - Returns: A mutated `CalendarViewRepresentable` with a new month-day-insets value.
-  public func monthDayInsets(_ monthDayInsets: NSDirectionalEdgeInsets) -> Self {
-    var view = self
-    view.monthDayInsets = monthDayInsets
-    return view
-  }
-
-  /// Configures the amount of space between two day frames vertically.
-  ///
-  /// If `verticalDayMargin` and `horizontalDayMargin` are the same, then each day will appear to
-  /// have a 1:1 (square) aspect ratio. If `verticalDayMargin` and `horizontalDayMargin` are different, then days can
-  /// appear wider or taller.
-  ///
-  /// - Parameters:
-  ///   - verticalDayMargin: The amount of space between two day frames along the vertical axis.
-  /// - Returns: A mutated `CalendarViewRepresentable` with a new vertical day margin value.
-  public func verticalDayMargin(_ verticalDayMargin: CGFloat) -> Self {
-    var view = self
-    view.verticalDayMargin = verticalDayMargin
-    return view
-  }
-
-  /// Configures the amount of space between two day frames horizontally.
-  ///
-  /// If `verticalDayMargin` and `horizontalDayMargin` are the same, then each day will appear to
-  /// have a 1:1 (square) aspect ratio. If `verticalDayMargin` and `horizontalDayMargin` are
-  /// different, then days can appear wider or taller.
-  ///
-  /// - Parameters:
-  ///   - horizontalDayMargin: The amount of space between two day frames along the horizontal axis.
-  /// - Returns: A mutated `CalendarViewRepresentable` with a new horizontal day margin value.
-  public func horizontalDayMargin(_ horizontalDayMargin: CGFloat) -> Self {
-    var view = self
-    view.horizontalDayMargin = horizontalDayMargin
-    return view
-  }
-
-  /// Configures the days-of-the-week row's separator options. The separator appears below the days-of-the-week row.
-  ///
-  /// - Parameters:
-  ///   - options: An instance that has properties to control various aspects of the separator's design.
-  /// - Returns: A mutated `CalendarViewRepresentable` with a days-of-the-week row separator configured.
-  public func daysOfTheWeekRowSeparator(
-    options daysOfTheWeekRowSeparatorOptions: DaysOfTheWeekRowSeparatorOptions?)
+    
+    /// Configures the aspect ratio of each day.
+    ///
+    /// Values less than 1 will result in rectangular days that are wider than they are tall. Values
+    /// greater than 1 will result in rectangular days that are taller than they are wide. The default value is `1`, which results in square
+    /// views with the same width and height.
+    ///
+    /// - Parameters:
+    ///   - dayAspectRatio: The aspect ratio of each day view.
+    /// - Returns: A mutated `CalendarViewRepresentable` with a new day aspect ratio value.
+    public func dayAspectRatio(_ dayAspectRatio: CGFloat) -> Self {
+        var view = self
+        view.dayAspectRatio = dayAspectRatio
+        return view
+    }
+    
+    /// Configures the amount of spacing, in points, between months. The default value is `0`.
+    ///
+    /// - Parameters:
+    ///   - interMonthSpacing: The amount of spacing, in points, between months.
+    /// - Returns: A mutated `CalendarViewRepresentable` with a new inter-month-spacing value.
+    public func interMonthSpacing(_ interMonthSpacing: CGFloat) -> Self {
+        var view = self
+        view.interMonthSpacing = interMonthSpacing
+        return view
+    }
+    
+    /// Configures the amount to inset days and day-of-week items from the edges of a month. The default value is `.zero`.
+    ///
+    /// - Parameters:
+    ///   - monthDayInsets: The amount to inset days and day-of-week items from the edges of a month.
+    /// - Returns: A mutated `CalendarViewRepresentable` with a new month-day-insets value.
+    public func monthDayInsets(_ monthDayInsets: NSDirectionalEdgeInsets) -> Self {
+        var view = self
+        view.monthDayInsets = monthDayInsets
+        return view
+    }
+    
+    /// Configures the amount of space between two day frames vertically.
+    ///
+    /// If `verticalDayMargin` and `horizontalDayMargin` are the same, then each day will appear to
+    /// have a 1:1 (square) aspect ratio. If `verticalDayMargin` and `horizontalDayMargin` are different, then days can
+    /// appear wider or taller.
+    ///
+    /// - Parameters:
+    ///   - verticalDayMargin: The amount of space between two day frames along the vertical axis.
+    /// - Returns: A mutated `CalendarViewRepresentable` with a new vertical day margin value.
+    public func verticalDayMargin(_ verticalDayMargin: CGFloat) -> Self {
+        var view = self
+        view.verticalDayMargin = verticalDayMargin
+        return view
+    }
+    
+    /// Configures the amount of space between two day frames horizontally.
+    ///
+    /// If `verticalDayMargin` and `horizontalDayMargin` are the same, then each day will appear to
+    /// have a 1:1 (square) aspect ratio. If `verticalDayMargin` and `horizontalDayMargin` are
+    /// different, then days can appear wider or taller.
+    ///
+    /// - Parameters:
+    ///   - horizontalDayMargin: The amount of space between two day frames along the horizontal axis.
+    /// - Returns: A mutated `CalendarViewRepresentable` with a new horizontal day margin value.
+    public func horizontalDayMargin(_ horizontalDayMargin: CGFloat) -> Self {
+        var view = self
+        view.horizontalDayMargin = horizontalDayMargin
+        return view
+    }
+    
+    /// Configures the days-of-the-week row's separator options. The separator appears below the days-of-the-week row.
+    ///
+    /// - Parameters:
+    ///   - options: An instance that has properties to control various aspects of the separator's design.
+    /// - Returns: A mutated `CalendarViewRepresentable` with a days-of-the-week row separator configured.
+    public func daysOfTheWeekRowSeparator(
+        options daysOfTheWeekRowSeparatorOptions: DaysOfTheWeekRowSeparatorOptions?)
     -> Self
-  {
-    var view = self
-    view.daysOfTheWeekRowSeparatorOptions = daysOfTheWeekRowSeparatorOptions
-    return view
-  }
-
-  /// Configures the month header item provider.
-  ///
-  /// `CalendarView` invokes the provided `monthHeaderItemProvider` for each month in the range of months being
-  /// displayed. The `CalendarItemModel`s that you return will be used to create the views for each month header in
-  /// `CalendarView`.
-  ///
-  /// If you don't configure your own month header item provider via this function, then a default month header item provider will be
-  /// used.
-  ///
-  /// - Parameters:
-  ///   - monthHeaderItemProvider: A closure (that is retained) that returns a `CalendarItemModel` representing a
-  ///   month header.
-  ///   - month: The `Month` for which to provide a month header item.
-  /// - Returns: A mutated `CalendarViewRepresentable` with a new month header item provider.
-  public func monthHeaderItemProvider(
-    _ monthHeaderItemProvider: @escaping (_ month: Month) -> AnyCalendarItemModel)
+    {
+        var view = self
+        view.daysOfTheWeekRowSeparatorOptions = daysOfTheWeekRowSeparatorOptions
+        return view
+    }
+    
+    /// Configures the month header item provider.
+    ///
+    /// `CalendarView` invokes the provided `monthHeaderItemProvider` for each month in the range of months being
+    /// displayed. The `CalendarItemModel`s that you return will be used to create the views for each month header in
+    /// `CalendarView`.
+    ///
+    /// If you don't configure your own month header item provider via this function, then a default month header item provider will be
+    /// used.
+    ///
+    /// - Parameters:
+    ///   - monthHeaderItemProvider: A closure (that is retained) that returns a `CalendarItemModel` representing a
+    ///   month header.
+    ///   - month: The `Month` for which to provide a month header item.
+    /// - Returns: A mutated `CalendarViewRepresentable` with a new month header item provider.
+    public func monthHeaderItemProvider(
+        _ monthHeaderItemProvider: @escaping (_ month: Month) -> AnyCalendarItemModel)
     -> Self
-  {
-    var view = self
-    view.monthHeaderItemProvider = monthHeaderItemProvider
-    return view
-  }
-
-  /// Configures the day-of-week item provider.
-  ///
-  /// `CalendarView` invokes the provided `dayOfWeekItemProvider` for each weekday index for the current calendar.
-  /// For example, for the en_US locale, 0 is Sunday, 1 is Monday, and 6 is Saturday. This will be different in some other locales. The
-  /// `CalendarItemModel`s that you return will be used to create the views for each day-of-week view in `CalendarView`.
-  ///
-  /// If you don't configure your own day-of-week item provider via this function, then a default day-of-week item provider will be used.
-  ///
-  /// - Parameters:
-  ///   - dayOfWeekItemProvider: A closure (that is retained) that returns a `CalendarItemModel` representing a
-  ///   day of the week.
-  ///   - month: The month in which the day-of-week item belongs. This parameter will be `nil` if days of the week are pinned to
-  ///   the top of the calendar, since in that scenario, they don't belong to any particular month.
-  ///   - weekdayIndex: The weekday index for which to provide a `CalendarItemModel`.
-  /// - Returns: A mutated `CalendarViewRepresentable` with a new day-of-week item provider.
-  public func dayOfWeekItemProvider(
-    _ dayOfWeekItemProvider: @escaping (
-      _ month: Month?,
-      _ weekdayIndex: Int)
-      -> AnyCalendarItemModel)
+    {
+        var view = self
+        view.monthHeaderItemProvider = monthHeaderItemProvider
+        return view
+    }
+    
+    /// Configures the day-of-week item provider.
+    ///
+    /// `CalendarView` invokes the provided `dayOfWeekItemProvider` for each weekday index for the current calendar.
+    /// For example, for the en_US locale, 0 is Sunday, 1 is Monday, and 6 is Saturday. This will be different in some other locales. The
+    /// `CalendarItemModel`s that you return will be used to create the views for each day-of-week view in `CalendarView`.
+    ///
+    /// If you don't configure your own day-of-week item provider via this function, then a default day-of-week item provider will be used.
+    ///
+    /// - Parameters:
+    ///   - dayOfWeekItemProvider: A closure (that is retained) that returns a `CalendarItemModel` representing a
+    ///   day of the week.
+    ///   - month: The month in which the day-of-week item belongs. This parameter will be `nil` if days of the week are pinned to
+    ///   the top of the calendar, since in that scenario, they don't belong to any particular month.
+    ///   - weekdayIndex: The weekday index for which to provide a `CalendarItemModel`.
+    /// - Returns: A mutated `CalendarViewRepresentable` with a new day-of-week item provider.
+    public func dayOfWeekItemProvider(
+        _ dayOfWeekItemProvider: @escaping (
+            _ month: Month?,
+            _ weekdayIndex: Int)
+        -> AnyCalendarItemModel)
     -> Self
-  {
-    var view = self
-    view.dayOfWeekItemProvider = dayOfWeekItemProvider
-    return view
-  }
-
-  /// Configures the day item provider.
-  ///
-  /// `CalendarView` invokes the provided `dayItemProvider` for each day being displayed. The
-  /// `CalendarItemModel`s that you return will be used to create the views for each day in `CalendarView`. In most cases, this
-  /// view should be some kind of label that tells the user the day number of the month. You can also add other decoration, like a badge
-  /// or background, by including it in the view that your `CalendarItemModel` creates.
-  ///
-  /// If you don't configure your own day item provider via this function, then a default day item provider will be used.
-  ///
-  /// - Parameters:
-  ///   - dayItemProvider: A closure (that is retained) that returns a `CalendarItemModel` representing a single day
-  ///   in the calendar.
-  ///   - day: The `Day` for which to provide a day item.
-  /// - Returns: A mutated `CalendarViewRepresentable` with a new day item provider.
-  public func dayItemProvider(
-    _ dayItemProvider: @escaping (_ day: Day) -> AnyCalendarItemModel)
+    {
+        var view = self
+        view.dayOfWeekItemProvider = dayOfWeekItemProvider
+        return view
+    }
+    
+    /// Configures the day item provider.
+    ///
+    /// `CalendarView` invokes the provided `dayItemProvider` for each day being displayed. The
+    /// `CalendarItemModel`s that you return will be used to create the views for each day in `CalendarView`. In most cases, this
+    /// view should be some kind of label that tells the user the day number of the month. You can also add other decoration, like a badge
+    /// or background, by including it in the view that your `CalendarItemModel` creates.
+    ///
+    /// If you don't configure your own day item provider via this function, then a default day item provider will be used.
+    ///
+    /// - Parameters:
+    ///   - dayItemProvider: A closure (that is retained) that returns a `CalendarItemModel` representing a single day
+    ///   in the calendar.
+    ///   - day: The `Day` for which to provide a day item.
+    /// - Returns: A mutated `CalendarViewRepresentable` with a new day item provider.
+    public func dayItemProvider(
+        _ dayItemProvider: @escaping (_ day: Day) -> AnyCalendarItemModel)
     -> Self
-  {
-    var view = self
-    view.dayItemProvider = dayItemProvider
-    return view
-  }
-
-  /// Configures the day background item provider.
-  ///
-  /// `CalendarView` invokes the provided `dayBackgroundItemProvider` for each day being displayed. The
-  /// `CalendarItemModel`s that you return will be used to create the background views for each day in `CalendarView`. If a
-  /// particular day does not have a background view, return `nil` for that day.
-  ///
-  /// If you don't configure a day background item provider via this function, then days will not have additional background decoration.
-  ///
-  /// - Parameters:
-  ///   - dayBackgroundItemProvider: A closure (that is retained) that returns a `CalendarItemModel` representing the
-  ///   background of a single day in the calendar.
-  ///   - day: The `Day` for which to provide a day background item.
-  /// - Returns: A mutated `CalendarViewRepresentable` with a new day background item provider.
-  public func dayBackgroundItemProvider(
-    _ dayBackgroundItemProvider: @escaping (_ day: Day) -> AnyCalendarItemModel?)
+    {
+        var view = self
+        view.dayItemProvider = dayItemProvider
+        return view
+    }
+    
+    /// Configures the day background item provider.
+    ///
+    /// `CalendarView` invokes the provided `dayBackgroundItemProvider` for each day being displayed. The
+    /// `CalendarItemModel`s that you return will be used to create the background views for each day in `CalendarView`. If a
+    /// particular day does not have a background view, return `nil` for that day.
+    ///
+    /// If you don't configure a day background item provider via this function, then days will not have additional background decoration.
+    ///
+    /// - Parameters:
+    ///   - dayBackgroundItemProvider: A closure (that is retained) that returns a `CalendarItemModel` representing the
+    ///   background of a single day in the calendar.
+    ///   - day: The `Day` for which to provide a day background item.
+    /// - Returns: A mutated `CalendarViewRepresentable` with a new day background item provider.
+    public func dayBackgroundItemProvider(
+        _ dayBackgroundItemProvider: @escaping (_ day: Day) -> AnyCalendarItemModel?)
     -> Self
-  {
-    var view = self
-    view.dayBackgroundItemProvider = dayBackgroundItemProvider
-    return view
-  }
-
-  /// Configures the month background item provider.
-  ///
-  /// `CalendarView` invokes the provided `monthBackgroundItemProvider` for each month being displayed. The
-  /// `CalendarItemModel` that you return for each month will be used to create a view that spans the entire frame of that month,
-  /// encapsulating all days, days-of-the-week headers, and the month header. This behavior makes month backgrounds useful for
-  /// things like grid lines or colored backgrounds.
-  ///
-  /// If you don't configure your own month background item provider via this function, then months will not have additional
-  /// background decoration.
-  ///
-  /// - Parameters:
-  ///   - monthBackgroundItemProvider: A closure (that is retained) that returns a `CalendarItemModel` representing the
-  ///   background of a single month in the calendar.
-  ///   - monthLayoutContext: The layout context for the month containing information about the frames of views in that month
-  ///   and the bounds in which your month background will be displayed.
-  /// - Returns: A mutated `CalendarViewRepresentable` with a new month background item provider.
-  public func monthBackgroundItemProvider(
-    _ monthBackgroundItemProvider: @escaping (
-      _ monthLayoutContext: MonthLayoutContext)
-      -> AnyCalendarItemModel?)
+    {
+        var view = self
+        view.dayBackgroundItemProvider = dayBackgroundItemProvider
+        return view
+    }
+    
+    /// Configures the month background item provider.
+    ///
+    /// `CalendarView` invokes the provided `monthBackgroundItemProvider` for each month being displayed. The
+    /// `CalendarItemModel` that you return for each month will be used to create a view that spans the entire frame of that month,
+    /// encapsulating all days, days-of-the-week headers, and the month header. This behavior makes month backgrounds useful for
+    /// things like grid lines or colored backgrounds.
+    ///
+    /// If you don't configure your own month background item provider via this function, then months will not have additional
+    /// background decoration.
+    ///
+    /// - Parameters:
+    ///   - monthBackgroundItemProvider: A closure (that is retained) that returns a `CalendarItemModel` representing the
+    ///   background of a single month in the calendar.
+    ///   - monthLayoutContext: The layout context for the month containing information about the frames of views in that month
+    ///   and the bounds in which your month background will be displayed.
+    /// - Returns: A mutated `CalendarViewRepresentable` with a new month background item provider.
+    public func monthBackgroundItemProvider(
+        _ monthBackgroundItemProvider: @escaping (
+            _ monthLayoutContext: MonthLayoutContext)
+        -> AnyCalendarItemModel?)
     -> Self
-  {
-    var view = self
-    view.monthBackgroundItemProvider = monthBackgroundItemProvider
-    return view
-  }
-
-  /// Configures the day range item provider.
-  ///
-  /// `CalendarView` invokes the provided `dayRangeItemProvider` for each day range in the `dateRanges` set.
-  /// Date ranges will be converted to day ranges by using the `calendar`passed into the `CalendarViewRepresentable`
-  /// initializer. The `CalendarItemModel` that you return for each day range will be used to create a view that spans the entire
-  /// frame encapsulating all days in that day range. This behavior makes day range items useful for things like day range selection
-  /// indicators that might have specific styling requirements for different parts of the selected day range. For example, you might have
-  /// a cross fade in your day range selection indicator view when a day range spans multiple months, or you might have rounded end
-  /// caps for the start and end of a day range.
-  ///
-  /// The views created by the `CalendarItemModel`s provided by this function will be placed at a lower z-index than the layer of
-  /// day items. If you don't configure your own day range item provider via this function, then no day range view will be displayed.
-  ///
-  /// If you don't want to show any day range items, pass in an empty set for the `dateRanges` parameter.
-  ///
-  /// - Parameters:
-  ///   - dateRanges: The date ranges for which `CalendarView` will invoke your day range item provider closure.
-  ///   - dayRangeItemProvider: A closure (that is retained) that returns a `CalendarItemModel` representing a day
-  ///   range in the calendar.
-  ///   - dayRangeLayoutContext: The layout context for the day range containing information about the frames of days and
-  ///   bounds in which your day range item will be displayed.
-  /// - Returns: A mutated `CalendarViewRepresentable` with a new day range item provider.
-  public func dayRangeItemProvider(
-    for dateRanges: Set<ClosedRange<Date>>,
-    _ dayRangeItemProvider: @escaping (
-      _ dayRangeLayoutContext: DayRangeLayoutContext)
-    -> AnyCalendarItemModel)
+    {
+        var view = self
+        view.monthBackgroundItemProvider = monthBackgroundItemProvider
+        return view
+    }
+    
+    /// Configures the day range item provider.
+    ///
+    /// `CalendarView` invokes the provided `dayRangeItemProvider` for each day range in the `dateRanges` set.
+    /// Date ranges will be converted to day ranges by using the `calendar`passed into the `CalendarViewRepresentable`
+    /// initializer. The `CalendarItemModel` that you return for each day range will be used to create a view that spans the entire
+    /// frame encapsulating all days in that day range. This behavior makes day range items useful for things like day range selection
+    /// indicators that might have specific styling requirements for different parts of the selected day range. For example, you might have
+    /// a cross fade in your day range selection indicator view when a day range spans multiple months, or you might have rounded end
+    /// caps for the start and end of a day range.
+    ///
+    /// The views created by the `CalendarItemModel`s provided by this function will be placed at a lower z-index than the layer of
+    /// day items. If you don't configure your own day range item provider via this function, then no day range view will be displayed.
+    ///
+    /// If you don't want to show any day range items, pass in an empty set for the `dateRanges` parameter.
+    ///
+    /// - Parameters:
+    ///   - dateRanges: The date ranges for which `CalendarView` will invoke your day range item provider closure.
+    ///   - dayRangeItemProvider: A closure (that is retained) that returns a `CalendarItemModel` representing a day
+    ///   range in the calendar.
+    ///   - dayRangeLayoutContext: The layout context for the day range containing information about the frames of days and
+    ///   bounds in which your day range item will be displayed.
+    /// - Returns: A mutated `CalendarViewRepresentable` with a new day range item provider.
+    public func dayRangeItemProvider(
+        for dateRanges: Set<ClosedRange<Date>>,
+        _ dayRangeItemProvider: @escaping (
+            _ dayRangeLayoutContext: DayRangeLayoutContext)
+        -> AnyCalendarItemModel)
     -> Self
-  {
-    var view = self
-    view.dateRangesAndItemProvider = (dateRanges, dayRangeItemProvider)
-    return view
-  }
-
-  /// Configures the overlay item provider.
-  ///
-  /// `CalendarView` invokes the provided `overlayItemProvider` for each overlaid item location in the
-  /// `overlaidItemLocations` set. All of the layout information needed to create an overlay item is provided via the overlay
-  /// context passed into the `overlayItemProvider` closure. The `CalendarItemModel` that you return for each
-  /// overlaid item location will be used to create a view that spans the visible bounds of the calendar when that overlaid item's location
-  /// is visible. This behavior makes overlay items useful for things like tooltips.
-  ///
-  /// - Parameters:
-  ///   - overlaidItemLocations: The overlaid item locations for which `CalendarView` will invoke your overlay item
-  ///   provider closure.
-  ///   - overlayItemProvider: A closure (that is retained) that returns a `CalendarItemModel` representing an
-  ///   overlay.
-  ///   - overlayLayoutContext: The layout context for the overlaid item location containing information about that location's
-  ///   frame and the bounds in which your overlay item will be displayed.
-  /// - Returns: A mutated `CalendarViewRepresentable` with a new overlay item provider.
-  public func overlayItemProvider(
-    for overlaidItemLocations: Set<OverlaidItemLocation>,
-    _ overlayItemProvider: @escaping (
-      _ overlayLayoutContext: OverlayLayoutContext)
-    -> AnyCalendarItemModel)
+    {
+        var view = self
+        view.dateRangesAndItemProvider = (dateRanges, dayRangeItemProvider)
+        return view
+    }
+    
+    /// Configures the overlay item provider.
+    ///
+    /// `CalendarView` invokes the provided `overlayItemProvider` for each overlaid item location in the
+    /// `overlaidItemLocations` set. All of the layout information needed to create an overlay item is provided via the overlay
+    /// context passed into the `overlayItemProvider` closure. The `CalendarItemModel` that you return for each
+    /// overlaid item location will be used to create a view that spans the visible bounds of the calendar when that overlaid item's location
+    /// is visible. This behavior makes overlay items useful for things like tooltips.
+    ///
+    /// - Parameters:
+    ///   - overlaidItemLocations: The overlaid item locations for which `CalendarView` will invoke your overlay item
+    ///   provider closure.
+    ///   - overlayItemProvider: A closure (that is retained) that returns a `CalendarItemModel` representing an
+    ///   overlay.
+    ///   - overlayLayoutContext: The layout context for the overlaid item location containing information about that location's
+    ///   frame and the bounds in which your overlay item will be displayed.
+    /// - Returns: A mutated `CalendarViewRepresentable` with a new overlay item provider.
+    public func overlayItemProvider(
+        for overlaidItemLocations: Set<OverlaidItemLocation>,
+        _ overlayItemProvider: @escaping (
+            _ overlayLayoutContext: OverlayLayoutContext)
+        -> AnyCalendarItemModel)
     -> Self
-  {
-    var view = self
-    view.overlaidItemLocationsAndItemProvider = (overlaidItemLocations, overlayItemProvider)
-    return view
-  }
-
+    {
+        var view = self
+        view.overlaidItemLocationsAndItemProvider = (overlaidItemLocations, overlayItemProvider)
+        return view
+    }
+    
 }
 
 // MARK: Event Handlers
 
 @available(iOS 13.0, *)
 extension CalendarViewRepresentable {
-
-  /// Configures the day-selection handler.
-  ///
-  /// It is the responsibility of your feature code to decide what to do with each day. For example, you might store the most recent day
-  /// in a selected day property, then read that property in your `dayItemProvider` closure to add specific "selected" styling to a
-  /// particular day view. If one of your item provider closures depends on this selected day state, remember to include it as part of the
-  /// `dataDependency` parameter when initializing your `CalendarViewRepresentable`.
-  ///
-  /// - Parameters:
-  ///   - daySelectionHandler: A closure (that is retained) that is invoked whenever a day is selected.
-  public func onDaySelection(_ daySelectionHandler: @escaping (Day) -> Void) -> Self {
-    var view = self
-    view.daySelectionHandler = daySelectionHandler
-    return view
-  }
-
-  /// Configures the multiple-day-selection drag handler.
-  ///
-  /// Multiple selection is initiated with a long press, followed by a drag / pan. As the gesture crosses over more days in the calendar,
-  /// this handler will be invoked with each new day. It is the responsibility of your feature code to decide what to do with this stream of
-  /// days. For example, you might convert them to `Date` instances and use them as input to the `dayRangeItemProvider`. If
-  /// one of your item provider closures depends on state referencing this stream of selected days, remember to include it as part of
-  /// the `dataDependency` parameter when initializing your `CalendarViewRepresentable`.
-  ///
-  /// - Parameters:
-  ///   - began: A closure (that is retained) that is invoked when the multiple-day-selection drag gesture begins.
-  ///   - changed: A closure (that is retained) that is invoked when the multiple-day-selection drag gesture intersects a new day.
-  ///   - ended: A closure (that is retained) that is invoked when the multiple-day-selection drag gesture ends.
-  public func onMultipleDaySelectionDrag(
-    began: @escaping (Day) -> Void,
-    changed: @escaping (Day) -> Void,
-    ended: @escaping (Day) -> Void)
-    -> Self
-  {
-    var view = self
-    view.multipleDaySelectionDragHandler = { day, state in
-      switch state {
-      case .began:
-        began(day)
-      case .changed:
-        changed(day)
-      case .ended, .failed, .cancelled:
-        ended(day)
-      default:
-        break
-      }
+    
+    /// Configures the day-selection handler.
+    ///
+    /// It is the responsibility of your feature code to decide what to do with each day. For example, you might store the most recent day
+    /// in a selected day property, then read that property in your `dayItemProvider` closure to add specific "selected" styling to a
+    /// particular day view. If one of your item provider closures depends on this selected day state, remember to include it as part of the
+    /// `dataDependency` parameter when initializing your `CalendarViewRepresentable`.
+    ///
+    /// - Parameters:
+    ///   - daySelectionHandler: A closure (that is retained) that is invoked whenever a day is selected.
+    public func onDaySelection(_ daySelectionHandler: @escaping (Day) -> Void) -> Self {
+        var view = self
+        view.daySelectionHandler = daySelectionHandler
+        return view
     }
-    return view
-  }
-
-  public func onScroll(
-    _ scrollHandler: @escaping (_ visibleDayRange: DayRange,  _ isUserDragging: Bool) -> Void)
+    
+    /// Configures the multiple-day-selection drag handler.
+    ///
+    /// Multiple selection is initiated with a long press, followed by a drag / pan. As the gesture crosses over more days in the calendar,
+    /// this handler will be invoked with each new day. It is the responsibility of your feature code to decide what to do with this stream of
+    /// days. For example, you might convert them to `Date` instances and use them as input to the `dayRangeItemProvider`. If
+    /// one of your item provider closures depends on state referencing this stream of selected days, remember to include it as part of
+    /// the `dataDependency` parameter when initializing your `CalendarViewRepresentable`.
+    ///
+    /// - Parameters:
+    ///   - began: A closure (that is retained) that is invoked when the multiple-day-selection drag gesture begins.
+    ///   - changed: A closure (that is retained) that is invoked when the multiple-day-selection drag gesture intersects a new day.
+    ///   - ended: A closure (that is retained) that is invoked when the multiple-day-selection drag gesture ends.
+    public func onMultipleDaySelectionDrag(
+        began: @escaping (Day) -> Void,
+        changed: @escaping (Day) -> Void,
+        ended: @escaping (Day) -> Void)
     -> Self
-  {
-    var view = self
-    view.didScroll = scrollHandler
-    return view
-  }
-
-  public func onDragEnd(
-    _ dragEndHandler: @escaping (_ visibleDayRange: DayRange, _ willDecelerate: Bool) -> Void)
+    {
+        var view = self
+        view.multipleDaySelectionDragHandler = { day, state in
+            switch state {
+            case .began:
+                began(day)
+            case .changed:
+                changed(day)
+            case .ended, .failed, .cancelled:
+                ended(day)
+            default:
+                break
+            }
+        }
+        return view
+    }
+    
+    public func onScroll(
+        _ scrollHandler: @escaping (_ visibleDayRange: DayRange,  _ isUserDragging: Bool) -> Void)
     -> Self
-  {
-    var view = self
-    view.didEndDragging = dragEndHandler
-    return view
-  }
-
-  public func onDeceleratingEnd(
-    _ deceleratingEndHandler: @escaping (_ visibleDayRange: DayRange) -> Void)
+    {
+        var view = self
+        view.didScroll = scrollHandler
+        return view
+    }
+    
+    public func onDragEnd(
+        _ dragEndHandler: @escaping (_ visibleDayRange: DayRange, _ willDecelerate: Bool) -> Void)
     -> Self
-  {
-    var view = self
-    view.didEndDecelerating = deceleratingEndHandler
-    return view
-  }
-
+    {
+        var view = self
+        view.didEndDragging = dragEndHandler
+        return view
+    }
+    
+    public func onDeceleratingEnd(
+        _ deceleratingEndHandler: @escaping (_ visibleDayRange: DayRange) -> Void)
+    -> Self
+    {
+        var view = self
+        view.didEndDecelerating = deceleratingEndHandler
+        return view
+    }
+    
 }


### PR DESCRIPTION
## Details

As CalendarViewRepresentable didn't implement any function for scroll to position, I supported it recalling CalendarView

## Related Issue

Missing a way to scroll to current month in SwiftUI

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
