### PR TITLE
Add day of week aspect ratio support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `MonthsLayout.vertical` and `MonthsLayout.horizontal` as more concise alternatives to `MonthsLayout.vertical(options: .init())` and `MonthsLayout.horizontal(options: .init())`, respectively
 - Added `CalendarViewRepresentable` enabling developers to use `CalendarView` from SwiftUI
 - Added a `multipleDaySelectionDragHandler`, enabling developers to implement multiple-day-selection via a drag gesture (similar to multi-select in the iOS Photos app)
+- Added the ability to change the aspect ratio of individual day-of-the-week items
 
 ### Fixed
 - Fixed an issue that could cause the calendar to programmatically scroll to a month or day to which it had previously scrolled. 

--- a/Sources/Internal/FrameProvider.swift
+++ b/Sources/Internal/FrameProvider.swift
@@ -48,8 +48,12 @@ final class FrameProvider {
     let numberOfDaysPerWeek = CGFloat(7)
     let availableWidth = insetWidth - (content.horizontalDayMargin * (numberOfDaysPerWeek - 1))
     let width = availableWidth / numberOfDaysPerWeek
-    let height = width * content.dayAspectRatio
-    daySize = CGSize(width: width, height: height)
+
+    let dayHeight = width * content.dayAspectRatio
+    daySize = CGSize(width: width, height: dayHeight)
+
+    let dayOfWeekHeight = width * content.dayOfWeekAspectRatio
+    dayOfWeekSize = CGSize(width: width, height: dayOfWeekHeight)
 
     if daySize.width <= 0 || daySize.height <= 0 {
       print("Calendar metrics and size resulted in a negative-or-zero size of (\(daySize.debugDescription) points for each day. If ignored, this will cause incorrect / unexpected layouts.")
@@ -62,6 +66,7 @@ final class FrameProvider {
   let layoutMargins: NSDirectionalEdgeInsets
   let scale: CGFloat
   let daySize: CGSize
+  let dayOfWeekSize: CGSize
 
   var maxMonthHeight: CGFloat {
     let maxNumberOfWeekRowsPerMonth = 6
@@ -147,7 +152,7 @@ final class FrameProvider {
   {
     let x = minXOfItem(at: dayOfWeekPosition, minXOfContainingRow: monthOrigin.x)
     let y = monthOrigin.y + monthHeaderHeight + content.monthDayInsets.top
-    return CGRect(origin: CGPoint(x: x, y: y), size: daySize)
+    return CGRect(origin: CGPoint(x: x, y: y), size: dayOfWeekSize)
   }
 
   func frameOfDay(_ day: Day, inMonthWithOrigin monthOrigin: CGPoint) -> CGRect {
@@ -220,7 +225,7 @@ final class FrameProvider {
   {
     let x = minXOfItem(at: dayOfWeekPosition, minXOfContainingRow: layoutMargins.leading)
     let y = layoutMargins.top + yContentOffset
-    return CGRect(origin: CGPoint(x: x, y: y), size: daySize)
+    return CGRect(origin: CGPoint(x: x, y: y), size: dayOfWeekSize)
   }
 
   func frameOfPinnedDaysOfWeekRowBackground(yContentOffset: CGFloat) -> CGRect {
@@ -228,7 +233,7 @@ final class FrameProvider {
       x: layoutMargins.leading,
       y: layoutMargins.top + yContentOffset,
       width: monthWidth,
-      height: daySize.height)
+      height: dayOfWeekSize.height)
   }
 
   func frameOfPinnedDaysOfWeekRowSeparator(
@@ -238,7 +243,7 @@ final class FrameProvider {
   {
     CGRect(
       x: layoutMargins.leading,
-      y: layoutMargins.top + yContentOffset + daySize.height - separatorHeight,
+      y: layoutMargins.top + yContentOffset + dayOfWeekSize.height - separatorHeight,
       width: monthWidth,
       height: separatorHeight)
   }
@@ -250,7 +255,7 @@ final class FrameProvider {
     let y = monthOrigin.y +
       monthHeaderHeight +
       content.monthDayInsets.top +
-      daySize.height -
+      dayOfWeekSize.height -
       separatorHeight
     return CGRect(x: monthOrigin.x, y: y, width: monthWidth, height: separatorHeight)
   }
@@ -269,7 +274,7 @@ final class FrameProvider {
   {
     switch content.monthsLayout {
     case .vertical(let options):
-      let additionalOffset = (options.pinDaysOfWeekToTop ? daySize.height : 0)
+      let additionalOffset = (options.pinDaysOfWeekToTop ? dayOfWeekSize.height : 0)
       let minY = offset.y + additionalOffset
       let maxY = offset.y + size.height
       let firstFullyVisibleY = minY
@@ -432,7 +437,7 @@ final class FrameProvider {
   // days in each month. The returned value will be `0` if
   // `monthsLayout.pinDaysOfWeekToTop == true`.
   private func heightOfDaysOfTheWeekRowInMonth() -> CGFloat {
-    monthsLayout.pinDaysOfWeekToTop ? 0 : (daySize.height + content.verticalDayMargin)
+    monthsLayout.pinDaysOfWeekToTop ? 0 : (dayOfWeekSize.height + content.verticalDayMargin)
   }
 
 }

--- a/Sources/Internal/VisibleItemsProvider.swift
+++ b/Sources/Internal/VisibleItemsProvider.swift
@@ -720,7 +720,7 @@ final class VisibleItemsProvider {
           // Take into account the pinned days of week header when determining the first visible day
           if
             !content.monthsLayout.pinDaysOfWeekToTop ||
-            layoutItem.frame.maxY > (bounds.minY + frameProvider.daySize.height)
+            layoutItem.frame.maxY > (bounds.minY + frameProvider.dayOfWeekSize.height)
           {
             firstVisibleDay = min(firstVisibleDay ?? day, day)
           }
@@ -757,7 +757,7 @@ final class VisibleItemsProvider {
       switch content.monthsLayout {
       case .vertical(let options):
         contentStartBoundary = monthFrame.minY -
-          (options.pinDaysOfWeekToTop ? frameProvider.daySize.height : 0)
+          (options.pinDaysOfWeekToTop ? frameProvider.dayOfWeekSize.height : 0)
       case .horizontal:
         contentStartBoundary = monthFrame.minX
       }

--- a/Sources/Public/CalendarView.swift
+++ b/Sources/Public/CalendarView.swift
@@ -275,6 +275,7 @@ public final class CalendarView: UIView {
       oldContent.monthsLayout != content.monthsLayout ||
       oldContent.monthDayInsets != content.monthDayInsets ||
       oldContent.dayAspectRatio != content.dayAspectRatio ||
+      oldContent.dayOfWeekAspectRatio != content.dayOfWeekAspectRatio ||
       oldContent.horizontalDayMargin != content.horizontalDayMargin ||
       oldContent.verticalDayMargin != content.verticalDayMargin
     {

--- a/Sources/Public/CalendarViewContent.swift
+++ b/Sources/Public/CalendarViewContent.swift
@@ -121,6 +121,26 @@ public final class CalendarViewContent {
     return self
   }
 
+  /// Configures the aspect ratio of each day of the week.
+  ///
+  /// Values less than 1 will result in rectangular days of the week that are wider than they are tall. Values
+  /// greater than 1 will result in rectangular days of the week that are taller than they are wide. The default value is `1`, which results
+  /// in square views with the same width and height.
+  ///
+  /// - Parameters:
+  ///   - dayOfWeekAspectRatio: The aspect ratio of each day-of-the-week view.
+  /// - Returns: A mutated `CalendarViewContent` instance with a new day-of-the-week aspect ratio value.
+  public func dayOfWeekAspectRatio(_ dayOfWeekAspectRatio: CGFloat) -> CalendarViewContent {
+    let validAspectRatioRange: ClosedRange<CGFloat> = 0.5...3
+    assert(
+      validAspectRatioRange.contains(dayOfWeekAspectRatio),
+      "A day-of-the-week aspect ratio of \(dayOfWeekAspectRatio) will likely cause strange calendar layouts. Only values between \(validAspectRatioRange.lowerBound) and \(validAspectRatioRange.upperBound) should be used.")
+    self.dayOfWeekAspectRatio = min(
+      max(dayOfWeekAspectRatio, validAspectRatioRange.lowerBound),
+      validAspectRatioRange.upperBound)
+    return self
+  }
+
   /// Configures the amount of spacing, in points, between months. The default value is `0`.
   ///
   /// - Parameters:
@@ -368,6 +388,7 @@ public final class CalendarViewContent {
   let monthsLayout: MonthsLayout
 
   private(set) var dayAspectRatio: CGFloat = 1
+  private(set) var dayOfWeekAspectRatio: CGFloat = 1
   private(set) var interMonthSpacing: CGFloat = 0
   private(set) var monthDayInsets: NSDirectionalEdgeInsets = .zero
   private(set) var verticalDayMargin: CGFloat = 0

--- a/Sources/Public/CalendarViewRepresentable.swift
+++ b/Sources/Public/CalendarViewRepresentable.swift
@@ -77,6 +77,7 @@ public struct CalendarViewRepresentable: UIViewRepresentable {
   // MARK: Fileprivate
 
   fileprivate var dayAspectRatio: CGFloat?
+  fileprivate var dayOfWeekAspectRatio: CGFloat?
   fileprivate var interMonthSpacing: CGFloat?
   fileprivate var monthDayInsets: NSDirectionalEdgeInsets?
   fileprivate var verticalDayMargin: CGFloat?
@@ -119,6 +120,10 @@ public struct CalendarViewRepresentable: UIViewRepresentable {
 
     if let dayAspectRatio {
       content = content.dayAspectRatio(dayAspectRatio)
+    }
+
+    if let dayOfWeekAspectRatio {
+      content = content.dayOfWeekAspectRatio(dayOfWeekAspectRatio)
     }
 
     if let interMonthSpacing {
@@ -179,9 +184,8 @@ extension CalendarViewRepresentable {
 
   /// Configures the aspect ratio of each day.
   ///
-  /// Values less than 1 will result in rectangular days that are wider than they are tall. Values
-  /// greater than 1 will result in rectangular days that are taller than they are wide. The default value is `1`, which results in square
-  /// views with the same width and height.
+  /// Values less than 1 will result in rectangular days that are wider than they are tall. Values greater than 1 will result in rectangular
+  /// days that are taller than they are wide. The default value is `1`, which results in square views with the same width and height.
   ///
   /// - Parameters:
   ///   - dayAspectRatio: The aspect ratio of each day view.
@@ -189,6 +193,21 @@ extension CalendarViewRepresentable {
   public func dayAspectRatio(_ dayAspectRatio: CGFloat) -> Self {
     var view = self
     view.dayAspectRatio = dayAspectRatio
+    return view
+  }
+
+  /// Configures the aspect ratio of each day of the week.
+  ///
+  /// Values less than 1 will result in rectangular days of the week that are wider than they are tall. Values greater than 1 will result in
+  /// rectangular days of the week that are taller than they are wide. The default value is `1`, which results in square views with the
+  /// same width and height.
+  ///
+  /// - Parameters:
+  ///   - dayAspectRatio: The aspect ratio of each day-of-the-week view.
+  /// - Returns: A mutated `CalendarViewRepresentable` with a new day-of-the-week aspect ratio value.
+  public func dayOfWeekAspectRatio(_ dayAspectRatio: CGFloat) -> Self {
+    var view = self
+    view.dayOfWeekAspectRatio = dayOfWeekAspectRatio
     return view
   }
 

--- a/Tests/FrameProviderTests.swift
+++ b/Tests/FrameProviderTests.swift
@@ -90,6 +90,7 @@ final class FrameProviderTests: XCTestCase {
         monthsLayout: .vertical(options: VerticalMonthsLayoutOptions()))
         .monthDayInsets(NSDirectionalEdgeInsets(top: 5, leading: 8, bottom: 5, trailing: 8))
         .dayAspectRatio(1.5)
+        .dayOfWeekAspectRatio(1.5)
         .interMonthSpacing(20)
         .verticalDayMargin(20)
         .horizontalDayMargin(10),

--- a/Tests/VisibleItemsProviderTests.swift
+++ b/Tests/VisibleItemsProviderTests.swift
@@ -1821,7 +1821,8 @@ final class VisibleItemsProviderTests: XCTestCase {
         calendar: calendar,
         visibleDateRange: dateRange,
         monthsLayout: .vertical(options: VerticalMonthsLayoutOptions())))
-      .dayAspectRatio(0.5),
+      .dayAspectRatio(0.5)
+      .dayOfWeekAspectRatio(0.5),
     size: size,
     layoutMargins: .zero,
     scale: 2,


### PR DESCRIPTION
## Details

This adds support for changing the aspect ratio of the day-of-the-week views. The API is very similar to the existing `dayAspectRatio` API.

## Related Issue

https://github.com/airbnb/HorizonCalendar/issues/218

## Motivation and Context

Airbnb internal request + GH issue

## How Has This Been Tested

Example app, unit tests.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
