### PR TITLE
Fix scroll-to-item regression

### DIFF
--- a/Sources/Public/CalendarView.swift
+++ b/Sources/Public/CalendarView.swift
@@ -193,6 +193,9 @@ public final class CalendarView: UIView {
     let anchorLayoutItem: LayoutItem
     if let scrollToItemContext = scrollToItemContext, !scrollToItemContext.animated {
       anchorLayoutItem = self.anchorLayoutItem(for: scrollToItemContext)
+      // Clear the `scrollToItemContext` once we use it. This could happen over the course of
+      // several layout pass attempts since `isReadyForLayout` might be false initially.
+      self.scrollToItemContext = nil
     } else if let previousAnchorLayoutItem = self.anchorLayoutItem {
       anchorLayoutItem = previousAnchorLayoutItem
     } else {
@@ -337,16 +340,16 @@ public final class CalendarView: UIView {
     // Cancel in-flight scroll
     scrollView.setContentOffset(scrollView.contentOffset, animated: false)
 
-    let scrollToItemContext = ScrollToItemContext(
+    scrollToItemContext = ScrollToItemContext(
       targetItem: .month(month),
       scrollPosition: scrollPosition,
       animated: animated)
 
     if animated {
-      self.scrollToItemContext = scrollToItemContext
       startScrollingTowardTargetItem()
     } else {
-      finalizeScrollingTowardItem(for: scrollToItemContext)
+      setNeedsLayout()
+      layoutIfNeeded()
     }
   }
 
@@ -378,16 +381,16 @@ public final class CalendarView: UIView {
     // Cancel in-flight scroll
     scrollView.setContentOffset(scrollView.contentOffset, animated: false)
 
-    let scrollToItemContext = ScrollToItemContext(
+    scrollToItemContext = ScrollToItemContext(
       targetItem: .day(day),
       scrollPosition: scrollPosition,
       animated: animated)
 
     if animated {
-      self.scrollToItemContext = scrollToItemContext
       startScrollingTowardTargetItem()
     } else {
-      finalizeScrollingTowardItem(for: scrollToItemContext)
+      setNeedsLayout()
+      layoutIfNeeded()
     }
   }
 
@@ -789,11 +792,6 @@ public final class CalendarView: UIView {
       targetItem: scrollToItemContext.targetItem,
       scrollPosition: scrollToItemContext.scrollPosition,
       animated: false)
-
-    setNeedsLayout()
-    layoutIfNeeded()
-
-    self.scrollToItemContext = nil
   }
 
   @objc


### PR DESCRIPTION
## Details

While implementing a scroll-to-day/month API in SwiftUI, I realized I introduced a bug a few commits back https://github.com/airbnb/HorizonCalendar/pull/220

The bug is: if we try to scroll to a day or month _before_ we have a valid frame, `layoutSubviews` is never called all the way through, but we still clear the `scrollToItemContext`. This results in the scroll-to action getting dropped.

The solution is to only clear the `scrollToItemContext` once we're ready for layout and we've actually read + used the `scrollToItemContext` in `layoutSubviews`.

## Related Issue

N/A

## Motivation and Context

Bug fix

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
