### PR TITLE
Bk/swiftui scroll to proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `CalendarViewRepresentable` enabling developers to use `CalendarView` from SwiftUI
 - Added a `multipleDaySelectionDragHandler`, enabling developers to implement multiple-day-selection via a drag gesture (similar to multi-select in the iOS Photos app)
 - Added the ability to change the aspect ratio of individual day-of-the-week items
+- Added the ability to programmatically scroll to a month or day in SwiftUI
 
 ### Fixed
 - Fixed an issue that could cause the calendar to programmatically scroll to a month or day to which it had previously scrolled. 

--- a/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/SwiftUIScreenDemoViewController.swift
+++ b/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/SwiftUIScreenDemoViewController.swift
@@ -89,7 +89,8 @@ struct SwiftUIScreenDemo: View {
       calendar: calendar,
       visibleDateRange: visibleDateRange,
       monthsLayout: monthsLayout,
-      dataDependency: selectedDayRange)
+      dataDependency: selectedDayRange,
+      proxy: calendarViewProxy)
 
     .verticalDayMargin(8)
     .horizontalDayMargin(8)
@@ -164,6 +165,13 @@ struct SwiftUIScreenDemo: View {
           calendar: calendar)
       })
 
+    .onAppear {
+      calendarViewProxy.scrollToDay(
+        containing: calendar.date(from: DateComponents(year: 2023, month: 07, day: 19))!,
+        scrollPosition: .centered,
+        animated: false)
+    }
+
   }
 
   // MARK: Private
@@ -173,6 +181,8 @@ struct SwiftUIScreenDemo: View {
   private let visibleDateRange: ClosedRange<Date>
 
   private let monthDateFormatter: DateFormatter
+
+  @StateObject private var calendarViewProxy = CalendarViewProxy()
 
   @State private var selectedDayRange: DayRange?
   @State private var selectedDayRangeAtStartOfDrag: DayRange?

--- a/HorizonCalendar.xcodeproj/project.pbxproj
+++ b/HorizonCalendar.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		93FA64EE248D7B0100A8B7B1 /* DayHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93FA64ED248D7B0100A8B7B1 /* DayHelperTests.swift */; };
 		93FA64F0248D84FE00A8B7B1 /* DayOfWeekPositionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93FA64EF248D84FE00A8B7B1 /* DayOfWeekPositionTests.swift */; };
 		93FA64F2248D93EA00A8B7B1 /* MonthRowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93FA64F1248D93EA00A8B7B1 /* MonthRowTests.swift */; };
+		FD05F0D52A1F1AB300E6ACB0 /* CalendarViewProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD05F0D42A1F1AB300E6ACB0 /* CalendarViewProxy.swift */; };
 		FD264F87294B260B00B13C97 /* SubviewsManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD264F86294B260B00B13C97 /* SubviewsManagerTests.swift */; };
 		FD2C7DC52922C75800B54C1D /* CHANGELOG.md in Resources */ = {isa = PBXBuildFile; fileRef = FD2C7DC42922C75700B54C1D /* CHANGELOG.md */; };
 		FD3D9B6128ED2C1500CC6D62 /* UIView+NoAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD3D9B6028ED2C1500CC6D62 /* UIView+NoAnimation.swift */; };
@@ -137,6 +138,7 @@
 		93FA64ED248D7B0100A8B7B1 /* DayHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DayHelperTests.swift; sourceTree = "<group>"; };
 		93FA64EF248D84FE00A8B7B1 /* DayOfWeekPositionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DayOfWeekPositionTests.swift; sourceTree = "<group>"; };
 		93FA64F1248D93EA00A8B7B1 /* MonthRowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonthRowTests.swift; sourceTree = "<group>"; };
+		FD05F0D42A1F1AB300E6ACB0 /* CalendarViewProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarViewProxy.swift; sourceTree = "<group>"; };
 		FD264F86294B260B00B13C97 /* SubviewsManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubviewsManagerTests.swift; sourceTree = "<group>"; };
 		FD2C7DC42922C75700B54C1D /* CHANGELOG.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = CHANGELOG.md; sourceTree = "<group>"; };
 		FD3D9B6028ED2C1500CC6D62 /* UIView+NoAnimation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+NoAnimation.swift"; sourceTree = "<group>"; };
@@ -249,6 +251,7 @@
 				938DA40E24BEEB1A008A3B47 /* CalendarItemViewRepresentable.swift */,
 				939E691724837E0200A8BCC7 /* CalendarView.swift */,
 				939E693524837E8700A8BCC7 /* CalendarViewContent.swift */,
+				FD05F0D42A1F1AB300E6ACB0 /* CalendarViewProxy.swift */,
 				FD6E1D192991C50100B480A6 /* CalendarViewRepresentable.swift */,
 				939E693324837E8700A8BCC7 /* CalendarViewScrollPosition.swift */,
 				939E693F24846A8C00A8BCC7 /* Day.swift */,
@@ -453,6 +456,7 @@
 				939E692624837E0300A8BCC7 /* ScrollMetricsMutator.swift in Sources */,
 				939E694224846EB400A8BCC7 /* DayRange.swift in Sources */,
 				939E69442484784D00A8BCC7 /* Calendar+Helpers.swift in Sources */,
+				FD05F0D52A1F1AB300E6ACB0 /* CalendarViewProxy.swift in Sources */,
 				FD6E1CFC298D94DC00B480A6 /* MonthLayoutContext.swift in Sources */,
 				939E692824837E0300A8BCC7 /* ItemView.swift in Sources */,
 				FD8CF37A2988A06C00D0482D /* MonthGridBackgroundView.swift in Sources */,

--- a/Sources/Public/CalendarViewProxy.swift
+++ b/Sources/Public/CalendarViewProxy.swift
@@ -1,0 +1,90 @@
+// Created by Bryan Keller on 5/24/23.
+// Copyright © 2023 Airbnb Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+/// A proxy type that enables a `CalendarViewRepresentable` to be programmatically scrolled. Initialize this type yourself from
+/// your SwiftUI view as a `@StateObject`, and use it when initializing a `CalendarViewRepresentable`.
+@available(iOS 13.0, *)
+public final class CalendarViewProxy: ObservableObject {
+
+  // MARK: Lifecycle
+
+  public init() { }
+
+  // MARK: Public
+
+  /// Scrolls the calendar to the specified month with the specified position.
+  ///
+  /// If the calendar has a non-zero frame, this function will scroll to the specified month immediately. Otherwise the scroll-to-month
+  /// action will be queued and executed once the calendar has a non-zero frame. If this function is invoked multiple times before the
+  /// calendar has a non-zero frame, only the most recent scroll-to-month action will be executed.
+  ///
+  /// - Parameters:
+  ///   - dateInTargetMonth: A date in the target month to which to scroll into view.
+  ///   - scrollPosition: The final position of the `CalendarView`'s scrollable region after the scroll completes.
+  ///   - animated: Whether the scroll should be animated (from the current position), or whether the scroll should update the
+  ///   visible region immediately with no animation.
+  public func scrollToMonth(
+    containing dateInTargetMonth: Date,
+    scrollPosition: CalendarViewScrollPosition,
+    animated: Bool)
+  {
+    calendarView.scroll(
+      toMonthContaining: dateInTargetMonth,
+      scrollPosition: scrollPosition,
+      animated: animated)
+  }
+
+  /// Scrolls the calendar to the specified day with the specified position.
+  ///
+  /// If the calendar has a non-zero frame, this function will scroll to the specified day immediately. Otherwise the scroll-to-day action
+  /// will be queued and executed once the calendar has a non-zero frame. If this function is invoked multiple times before the calendar
+  /// has a non-zero frame, only the most recent scroll-to-day action will be executed.
+  ///
+  /// - Parameters:
+  ///   - dateInTargetDay: A date in the target day to which to scroll into view.
+  ///   - scrollPosition: The final position of the `CalendarView`'s scrollable region after the scroll completes.
+  ///   - animated: Whether the scroll should be animated (from the current position), or whether the scroll should update the
+  ///   visible region immediately with no animation.
+  public func scrollToDay(
+    containing dateInTargetDay: Date,
+    scrollPosition: CalendarViewScrollPosition,
+    animated: Bool)
+  {
+    calendarView.scroll(
+      toDayContaining: dateInTargetDay,
+      scrollPosition: scrollPosition,
+      animated: animated)
+  }
+
+  // MARK: Internal
+
+  var calendarView: CalendarView {
+    guard let _calendarView else {
+      fatalError("Attempted to use `CalendarViewProxy` before passing it to the `CalendarViewRepresentable` initializer.")
+    }
+    return _calendarView
+  }
+
+  weak var _calendarView: CalendarView? {
+    didSet {
+      if oldValue != nil && _calendarView != oldValue {
+        fatalError("Attempted to use an existing `CalendarViewProxy` instance with a new `CalendarViewRepresentable`.")
+      }
+    }
+  }
+
+}

--- a/Sources/Public/CalendarViewRepresentable.swift
+++ b/Sources/Public/CalendarViewRepresentable.swift
@@ -46,22 +46,27 @@ public struct CalendarViewRepresentable: UIViewRepresentable {
   ///   `CalendarView` lazily invokes item provider closures outside of the normal SwiftUI update loop. To ensure that the calendar
   ///   is updated at the right times, pass in any properties that are accessed in your item provider closures. For example, if a
   ///   `dayItemProvider` closure accesses a local state variable called `selectedDay`, then pass it in here.
+  ///   - proxy: A proxy instance that can be used to programmatically scroll the calendar.
   public init(
     calendar: Calendar = Calendar.current,
     visibleDateRange: ClosedRange<Date>,
     monthsLayout: MonthsLayout,
-    dataDependency: Any?)
+    dataDependency: Any?,
+    proxy: CalendarViewProxy? = nil)
   {
     self.calendar = calendar
     self.visibleDateRange = visibleDateRange
     self.monthsLayout = monthsLayout
     self.dataDependency = dataDependency
+    self.proxy = proxy
   }
 
   // MARK: Public
 
   public func makeUIView(context: Context) -> CalendarView {
-    CalendarView(initialContent: makeContent())
+    let calendarView = CalendarView(initialContent: makeContent())
+    proxy?._calendarView = calendarView
+    return calendarView
   }
 
   public func updateUIView(_ calendarView: CalendarView, context: Context) {
@@ -111,6 +116,7 @@ public struct CalendarViewRepresentable: UIViewRepresentable {
   private let visibleDateRange: ClosedRange<Date>
   private let monthsLayout: MonthsLayout
   private let dataDependency: Any?
+  private let proxy: CalendarViewProxy?
 
   private func makeContent() -> CalendarViewContent {
     var content = CalendarViewContent(


### PR DESCRIPTION
## Details

This change adds the ability to programmatically scroll the calendar to a day or month. Developers who want this ability should do the following:

1. Define a State Object for a `CalendarViewProxy` instance in their view
e.g.
```swift
@StateObject private var calendarViewProxy = CalendarViewProxy()
```

2. Pass the proxy instance into the `CalendarViewRepresentable` initializer
e.g.
```swift
CalendarViewRepresentable(
      visibleDateRange: visibleDateRange,
      monthsLayout: .vertical,
      dataDependency: selectedDayRange,
      proxy: calendarViewProxy)
```

3. Call `calendarViewProxy.scrollToDay(...)` / `calendarViewProxy.scrollToMonth(...)` in response to some event in your view (button tap, onAppear, timer, etc).
e.g.
```swift
CalendarViewRepresentable(...)
  .onAppear { 
    calendarViewProxy.scrollToDay(containing: .now, scrollPosition: .centered, animated: false) 
  }
```

## Related Issue

https://github.com/airbnb/HorizonCalendar/issues/234
https://github.com/airbnb/HorizonCalendar/issues/219
https://github.com/airbnb/HorizonCalendar/issues/211

## Motivation and Context

Filling in gaps on the SwiftUI API side

## How Has This Been Tested

Tested on simulator / example app.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
