### PR TITLE
Bk/swiftui layout margins and background color

### DIFF
--- a/Sources/Public/CalendarViewRepresentable.swift
+++ b/Sources/Public/CalendarViewRepresentable.swift
@@ -65,7 +65,6 @@ public struct CalendarViewRepresentable: UIViewRepresentable {
 
   public func makeUIView(context: Context) -> CalendarView {
     let calendarView = CalendarView(initialContent: makeContent())
-    calendarView.backgroundColor = .clear
     calendarView.directionalLayoutMargins = .zero
     proxy?._calendarView = calendarView
     return calendarView

--- a/Sources/Public/CalendarViewRepresentable.swift
+++ b/Sources/Public/CalendarViewRepresentable.swift
@@ -66,6 +66,7 @@ public struct CalendarViewRepresentable: UIViewRepresentable {
   public func makeUIView(context: Context) -> CalendarView {
     let calendarView = CalendarView(initialContent: makeContent())
     calendarView.backgroundColor = .clear
+    calendarView.layoutMargins = .zero
     proxy?._calendarView = calendarView
     return calendarView
   }

--- a/Sources/Public/CalendarViewRepresentable.swift
+++ b/Sources/Public/CalendarViewRepresentable.swift
@@ -65,6 +65,7 @@ public struct CalendarViewRepresentable: UIViewRepresentable {
 
   public func makeUIView(context: Context) -> CalendarView {
     let calendarView = CalendarView(initialContent: makeContent())
+    calendarView.backgroundColor = .clear
     proxy?._calendarView = calendarView
     return calendarView
   }

--- a/Sources/Public/CalendarViewRepresentable.swift
+++ b/Sources/Public/CalendarViewRepresentable.swift
@@ -66,12 +66,15 @@ public struct CalendarViewRepresentable: UIViewRepresentable {
   public func makeUIView(context: Context) -> CalendarView {
     let calendarView = CalendarView(initialContent: makeContent())
     calendarView.backgroundColor = .clear
-    calendarView.layoutMargins = .zero
+    calendarView.directionalLayoutMargins = .zero
     proxy?._calendarView = calendarView
     return calendarView
   }
 
   public func updateUIView(_ calendarView: CalendarView, context: Context) {
+    calendarView.backgroundColor = backgroundColor ?? calendarView.backgroundColor
+    calendarView.directionalLayoutMargins = layoutMargins ?? calendarView.directionalLayoutMargins
+
     calendarView.daySelectionHandler = daySelectionHandler
     calendarView.multipleDaySelectionDragHandler = multipleDaySelectionDragHandler
     calendarView.didScroll = didScroll
@@ -82,6 +85,9 @@ public struct CalendarViewRepresentable: UIViewRepresentable {
   }
 
   // MARK: Fileprivate
+
+  fileprivate var backgroundColor: UIColor?
+  fileprivate var layoutMargins: NSDirectionalEdgeInsets?
 
   fileprivate var dayAspectRatio: CGFloat?
   fileprivate var dayOfWeekAspectRatio: CGFloat?
@@ -189,6 +195,28 @@ public struct CalendarViewRepresentable: UIViewRepresentable {
 
 @available(iOS 13.0, *)
 extension CalendarViewRepresentable {
+
+  /// Configures the background color of the calendar view.
+  ///
+  ///  - Parameters:
+  ///     - backgroundColor: The background color to apply to the calendar view.
+  ///  - Returns: A mutated `CalendarViewRepresentable` with a new background color.
+  public func backgroundColor(_ backgroundColor: UIColor) -> Self {
+    var view = self
+    view.backgroundColor = backgroundColor
+    return view
+  }
+
+  /// Configures the layout margins of the calendar view.
+  ///
+  ///  - Parameters:
+  ///     - layoutMargins: The layout margins to apply to the calendar view.
+  ///  - Returns: A mutated `CalendarViewRepresentable` with new layout margins.
+  public func layoutMargins(_ layoutMargins: NSDirectionalEdgeInsets) -> Self {
+    var view = self
+    view.layoutMargins = layoutMargins
+    return view
+  }
 
   /// Configures the aspect ratio of each day.
   ///

--- a/Sources/Public/CalendarViewRepresentable.swift
+++ b/Sources/Public/CalendarViewRepresentable.swift
@@ -200,7 +200,7 @@ extension CalendarViewRepresentable {
   ///
   ///  - Parameters:
   ///     - backgroundColor: The background color to apply to the calendar view.
-  ///  - Returns: A mutated `CalendarViewRepresentable` with a new background color.
+  ///  - Returns: A new `CalendarViewRepresentable` with a new background color.
   public func backgroundColor(_ backgroundColor: UIColor) -> Self {
     var view = self
     view.backgroundColor = backgroundColor
@@ -211,7 +211,7 @@ extension CalendarViewRepresentable {
   ///
   ///  - Parameters:
   ///     - layoutMargins: The layout margins to apply to the calendar view.
-  ///  - Returns: A mutated `CalendarViewRepresentable` with new layout margins.
+  ///  - Returns: A new `CalendarViewRepresentable` with new layout margins.
   public func layoutMargins(_ layoutMargins: NSDirectionalEdgeInsets) -> Self {
     var view = self
     view.layoutMargins = layoutMargins
@@ -225,7 +225,7 @@ extension CalendarViewRepresentable {
   ///
   /// - Parameters:
   ///   - dayAspectRatio: The aspect ratio of each day view.
-  /// - Returns: A mutated `CalendarViewRepresentable` with a new day aspect ratio value.
+  /// - Returns: A new `CalendarViewRepresentable` with a new day aspect ratio value.
   public func dayAspectRatio(_ dayAspectRatio: CGFloat) -> Self {
     var view = self
     view.dayAspectRatio = dayAspectRatio
@@ -240,7 +240,7 @@ extension CalendarViewRepresentable {
   ///
   /// - Parameters:
   ///   - dayAspectRatio: The aspect ratio of each day-of-the-week view.
-  /// - Returns: A mutated `CalendarViewRepresentable` with a new day-of-the-week aspect ratio value.
+  /// - Returns: A new `CalendarViewRepresentable` with a new day-of-the-week aspect ratio value.
   public func dayOfWeekAspectRatio(_ dayAspectRatio: CGFloat) -> Self {
     var view = self
     view.dayOfWeekAspectRatio = dayOfWeekAspectRatio
@@ -251,7 +251,7 @@ extension CalendarViewRepresentable {
   ///
   /// - Parameters:
   ///   - interMonthSpacing: The amount of spacing, in points, between months.
-  /// - Returns: A mutated `CalendarViewRepresentable` with a new inter-month-spacing value.
+  /// - Returns: A new `CalendarViewRepresentable` with a new inter-month-spacing value.
   public func interMonthSpacing(_ interMonthSpacing: CGFloat) -> Self {
     var view = self
     view.interMonthSpacing = interMonthSpacing
@@ -262,7 +262,7 @@ extension CalendarViewRepresentable {
   ///
   /// - Parameters:
   ///   - monthDayInsets: The amount to inset days and day-of-week items from the edges of a month.
-  /// - Returns: A mutated `CalendarViewRepresentable` with a new month-day-insets value.
+  /// - Returns: A new `CalendarViewRepresentable` with a new month-day-insets value.
   public func monthDayInsets(_ monthDayInsets: NSDirectionalEdgeInsets) -> Self {
     var view = self
     view.monthDayInsets = monthDayInsets
@@ -277,7 +277,7 @@ extension CalendarViewRepresentable {
   ///
   /// - Parameters:
   ///   - verticalDayMargin: The amount of space between two day frames along the vertical axis.
-  /// - Returns: A mutated `CalendarViewRepresentable` with a new vertical day margin value.
+  /// - Returns: A new `CalendarViewRepresentable` with a new vertical day margin value.
   public func verticalDayMargin(_ verticalDayMargin: CGFloat) -> Self {
     var view = self
     view.verticalDayMargin = verticalDayMargin
@@ -292,7 +292,7 @@ extension CalendarViewRepresentable {
   ///
   /// - Parameters:
   ///   - horizontalDayMargin: The amount of space between two day frames along the horizontal axis.
-  /// - Returns: A mutated `CalendarViewRepresentable` with a new horizontal day margin value.
+  /// - Returns: A new `CalendarViewRepresentable` with a new horizontal day margin value.
   public func horizontalDayMargin(_ horizontalDayMargin: CGFloat) -> Self {
     var view = self
     view.horizontalDayMargin = horizontalDayMargin
@@ -303,7 +303,7 @@ extension CalendarViewRepresentable {
   ///
   /// - Parameters:
   ///   - options: An instance that has properties to control various aspects of the separator's design.
-  /// - Returns: A mutated `CalendarViewRepresentable` with a days-of-the-week row separator configured.
+  /// - Returns: A new `CalendarViewRepresentable` with a days-of-the-week row separator configured.
   public func daysOfTheWeekRowSeparator(
     options daysOfTheWeekRowSeparatorOptions: DaysOfTheWeekRowSeparatorOptions?)
     -> Self
@@ -326,7 +326,7 @@ extension CalendarViewRepresentable {
   ///   - monthHeaderItemProvider: A closure (that is retained) that returns a `CalendarItemModel` representing a
   ///   month header.
   ///   - month: The `Month` for which to provide a month header item.
-  /// - Returns: A mutated `CalendarViewRepresentable` with a new month header item provider.
+  /// - Returns: A new `CalendarViewRepresentable` with a new month header item provider.
   public func monthHeaderItemProvider(
     _ monthHeaderItemProvider: @escaping (_ month: Month) -> AnyCalendarItemModel)
     -> Self
@@ -350,7 +350,7 @@ extension CalendarViewRepresentable {
   ///   - month: The month in which the day-of-week item belongs. This parameter will be `nil` if days of the week are pinned to
   ///   the top of the calendar, since in that scenario, they don't belong to any particular month.
   ///   - weekdayIndex: The weekday index for which to provide a `CalendarItemModel`.
-  /// - Returns: A mutated `CalendarViewRepresentable` with a new day-of-week item provider.
+  /// - Returns: A new `CalendarViewRepresentable` with a new day-of-week item provider.
   public func dayOfWeekItemProvider(
     _ dayOfWeekItemProvider: @escaping (
       _ month: Month?,
@@ -376,7 +376,7 @@ extension CalendarViewRepresentable {
   ///   - dayItemProvider: A closure (that is retained) that returns a `CalendarItemModel` representing a single day
   ///   in the calendar.
   ///   - day: The `Day` for which to provide a day item.
-  /// - Returns: A mutated `CalendarViewRepresentable` with a new day item provider.
+  /// - Returns: A new `CalendarViewRepresentable` with a new day item provider.
   public func dayItemProvider(
     _ dayItemProvider: @escaping (_ day: Day) -> AnyCalendarItemModel)
     -> Self
@@ -398,7 +398,7 @@ extension CalendarViewRepresentable {
   ///   - dayBackgroundItemProvider: A closure (that is retained) that returns a `CalendarItemModel` representing the
   ///   background of a single day in the calendar.
   ///   - day: The `Day` for which to provide a day background item.
-  /// - Returns: A mutated `CalendarViewRepresentable` with a new day background item provider.
+  /// - Returns: A new `CalendarViewRepresentable` with a new day background item provider.
   public func dayBackgroundItemProvider(
     _ dayBackgroundItemProvider: @escaping (_ day: Day) -> AnyCalendarItemModel?)
     -> Self
@@ -423,7 +423,7 @@ extension CalendarViewRepresentable {
   ///   background of a single month in the calendar.
   ///   - monthLayoutContext: The layout context for the month containing information about the frames of views in that month
   ///   and the bounds in which your month background will be displayed.
-  /// - Returns: A mutated `CalendarViewRepresentable` with a new month background item provider.
+  /// - Returns: A new `CalendarViewRepresentable` with a new month background item provider.
   public func monthBackgroundItemProvider(
     _ monthBackgroundItemProvider: @escaping (
       _ monthLayoutContext: MonthLayoutContext)
@@ -456,7 +456,7 @@ extension CalendarViewRepresentable {
   ///   range in the calendar.
   ///   - dayRangeLayoutContext: The layout context for the day range containing information about the frames of days and
   ///   bounds in which your day range item will be displayed.
-  /// - Returns: A mutated `CalendarViewRepresentable` with a new day range item provider.
+  /// - Returns: A new `CalendarViewRepresentable` with a new day range item provider.
   public func dayRangeItemProvider(
     for dateRanges: Set<ClosedRange<Date>>,
     _ dayRangeItemProvider: @escaping (
@@ -484,7 +484,7 @@ extension CalendarViewRepresentable {
   ///   overlay.
   ///   - overlayLayoutContext: The layout context for the overlaid item location containing information about that location's
   ///   frame and the bounds in which your overlay item will be displayed.
-  /// - Returns: A mutated `CalendarViewRepresentable` with a new overlay item provider.
+  /// - Returns: A new `CalendarViewRepresentable` with a new overlay item provider.
   public func overlayItemProvider(
     for overlaidItemLocations: Set<OverlaidItemLocation>,
     _ overlayItemProvider: @escaping (


### PR DESCRIPTION
## Details

This makes the background color and the layout margins default to clear and zero, respectively, for `CalendarViewRepresentable`.

## Related Issue

https://github.com/airbnb/HorizonCalendar/issues/225

## Motivation and Context

Add proper APIs for background color and layout margins.

## How Has This Been Tested

Example app

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
