### PR TITLE
Bk/improve multi day selection drag gesture ux

### DIFF
--- a/Sources/Public/CalendarView.swift
+++ b/Sources/Public/CalendarView.swift
@@ -971,6 +971,10 @@ public final class CalendarView: UIView {
     if let intersectedDay, intersectedDay != lastMultipleDaySelectionDay {
       lastMultipleDaySelectionDay = intersectedDay
       multipleDaySelectionDragHandler?(intersectedDay, dragGestureRecognizer.state)
+    } else if dragGestureRecognizer.state == .began {
+      // If the gesture doesn't intersect a day in the `began` state, cancel it
+      dragGestureRecognizer.isEnabled = false
+      dragGestureRecognizer.isEnabled = true
     }
   }
 

--- a/Sources/Public/CalendarView.swift
+++ b/Sources/Public/CalendarView.swift
@@ -418,11 +418,12 @@ public final class CalendarView: UIView {
     return scrollView
   }()
 
-  fileprivate lazy var multipleDaySelectionGestureRecognizer: UILongPressGestureRecognizer = {
-    let gestureRecognizer = UILongPressGestureRecognizer(
+  fileprivate lazy var multipleDaySelectionGestureRecognizer: UIPanGestureRecognizer = {
+    let gestureRecognizer = UIPanGestureRecognizer(
       target: self,
       action: #selector(multipleDaySelectionGestureRecognized(_:)))
-    gestureRecognizer.allowableMovement = .greatestFiniteMagnitude
+    gestureRecognizer.maximumNumberOfTouches = 1
+    gestureRecognizer.maximumNumberOfTouches = 1
     gestureRecognizer.delegate = gestureRecognizerDelegate
     return gestureRecognizer
   }()
@@ -949,7 +950,7 @@ public final class CalendarView: UIView {
     }
   }
 
-  private func updateSelectedDayRange(dragGestureRecognizer: UILongPressGestureRecognizer) {
+  private func updateSelectedDayRange(dragGestureRecognizer: UIGestureRecognizer) {
     let locationInScrollView = dragGestureRecognizer.location(in: scrollView)
 
     // Find the intersected day


### PR DESCRIPTION
## Details

This PR improves the multi-day-selection gesture UX. There are 2 changes:

- prevent the `multipleDaySelectionDragHandler` from getting called with `.changed` first (receiving a `.began` first should be guaranteed, and now is)
- remove the delay for starting the multi-day-selection gesture - a drag gesture that's perpendicular to the scroll direction is all that's needed to start the gesture

## Related Issue

N/A

## Motivation and Context

Optimizing gesture behavior for internal Airbnb needs

## How Has This Been Tested

Example app

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
