### PR TITLE
Add back long-press multi-day-selection gesture support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added `MonthsLayout.vertical` and `MonthsLayout.horizontal` as more concise alternatives to `MonthsLayout.vertical(options: .init())` and `MonthsLayout.horizontal(options: .init())`, respectively
 - Added `CalendarViewRepresentable` enabling developers to use `CalendarView` from SwiftUI
-- Added a `multipleDaySelectionDragHandler`, enabling developers to implement multiple-day-selection via a drag gesture (similar to multi-select in the iOS Photos app)
+- Added a `multiDaySelectionDragHandler`, enabling developers to implement multiple-day-selection via a drag gesture (similar to multi-select in the iOS Photos app)
 - Added the ability to change the aspect ratio of individual day-of-the-week items
 - Added the ability to programmatically scroll to a month or day in SwiftUI
 

--- a/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/DayRangeSelectionDemoViewController.swift
+++ b/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/DayRangeSelectionDemoViewController.swift
@@ -35,7 +35,7 @@ final class DayRangeSelectionDemoViewController: BaseDemoViewController {
       self.calendarView.setContent(self.makeContent())
     }
 
-    calendarView.multipleDaySelectionDragHandler = { [weak self, calendar] day, state in
+    calendarView.multiDaySelectionDragHandler = { [weak self, calendar] day, state in
       guard let self else { return }
 
       DayRangeSelectionHelper.updateDayRange(

--- a/Sources/Public/CalendarViewRepresentable.swift
+++ b/Sources/Public/CalendarViewRepresentable.swift
@@ -75,7 +75,7 @@ public struct CalendarViewRepresentable: UIViewRepresentable {
     calendarView.directionalLayoutMargins = layoutMargins ?? calendarView.directionalLayoutMargins
 
     calendarView.daySelectionHandler = daySelectionHandler
-    calendarView.multipleDaySelectionDragHandler = multipleDaySelectionDragHandler
+    calendarView.multiDaySelectionDragHandler = multiDaySelectionDragHandler
     calendarView.didScroll = didScroll
     calendarView.didEndDragging = didEndDragging
     calendarView.didEndDecelerating = didEndDecelerating
@@ -112,7 +112,7 @@ public struct CalendarViewRepresentable: UIViewRepresentable {
     overlayItemProvider: (OverlayLayoutContext) -> AnyCalendarItemModel)?
 
   fileprivate var daySelectionHandler: ((Day) -> Void)?
-  fileprivate var multipleDaySelectionDragHandler: ((Day, UIGestureRecognizer.State) -> Void)?
+  fileprivate var multiDaySelectionDragHandler: ((Day, UIGestureRecognizer.State) -> Void)?
   fileprivate var didScroll: ((_ visibleDayRange: DayRange, _ isUserDragging: Bool) -> Void)?
   fileprivate var didEndDragging: ((_ visibleDayRange: DayRange, _ willDecelerate: Bool) -> Void)?
   fileprivate var didEndDecelerating: ((_ visibleDayRange: DayRange) -> Void)?
@@ -537,7 +537,7 @@ extension CalendarViewRepresentable {
     -> Self
   {
     var view = self
-    view.multipleDaySelectionDragHandler = { day, state in
+    view.multiDaySelectionDragHandler = { day, state in
       switch state {
       case .began:
         began(day)


### PR DESCRIPTION
## Details

This adds back long-press-to-start mutli-day-selection. This PR recently removed it https://github.com/airbnb/HorizonCalendar/pull/243

We want to support a quick swipe / pan (perpendicular to the scroll axis) to immediately start multi-selecting dates, and a long press to start the same gesture.

I also shortened the name from `multiple*` to `multi*`. The API wasn't in a public release yet so it's a safe "breaking" change.

## Related Issue

N/A

## Motivation and Context

Support pan and long press to start mutli-day-selection.

## How Has This Been Tested

Example app, real device.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
