### PR TITLE
Bk/fix swiftui horizontal sizing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added `MonthsLayout.vertical` and `MonthsLayout.horizontal` as more concise alternatives to `MonthsLayout.vertical(options: .init())` and `MonthsLayout.horizontal(options: .init())`, respectively
-- Added `CalendarViewRepresentable` enabling developers to use `CalendarView` from SwiftUI
+- Added `CalendarViewRepresentable`, enabling developers to use `CalendarView` in a SwiftUI view hierarchy
 - Added a `multiDaySelectionDragHandler`, enabling developers to implement multiple-day-selection via a drag gesture (similar to multi-select in the iOS Photos app)
 - Added the ability to change the aspect ratio of individual day-of-the-week items
-- Added the ability to programmatically scroll to a month or day in SwiftUI
 
 ### Fixed
 - Fixed an issue that could cause the calendar to programmatically scroll to a month or day to which it had previously scrolled

--- a/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/SwiftUIScreenDemoViewController.swift
+++ b/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/SwiftUIScreenDemoViewController.swift
@@ -92,9 +92,9 @@ struct SwiftUIScreenDemo: View {
       dataDependency: selectedDayRange,
       proxy: calendarViewProxy)
 
+    .interMonthSpacing(24)
     .verticalDayMargin(8)
     .horizontalDayMargin(8)
-    .interMonthSpacing(16)
 
     .monthHeaderItemProvider { month in
       let monthHeaderText = monthDateFormatter.string(from: calendar.date(from: month.components)!)
@@ -171,6 +171,8 @@ struct SwiftUIScreenDemo: View {
         scrollPosition: .centered,
         animated: false)
     }
+
+    .frame(maxWidth: 375, maxHeight: .infinity)
 
   }
 

--- a/HorizonCalendar.xcodeproj/project.pbxproj
+++ b/HorizonCalendar.xcodeproj/project.pbxproj
@@ -60,6 +60,7 @@
 		FD05F0D52A1F1AB300E6ACB0 /* CalendarViewProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD05F0D42A1F1AB300E6ACB0 /* CalendarViewProxy.swift */; };
 		FD264F87294B260B00B13C97 /* SubviewsManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD264F86294B260B00B13C97 /* SubviewsManagerTests.swift */; };
 		FD2C7DC52922C75800B54C1D /* CHANGELOG.md in Resources */ = {isa = PBXBuildFile; fileRef = FD2C7DC42922C75700B54C1D /* CHANGELOG.md */; };
+		FD33BADE2A7249D600C1DA27 /* CGFloat+MaxLayoutValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD33BADD2A7249D600C1DA27 /* CGFloat+MaxLayoutValue.swift */; };
 		FD3D9B6128ED2C1500CC6D62 /* UIView+NoAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD3D9B6028ED2C1500CC6D62 /* UIView+NoAnimation.swift */; };
 		FD6E1CFA298D94DC00B480A6 /* DaysOfTheWeekRowSeparatorOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD6E1CF5298D94DC00B480A6 /* DaysOfTheWeekRowSeparatorOptions.swift */; };
 		FD6E1CFB298D94DC00B480A6 /* OverlayLayoutContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD6E1CF6298D94DC00B480A6 /* OverlayLayoutContext.swift */; };
@@ -141,6 +142,7 @@
 		FD05F0D42A1F1AB300E6ACB0 /* CalendarViewProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarViewProxy.swift; sourceTree = "<group>"; };
 		FD264F86294B260B00B13C97 /* SubviewsManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubviewsManagerTests.swift; sourceTree = "<group>"; };
 		FD2C7DC42922C75700B54C1D /* CHANGELOG.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = CHANGELOG.md; sourceTree = "<group>"; };
+		FD33BADD2A7249D600C1DA27 /* CGFloat+MaxLayoutValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CGFloat+MaxLayoutValue.swift"; sourceTree = "<group>"; };
 		FD3D9B6028ED2C1500CC6D62 /* UIView+NoAnimation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+NoAnimation.swift"; sourceTree = "<group>"; };
 		FD6E1CF5298D94DC00B480A6 /* DaysOfTheWeekRowSeparatorOptions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DaysOfTheWeekRowSeparatorOptions.swift; sourceTree = "<group>"; };
 		FD6E1CF6298D94DC00B480A6 /* OverlayLayoutContext.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OverlayLayoutContext.swift; sourceTree = "<group>"; };
@@ -273,6 +275,7 @@
 			isa = PBXGroup;
 			children = (
 				939E69432484784D00A8BCC7 /* Calendar+Helpers.swift */,
+				FD33BADD2A7249D600C1DA27 /* CGFloat+MaxLayoutValue.swift */,
 				FDD8EE6D2984C08A00F6EC9D /* ColorViewRepresentable.swift */,
 				939E691E24837E0200A8BCC7 /* Dictionary+MutatingValueForKey.swift */,
 				933992982736562C00C80380 /* DoubleLayoutPassHelpers.swift */,
@@ -447,6 +450,7 @@
 				FDE2893C28F8A6D50020EBF1 /* SwiftUIWrapperView.swift in Sources */,
 				939E694624847BA300A8BCC7 /* DayOfWeekPosition.swift in Sources */,
 				FD6E1CFB298D94DC00B480A6 /* OverlayLayoutContext.swift in Sources */,
+				FD33BADE2A7249D600C1DA27 /* CGFloat+MaxLayoutValue.swift in Sources */,
 				933992992736562D00C80380 /* DoubleLayoutPassHelpers.swift in Sources */,
 				939E694024846A8C00A8BCC7 /* Day.swift in Sources */,
 				939E692424837E0300A8BCC7 /* CalendarView.swift in Sources */,

--- a/Sources/Internal/CGFloat+MaxLayoutValue.swift
+++ b/Sources/Internal/CGFloat+MaxLayoutValue.swift
@@ -1,0 +1,24 @@
+// Created by Bryan Keller on 7/26/23.
+// Copyright © 2023 Airbnb Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import CoreGraphics
+
+extension CGFloat {
+
+  // Used to work around "... returned inf for an intrinsicContentSize dimension. Using 2.5e+07
+  // instead."
+  static let maxLayoutValue: CGFloat = 2.5E07
+
+}


### PR DESCRIPTION
## Details

This change enables horizontal calendars used with SwiftUI to be sized correctly.

| Before | After |
| ---- | ---- |
| ![Simulator Screenshot - iPhone 14 Pro - 2023-07-26 at 23 57 29](https://github.com/airbnb/HorizonCalendar/assets/746571/c0794f10-9f17-4059-bb60-a07622c1cdaa) | ![Simulator Screenshot - iPhone 14 Pro - 2023-07-26 at 23 57 09](https://github.com/airbnb/HorizonCalendar/assets/746571/de07ecdc-988c-49d9-ac9a-14e89ef5c695) |

## Related Issue

N/A

## Motivation and Context

Horizontal layout calendars should size correctly for SwiftUI (like they already do for UIKit)

## How Has This Been Tested

Tested in simulator with example app.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
