### PR TITLE
Fix vertical layout crash for large day ranges

### DIFF
--- a/Sources/Public/CalendarView.swift
+++ b/Sources/Public/CalendarView.swift
@@ -1077,10 +1077,17 @@ extension CalendarView: WidthDependentIntrinsicContentHeightProviding {
   // for more details about why this is needed and how it works.
   func intrinsicContentSize(forHorizontallyInsetWidth width: CGFloat) -> CGSize {
     let calendarWidth = width + layoutMargins.left + layoutMargins.right
+    let calendarHeight: CGFloat
+    if content.monthsLayout.isHorizontal {
+      calendarHeight = .maxLayoutValue
+    } else {
+      calendarHeight = bounds.height
+    }
+
     let visibleItemsProvider = VisibleItemsProvider(
       calendar: calendar,
       content: content,
-      size: CGSize(width: calendarWidth, height: .maxLayoutValue),
+      size: CGSize(width: calendarWidth, height: calendarHeight),
       layoutMargins: directionalLayoutMargins,
       scale: scale,
       monthHeaderHeight: monthHeaderHeight(calendarWidth: calendarWidth),


### PR DESCRIPTION
## Details

I introduced a regression when I changed the intrinsic content size strategy here https://github.com/airbnb/HorizonCalendar/pull/250/files#diff-733b4844a228b4fda6b27e4f88b42a6fc4b04eb589081da658741416a2152bd9R1083

Since I started passing in a huge height, it will actually try to layout every single day in the calendar for a huge day range. This caused the Large Day Range demo in the example app to hang at 100% CPU usage, until Springboard killed it 💀

## Related Issue

N/A

## Motivation and Context

Whoops!

## How Has This Been Tested

Example app

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
