### PR TITLE
Bk/self sizing month headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `CalendarViewRepresentable`, enabling developers to use `CalendarView` in a SwiftUI view hierarchy
 - Added a `multiDaySelectionDragHandler`, enabling developers to implement multiple-day-selection via a drag gesture (similar to multi-select in the iOS Photos app)
 - Added the ability to change the aspect ratio of individual day-of-the-week items
+- Added support for self-sizing month headers
 
 ### Fixed
 - Fixed an issue that could cause the calendar to programmatically scroll to a month or day to which it had previously scrolled

--- a/HorizonCalendar.xcodeproj/project.pbxproj
+++ b/HorizonCalendar.xcodeproj/project.pbxproj
@@ -62,6 +62,7 @@
 		FD2C7DC52922C75800B54C1D /* CHANGELOG.md in Resources */ = {isa = PBXBuildFile; fileRef = FD2C7DC42922C75700B54C1D /* CHANGELOG.md */; };
 		FD33BADE2A7249D600C1DA27 /* CGFloat+MaxLayoutValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD33BADD2A7249D600C1DA27 /* CGFloat+MaxLayoutValue.swift */; };
 		FD3D9B6128ED2C1500CC6D62 /* UIView+NoAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD3D9B6028ED2C1500CC6D62 /* UIView+NoAnimation.swift */; };
+		FD57B2582A6B01F700EEE1AA /* VisibleMonthHeaderHeightTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD57B2572A6B01F700EEE1AA /* VisibleMonthHeaderHeightTracker.swift */; };
 		FD6E1CFA298D94DC00B480A6 /* DaysOfTheWeekRowSeparatorOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD6E1CF5298D94DC00B480A6 /* DaysOfTheWeekRowSeparatorOptions.swift */; };
 		FD6E1CFB298D94DC00B480A6 /* OverlayLayoutContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD6E1CF6298D94DC00B480A6 /* OverlayLayoutContext.swift */; };
 		FD6E1CFC298D94DC00B480A6 /* MonthLayoutContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD6E1CF7298D94DC00B480A6 /* MonthLayoutContext.swift */; };
@@ -144,6 +145,7 @@
 		FD2C7DC42922C75700B54C1D /* CHANGELOG.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = CHANGELOG.md; sourceTree = "<group>"; };
 		FD33BADD2A7249D600C1DA27 /* CGFloat+MaxLayoutValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CGFloat+MaxLayoutValue.swift"; sourceTree = "<group>"; };
 		FD3D9B6028ED2C1500CC6D62 /* UIView+NoAnimation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+NoAnimation.swift"; sourceTree = "<group>"; };
+		FD57B2572A6B01F700EEE1AA /* VisibleMonthHeaderHeightTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisibleMonthHeaderHeightTracker.swift; sourceTree = "<group>"; };
 		FD6E1CF5298D94DC00B480A6 /* DaysOfTheWeekRowSeparatorOptions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DaysOfTheWeekRowSeparatorOptions.swift; sourceTree = "<group>"; };
 		FD6E1CF6298D94DC00B480A6 /* OverlayLayoutContext.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OverlayLayoutContext.swift; sourceTree = "<group>"; };
 		FD6E1CF7298D94DC00B480A6 /* MonthLayoutContext.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MonthLayoutContext.swift; sourceTree = "<group>"; };
@@ -294,6 +296,7 @@
 				FD3D9B6028ED2C1500CC6D62 /* UIView+NoAnimation.swift */,
 				939E691C24837E0200A8BCC7 /* VisibleItem.swift */,
 				939E691A24837E0200A8BCC7 /* VisibleItemsProvider.swift */,
+				FD57B2572A6B01F700EEE1AA /* VisibleMonthHeaderHeightTracker.swift */,
 			);
 			path = Internal;
 			sourceTree = "<group>";
@@ -444,6 +447,7 @@
 				9321958226EEB6AB0001C7E9 /* DrawingConfig.swift in Sources */,
 				939E692D24837E0300A8BCC7 /* LayoutItem.swift in Sources */,
 				939E693A24837E8700A8BCC7 /* CalendarViewContent.swift in Sources */,
+				FD57B2582A6B01F700EEE1AA /* VisibleMonthHeaderHeightTracker.swift in Sources */,
 				FD6E1D1A2991C50100B480A6 /* CalendarViewRepresentable.swift in Sources */,
 				FDD8EE6E2984C08A00F6EC9D /* ColorViewRepresentable.swift in Sources */,
 				939E692F24837E0300A8BCC7 /* OffScreenCalendarItemAccessibilityElement.swift in Sources */,

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Features:
 - Declarative API that enables unidirectional data flow for updating the content of the calendar
 - A custom layout system that enables virtually infinite date ranges without increasing memory usage
 - Pagination for horizontally-scrolling calendars
+- Self-sizing month headers
 - Specify custom views (`UIView` or SwiftUI `View`) for individual days, month headers, and days of the week
 - Specify custom views (`UIView` or SwiftUI `View`) to highlight date ranges
 - Specify custom views (`UIView` or SwiftUI `View`) to overlay parts of the calendar, enabling features like tooltips

--- a/Sources/Internal/VisibleItemsProvider.swift
+++ b/Sources/Internal/VisibleItemsProvider.swift
@@ -77,7 +77,7 @@ final class VisibleItemsProvider {
   {
     var context = VisibleItemsContext(
       centermostLayoutItem: LayoutItem(itemType: .monthHeader(month), frame: .zero))
-    let monthHeaderHeight = monthHeaderHeight(for: month, context: &context)
+    let monthHeaderHeight = visibleMonthHeaderHeightTracker.monthHeaderHeight(for: month)
 
     let monthOrigin: CGPoint
     switch content.monthsLayout {
@@ -120,7 +120,7 @@ final class VisibleItemsProvider {
     var context = VisibleItemsContext(
       centermostLayoutItem: LayoutItem(itemType: .day(day), frame: .zero))
     let month = day.month
-    let monthHeaderHeight = monthHeaderHeight(for: month, context: &context)
+    let monthHeaderHeight = visibleMonthHeaderHeightTracker.monthHeaderHeight(for: month)
 
     let monthOrigin: CGPoint
     switch content.monthsLayout {
@@ -195,9 +195,8 @@ final class VisibleItemsProvider {
     let startingLayoutItem = layoutItem(
       for: previouslyVisibleLayoutItem.itemType,
       lastHandledLayoutItem: previouslyVisibleLayoutItem,
-      monthHeaderHeight: monthHeaderHeight(
-        for: previouslyVisibleLayoutItem.itemType.month,
-        context: &context),
+      monthHeaderHeight: visibleMonthHeaderHeightTracker.monthHeaderHeight(
+        for: previouslyVisibleLayoutItem.itemType.month),
       context: &context)
 
     var lastHandledLayoutItemEnumeratingBackwards = startingLayoutItem
@@ -206,7 +205,8 @@ final class VisibleItemsProvider {
     layoutItemTypeEnumerator.enumerateItemTypes(
       startingAt: previouslyVisibleLayoutItem.itemType,
       itemTypeHandlerLookingBackwards: { itemType, shouldStop in
-        let monthHeaderHeight = monthHeaderHeight(for: itemType.month, context: &context)
+        let monthHeaderHeight = visibleMonthHeaderHeightTracker.monthHeaderHeight(
+          for: itemType.month)
 
         let layoutItem = self.layoutItem(
           for: itemType,
@@ -225,7 +225,8 @@ final class VisibleItemsProvider {
           shouldStop: &shouldStop)
       },
       itemTypeHandlerLookingForwards: { itemType, shouldStop in
-        let monthHeaderHeight = monthHeaderHeight(for: itemType.month, context: &context)
+        let monthHeaderHeight = visibleMonthHeaderHeightTracker.monthHeaderHeight(
+          for: itemType.month)
 
         let layoutItem = self.layoutItem(
           for: itemType,
@@ -344,7 +345,7 @@ final class VisibleItemsProvider {
         let layoutItem = self.layoutItem(
           for: itemType,
           lastHandledLayoutItem: lastHandledLayoutItemEnumeratingBackwards,
-          monthHeaderHeight: monthHeaderHeight(for: itemType.month, context: &context),
+          monthHeaderHeight: visibleMonthHeaderHeightTracker.monthHeaderHeight(for: itemType.month),
           context: &context)
         lastHandledLayoutItemEnumeratingBackwards = layoutItem
 
@@ -354,7 +355,7 @@ final class VisibleItemsProvider {
         let layoutItem = self.layoutItem(
           for: itemType,
           lastHandledLayoutItem: lastHandledLayoutItemEnumeratingForwards,
-          monthHeaderHeight: monthHeaderHeight(for: itemType.month, context: &context),
+          monthHeaderHeight: visibleMonthHeaderHeightTracker.monthHeaderHeight(for: itemType.month),
           context: &context)
         lastHandledLayoutItemEnumeratingForwards = layoutItem
 
@@ -437,9 +438,8 @@ final class VisibleItemsProvider {
       itemType.month < lastHandledLayoutItem.itemType.month,
       let origin = context.originsForMonths[lastHandledLayoutItem.itemType.month]
     {
-      let subsequentMonthHeaderHeight = self.monthHeaderHeight(
-        for: lastHandledLayoutItem.itemType.month,
-        context: &context)
+      let subsequentMonthHeaderHeight = visibleMonthHeaderHeightTracker.monthHeaderHeight(
+        for: lastHandledLayoutItem.itemType.month)
       monthOrigin = frameProvider.originOfMonth(
         itemType.month,
         beforeMonthWithOrigin: origin,
@@ -449,9 +449,8 @@ final class VisibleItemsProvider {
       itemType.month > lastHandledLayoutItem.itemType.month,
       let origin = context.originsForMonths[lastHandledLayoutItem.itemType.month]
     {
-      let previousMonthHeaderHeight = self.monthHeaderHeight(
-        for: lastHandledLayoutItem.itemType.month,
-        context: &context)
+      let previousMonthHeaderHeight = visibleMonthHeaderHeightTracker.monthHeaderHeight(
+        for: lastHandledLayoutItem.itemType.month)
       monthOrigin = frameProvider.originOfMonth(
         itemType.month,
         afterMonthWithOrigin: origin,
@@ -564,7 +563,7 @@ final class VisibleItemsProvider {
         let layoutItem = self.layoutItem(
           for: itemType,
           lastHandledLayoutItem: lastHandledLayoutItemEnumeratingBackwards,
-          monthHeaderHeight: monthHeaderHeight(for: itemType.month, context: &context),
+          monthHeaderHeight: visibleMonthHeaderHeightTracker.monthHeaderHeight(for: itemType.month),
           context: &context)
         lastHandledLayoutItemEnumeratingBackwards = layoutItem
 
@@ -574,7 +573,7 @@ final class VisibleItemsProvider {
         let layoutItem = self.layoutItem(
           for: itemType,
           lastHandledLayoutItem: lastHandledLayoutItemEnumeratingForwards,
-          monthHeaderHeight: monthHeaderHeight(for: itemType.month, context: &context),
+          monthHeaderHeight: visibleMonthHeaderHeightTracker.monthHeaderHeight(for: itemType.month),
           context: &context)
         lastHandledLayoutItemEnumeratingForwards = layoutItem
 
@@ -610,7 +609,7 @@ final class VisibleItemsProvider {
       let month = calendar.month(containing: date)
       guard let monthFrame = context.framesForVisibleMonths[month] else { return nil }
 
-      let monthHeaderHeight = monthHeaderHeight(for: month, context: &context)
+      let monthHeaderHeight = visibleMonthHeaderHeightTracker.monthHeaderHeight(for: month)
 
       itemFrame = frameProvider.frameOfMonthHeader(
         inMonthWithOrigin: monthFrame.origin,
@@ -793,10 +792,6 @@ final class VisibleItemsProvider {
     } else {
       shouldStop = true
     }
-  }
-
-  private func monthHeaderHeight(for month: Month, context: inout VisibleItemsContext) -> CGFloat {
-    visibleMonthHeaderHeightTracker.monthHeaderHeight(for: month)
   }
 
   private func determineContentBoundariesIfNeeded(
@@ -994,7 +989,7 @@ final class VisibleItemsProvider {
         translationX: -expandedMonthFrame.minX,
         y: -expandedMonthFrame.minY)
 
-      let monthHeaderHeight = monthHeaderHeight(for: month, context: &context)
+      let monthHeaderHeight = visibleMonthHeaderHeightTracker.monthHeaderHeight(for: month)
 
       // Get the month header frame
       let monthHeaderFrame = frameProvider.frameOfMonthHeader(
@@ -1073,7 +1068,8 @@ final class VisibleItemsProvider {
         context: &context)
 
       let previousMonth = calendar.month(byAddingMonths: -1, to: currentMonth)
-      let previousMonthHeaderHeight = self.monthHeaderHeight(for: previousMonth, context: &context)
+      let previousMonthHeaderHeight = visibleMonthHeaderHeightTracker.monthHeaderHeight(
+        for: previousMonth)
       let previousMonthOrigin = frameProvider.originOfMonth(
         previousMonth,
         beforeMonthWithOrigin: currentMonthFrame.origin,
@@ -1101,7 +1097,7 @@ final class VisibleItemsProvider {
         context: &context)
 
       let nextMonth = calendar.month(byAddingMonths: 1, to: currentMonth)
-      let nextMonthHeaderHeight = self.monthHeaderHeight(for: nextMonth, context: &context)
+      let nextMonthHeaderHeight = visibleMonthHeaderHeightTracker.monthHeaderHeight(for: nextMonth)
       let nextMonthOrigin = frameProvider.originOfMonth(
         nextMonth,
         afterMonthWithOrigin: currentMonthFrame.origin,

--- a/Sources/Internal/VisibleItemsProvider.swift
+++ b/Sources/Internal/VisibleItemsProvider.swift
@@ -25,10 +25,10 @@ final class VisibleItemsProvider {
   init(
     calendar: Calendar,
     content: CalendarViewContent,
+    reuseManager: ItemViewReuseManager,
     size: CGSize,
     layoutMargins: NSDirectionalEdgeInsets,
     scale: CGFloat,
-    monthHeaderHeight: CGFloat,
     backgroundColor: UIColor?)
   {
     self.content = content
@@ -39,12 +39,17 @@ final class VisibleItemsProvider {
       monthsLayout: content.monthsLayout,
       monthRange: content.monthRange,
       dayRange: content.dayRange)
+
+    visibleMonthHeaderHeightTracker = VisibleMonthHeaderHeightTracker(
+      content: content,
+      size: size,
+      reuseManager: reuseManager)
+
     frameProvider = FrameProvider(
       content: content,
       size: size,
       layoutMargins: layoutMargins,
-      scale: scale,
-      monthHeaderHeight: monthHeaderHeight)
+      scale: scale)
   }
 
   // MARK: Internal
@@ -72,18 +77,34 @@ final class VisibleItemsProvider {
   {
     var context = VisibleItemsContext(
       centermostLayoutItem: LayoutItem(itemType: .monthHeader(month), frame: .zero))
+    let monthHeaderHeight = monthHeaderHeight(for: month, context: &context)
 
-    let baseMonthFrame = frameProvider.frameOfMonth(month, withOrigin: offset)
+    let monthOrigin: CGPoint
+    switch content.monthsLayout {
+    case .vertical:
+      monthOrigin = offset
+    case .horizontal:
+      monthOrigin = CGPoint(
+        x: offset.x,
+        y: size.height - frameProvider.maxMonthHeight(monthHeaderHeight: monthHeaderHeight))
+    }
+
+    let baseMonthFrame = frameProvider.frameOfMonth(
+      month,
+      withOrigin: monthOrigin,
+      monthHeaderHeight: monthHeaderHeight)
     let proposedMonthFrame = frameProvider.frameOfItem(
       withOriginalFrame: baseMonthFrame,
       at: scrollPosition,
       offset: offset)
     let proposedMonthHeaderFrame = frameProvider.frameOfMonthHeader(
-      inMonthWithOrigin: proposedMonthFrame.origin)
+      inMonthWithOrigin: proposedMonthFrame.origin,
+      monthHeaderHeight: monthHeaderHeight)
     let finalMonthHeaderFrame = correctedScrollToItemFrameForContentBoundaries(
       fromProposedFrame: proposedMonthHeaderFrame,
       ofTargetInMonth: month,
       withMonthFrame: proposedMonthFrame,
+      monthHeaderHeight: monthHeaderHeight,
       bounds: CGRect(origin: offset, size: size),
       context: &context)
 
@@ -98,22 +119,43 @@ final class VisibleItemsProvider {
   {
     var context = VisibleItemsContext(
       centermostLayoutItem: LayoutItem(itemType: .day(day), frame: .zero))
+    let month = day.month
+    let monthHeaderHeight = monthHeaderHeight(for: month, context: &context)
 
-    let baseDayFrame = frameProvider.frameOfDay(day, inMonthWithOrigin: offset)
+    let monthOrigin: CGPoint
+    switch content.monthsLayout {
+    case .vertical:
+      monthOrigin = offset
+    case .horizontal:
+      monthOrigin = CGPoint(
+        x: offset.x,
+        y: size.height - frameProvider.maxMonthHeight(monthHeaderHeight: monthHeaderHeight))
+    }
+
+    let baseDayFrame = frameProvider.frameOfDay(
+      day,
+      inMonthWithOrigin: monthOrigin,
+      monthHeaderHeight: monthHeaderHeight)
     let proposedDayFrame = frameProvider.frameOfItem(
       withOriginalFrame: baseDayFrame,
       at: scrollPosition,
       offset: offset)
     let proposedMonthOrigin = frameProvider.originOfMonth(
-      containing: LayoutItem(itemType: .day(day), frame: proposedDayFrame))
-    let proposedMonthFrame = frameProvider.frameOfMonth(day.month, withOrigin: proposedMonthOrigin)
+      containing: LayoutItem(
+        itemType: .day(day),
+        frame: proposedDayFrame),
+      monthHeaderHeight: monthHeaderHeight)
+    let proposedMonthFrame = frameProvider.frameOfMonth(
+      day.month,
+      withOrigin: proposedMonthOrigin,
+      monthHeaderHeight: monthHeaderHeight)
     let finalDayFrame = correctedScrollToItemFrameForContentBoundaries(
       fromProposedFrame: proposedDayFrame,
       ofTargetInMonth: day.month,
       withMonthFrame: proposedMonthFrame,
+      monthHeaderHeight: monthHeaderHeight,
       bounds: CGRect(origin: offset, size: size),
       context: &context)
-
     return LayoutItem(itemType: .day(day), frame: finalDayFrame)
   }
 
@@ -153,6 +195,9 @@ final class VisibleItemsProvider {
     let startingLayoutItem = layoutItem(
       for: previouslyVisibleLayoutItem.itemType,
       lastHandledLayoutItem: previouslyVisibleLayoutItem,
+      monthHeaderHeight: monthHeaderHeight(
+        for: previouslyVisibleLayoutItem.itemType.month,
+        context: &context),
       context: &context)
 
     var lastHandledLayoutItemEnumeratingBackwards = startingLayoutItem
@@ -161,9 +206,12 @@ final class VisibleItemsProvider {
     layoutItemTypeEnumerator.enumerateItemTypes(
       startingAt: previouslyVisibleLayoutItem.itemType,
       itemTypeHandlerLookingBackwards: { itemType, shouldStop in
+        let monthHeaderHeight = monthHeaderHeight(for: itemType.month, context: &context)
+
         let layoutItem = self.layoutItem(
           for: itemType,
           lastHandledLayoutItem: lastHandledLayoutItemEnumeratingBackwards,
+          monthHeaderHeight: monthHeaderHeight,
           context: &context)
         lastHandledLayoutItemEnumeratingBackwards = layoutItem
 
@@ -172,13 +220,17 @@ final class VisibleItemsProvider {
           inBounds: bounds,
           extendedBounds: extendedBounds,
           isLookingBackwards: true,
+          monthHeaderHeight: monthHeaderHeight,
           context: &context,
           shouldStop: &shouldStop)
       },
       itemTypeHandlerLookingForwards: { itemType, shouldStop in
+        let monthHeaderHeight = monthHeaderHeight(for: itemType.month, context: &context)
+
         let layoutItem = self.layoutItem(
           for: itemType,
           lastHandledLayoutItem: lastHandledLayoutItemEnumeratingForwards,
+          monthHeaderHeight: monthHeaderHeight,
           context: &context)
         lastHandledLayoutItemEnumeratingForwards = layoutItem
 
@@ -187,6 +239,7 @@ final class VisibleItemsProvider {
           inBounds: bounds,
           extendedBounds: extendedBounds,
           isLookingBackwards: false,
+          monthHeaderHeight: monthHeaderHeight,
           context: &context,
           shouldStop: &shouldStop)
       })
@@ -234,7 +287,7 @@ final class VisibleItemsProvider {
       contentStartBoundary: context.contentStartBoundary,
       contentEndBoundary: context.contentEndBoundary,
       heightOfPinnedContent: context.heightOfPinnedContent,
-      maxMonthHeight: frameProvider.maxMonthHeight)
+      maxMonthHeight: context.maxMonthHeight)
   }
 
   func visibleItemsForAccessibilityElements(
@@ -291,6 +344,7 @@ final class VisibleItemsProvider {
         let layoutItem = self.layoutItem(
           for: itemType,
           lastHandledLayoutItem: lastHandledLayoutItemEnumeratingBackwards,
+          monthHeaderHeight: monthHeaderHeight(for: itemType.month, context: &context),
           context: &context)
         lastHandledLayoutItemEnumeratingBackwards = layoutItem
 
@@ -300,6 +354,7 @@ final class VisibleItemsProvider {
         let layoutItem = self.layoutItem(
           for: itemType,
           lastHandledLayoutItem: lastHandledLayoutItemEnumeratingForwards,
+          monthHeaderHeight: monthHeaderHeight(for: itemType.month, context: &context),
           context: &context)
         lastHandledLayoutItemEnumeratingForwards = layoutItem
 
@@ -312,6 +367,7 @@ final class VisibleItemsProvider {
   // MARK: Private
 
   private let layoutItemTypeEnumerator: LayoutItemTypeEnumerator
+  private let visibleMonthHeaderHeightTracker: VisibleMonthHeaderHeightTracker
   private let frameProvider: FrameProvider
 
   private var previousCalendarItemModelCache: [
@@ -340,6 +396,7 @@ final class VisibleItemsProvider {
 
   private func monthOrigin(
     forMonthContaining layoutItem: LayoutItem,
+    monthHeaderHeight: CGFloat,
     context: inout VisibleItemsContext)
     -> CGPoint
   {
@@ -347,7 +404,9 @@ final class VisibleItemsProvider {
     if let origin = context.originsForMonths[layoutItem.itemType.month] {
       monthOrigin = origin
     } else {
-      monthOrigin = frameProvider.originOfMonth(containing: layoutItem)
+      monthOrigin = frameProvider.originOfMonth(
+        containing: layoutItem,
+        monthHeaderHeight: monthHeaderHeight)
     }
 
     context.originsForMonths[layoutItem.itemType.month] = monthOrigin
@@ -358,12 +417,15 @@ final class VisibleItemsProvider {
   private func monthOrigin(
     for itemType: LayoutItem.ItemType,
     lastHandledLayoutItem: LayoutItem,
+    monthHeaderHeight: CGFloat,
     context: inout VisibleItemsContext)
     -> CGPoint
   {
     // Cache the month origin for `lastHandledLayoutItem`, if necessary
     if context.originsForMonths[lastHandledLayoutItem.itemType.month] == nil {
-      let monthOrigin = frameProvider.originOfMonth(containing: lastHandledLayoutItem)
+      let monthOrigin = frameProvider.originOfMonth(
+        containing: lastHandledLayoutItem,
+        monthHeaderHeight: monthHeaderHeight)
       context.originsForMonths[lastHandledLayoutItem.itemType.month] = monthOrigin
     }
 
@@ -375,14 +437,26 @@ final class VisibleItemsProvider {
       itemType.month < lastHandledLayoutItem.itemType.month,
       let origin = context.originsForMonths[lastHandledLayoutItem.itemType.month]
     {
+      let subsequentMonthHeaderHeight = self.monthHeaderHeight(
+        for: lastHandledLayoutItem.itemType.month,
+        context: &context)
       monthOrigin = frameProvider.originOfMonth(
         itemType.month,
-        beforeMonthWithOrigin: origin)
+        beforeMonthWithOrigin: origin,
+        subsequentMonthHeaderHeight: subsequentMonthHeaderHeight,
+        monthHeaderHeight: monthHeaderHeight)
     } else if
       itemType.month > lastHandledLayoutItem.itemType.month,
       let origin = context.originsForMonths[lastHandledLayoutItem.itemType.month]
     {
-      monthOrigin = frameProvider.originOfMonth(itemType.month, afterMonthWithOrigin: origin)
+      let previousMonthHeaderHeight = self.monthHeaderHeight(
+        for: lastHandledLayoutItem.itemType.month,
+        context: &context)
+      monthOrigin = frameProvider.originOfMonth(
+        itemType.month,
+        afterMonthWithOrigin: origin,
+        previousMonthHeaderHeight: previousMonthHeaderHeight,
+        monthHeaderHeight: monthHeaderHeight)
     } else {
       preconditionFailure("""
         Could not determine the origin of the month containing the layout item type \(itemType).
@@ -397,21 +471,28 @@ final class VisibleItemsProvider {
   private func layoutItem(
     for itemType: LayoutItem.ItemType,
     lastHandledLayoutItem: LayoutItem,
+    monthHeaderHeight: CGFloat,
     context: inout VisibleItemsContext)
     -> LayoutItem
   {
     let monthOrigin = self.monthOrigin(
       for: itemType,
       lastHandledLayoutItem: lastHandledLayoutItem,
+      monthHeaderHeight: monthHeaderHeight,
       context: &context)
 
     // Get the frame for the current item
     let frame: CGRect
     switch itemType {
     case .monthHeader:
-      frame = frameProvider.frameOfMonthHeader(inMonthWithOrigin: monthOrigin)
+      frame = frameProvider.frameOfMonthHeader(
+        inMonthWithOrigin: monthOrigin,
+        monthHeaderHeight: monthHeaderHeight)
     case .dayOfWeekInMonth(let position, _):
-      frame = frameProvider.frameOfDayOfWeek(at: position, inMonthWithOrigin: monthOrigin)
+      frame = frameProvider.frameOfDayOfWeek(
+        at: position,
+        inMonthWithOrigin: monthOrigin,
+        monthHeaderHeight: monthHeaderHeight)
     case .day(let day):
       // If we're laying out a day in the same month as a previously laid out day, we can use the
       // faster `frameOfDay(_:adjacentTo:withFrame:inMonthWithOrigin:)` function.
@@ -426,7 +507,10 @@ final class VisibleItemsProvider {
           withFrame: lastHandledLayoutItem.frame,
           inMonthWithOrigin: monthOrigin)
       } else {
-        frame = frameProvider.frameOfDay(day, inMonthWithOrigin: monthOrigin)
+        frame = frameProvider.frameOfDay(
+          day,
+          inMonthWithOrigin: monthOrigin,
+          monthHeaderHeight: monthHeaderHeight)
       }
     }
 
@@ -480,6 +564,7 @@ final class VisibleItemsProvider {
         let layoutItem = self.layoutItem(
           for: itemType,
           lastHandledLayoutItem: lastHandledLayoutItemEnumeratingBackwards,
+          monthHeaderHeight: monthHeaderHeight(for: itemType.month, context: &context),
           context: &context)
         lastHandledLayoutItemEnumeratingBackwards = layoutItem
 
@@ -489,6 +574,7 @@ final class VisibleItemsProvider {
         let layoutItem = self.layoutItem(
           for: itemType,
           lastHandledLayoutItem: lastHandledLayoutItemEnumeratingForwards,
+          monthHeaderHeight: monthHeaderHeight(for: itemType.month, context: &context),
           context: &context)
         lastHandledLayoutItemEnumeratingForwards = layoutItem
 
@@ -523,7 +609,12 @@ final class VisibleItemsProvider {
     case .monthHeader(let date):
       let month = calendar.month(containing: date)
       guard let monthFrame = context.framesForVisibleMonths[month] else { return nil }
-      itemFrame = frameProvider.frameOfMonthHeader(inMonthWithOrigin: monthFrame.origin)
+
+      let monthHeaderHeight = monthHeaderHeight(for: month, context: &context)
+
+      itemFrame = frameProvider.frameOfMonthHeader(
+        inMonthWithOrigin: monthFrame.origin,
+        monthHeaderHeight: monthHeaderHeight)
 
     case .day(let date):
       let day = calendar.day(containing: date)
@@ -549,6 +640,7 @@ final class VisibleItemsProvider {
     inBounds bounds: CGRect,
     extendedBounds: CGRect,
     isLookingBackwards: Bool,
+    monthHeaderHeight: CGFloat,
     context: inout VisibleItemsContext,
     shouldStop: inout Bool)
   {
@@ -559,9 +651,18 @@ final class VisibleItemsProvider {
     if let cachedMonthFrame = context.framesForVisibleMonths[month] {
       monthFrame = cachedMonthFrame
     } else {
-      let monthOrigin = frameProvider.originOfMonth(containing: layoutItem)
-      monthFrame = frameProvider.frameOfMonth(month, withOrigin: monthOrigin)
+      let monthOrigin = frameProvider.originOfMonth(
+        containing: layoutItem,
+        monthHeaderHeight: monthHeaderHeight)
+      monthFrame = frameProvider.frameOfMonth(
+        month,
+        withOrigin: monthOrigin,
+        monthHeaderHeight: monthHeaderHeight)
     }
+
+    context.maxMonthHeight = max(
+      frameProvider.maxMonthHeight(monthHeaderHeight: monthHeaderHeight),
+      context.maxMonthHeight)
 
     let layoutNonVisibleItemsInPartiallyVisibleMonth = content.monthsLayout.isHorizontal ||
       content.monthBackgroundItemProvider != nil
@@ -622,7 +723,8 @@ final class VisibleItemsProvider {
                 itemType: separatorItemType,
                 frame: frameProvider.frameOfDaysOfWeekRowSeparator(
                   inMonthWithOrigin: monthFrame.origin,
-                  separatorHeight: separatorOptions.height)))
+                  separatorHeight: separatorOptions.height,
+                  monthHeaderHeight: monthHeaderHeight)))
           }
 
         case let .dayOfWeekInMonth(dayOfWeekPosition, month):
@@ -691,6 +793,10 @@ final class VisibleItemsProvider {
     } else {
       shouldStop = true
     }
+  }
+
+  private func monthHeaderHeight(for month: Month, context: inout VisibleItemsContext) -> CGFloat {
+    visibleMonthHeaderHeightTracker.monthHeaderHeight(for: month)
   }
 
   private func determineContentBoundariesIfNeeded(
@@ -888,8 +994,12 @@ final class VisibleItemsProvider {
         translationX: -expandedMonthFrame.minX,
         y: -expandedMonthFrame.minY)
 
+      let monthHeaderHeight = monthHeaderHeight(for: month, context: &context)
+
       // Get the month header frame
-      let monthHeaderFrame = frameProvider.frameOfMonthHeader(inMonthWithOrigin: monthFrame.origin)
+      let monthHeaderFrame = frameProvider.frameOfMonthHeader(
+        inMonthWithOrigin: monthFrame.origin,
+        monthHeaderHeight: monthHeaderHeight)
       let finalMonthHeaderFrame = monthHeaderFrame
         .applying(frameToBoundsTransform)
         .alignedToPixels(forScreenWithScale: scale)
@@ -899,7 +1009,8 @@ final class VisibleItemsProvider {
       for dayOfWeekPosition in DayOfWeekPosition.allCases {
         let dayOfWeekFrame = frameProvider.frameOfDayOfWeek(
           at: dayOfWeekPosition,
-          inMonthWithOrigin: monthFrame.origin)
+          inMonthWithOrigin: monthFrame.origin,
+          monthHeaderHeight: monthHeaderHeight)
         let finalDayOfWeekFrame = dayOfWeekFrame
           .applying(frameToBoundsTransform)
           .alignedToPixels(forScreenWithScale: scale)
@@ -943,6 +1054,7 @@ final class VisibleItemsProvider {
     fromProposedFrame proposedFrame: CGRect,
     ofTargetInMonth month: Month,
     withMonthFrame monthFrame: CGRect,
+    monthHeaderHeight: CGFloat,
     bounds: CGRect,
     context: inout VisibleItemsContext)
     -> CGRect
@@ -961,12 +1073,16 @@ final class VisibleItemsProvider {
         context: &context)
 
       let previousMonth = calendar.month(byAddingMonths: -1, to: currentMonth)
+      let previousMonthHeaderHeight = self.monthHeaderHeight(for: previousMonth, context: &context)
       let previousMonthOrigin = frameProvider.originOfMonth(
         previousMonth,
-        beforeMonthWithOrigin: currentMonthFrame.origin)
+        beforeMonthWithOrigin: currentMonthFrame.origin,
+        subsequentMonthHeaderHeight: monthHeaderHeight,
+        monthHeaderHeight: monthHeaderHeight)
       let previousMonthFrame = frameProvider.frameOfMonth(
         previousMonth,
-        withOrigin: previousMonthOrigin)
+        withOrigin: previousMonthOrigin,
+        monthHeaderHeight: previousMonthHeaderHeight)
 
       currentMonth = previousMonth
       currentMonthFrame = previousMonthFrame
@@ -985,10 +1101,16 @@ final class VisibleItemsProvider {
         context: &context)
 
       let nextMonth = calendar.month(byAddingMonths: 1, to: currentMonth)
+      let nextMonthHeaderHeight = self.monthHeaderHeight(for: nextMonth, context: &context)
       let nextMonthOrigin = frameProvider.originOfMonth(
         nextMonth,
-        afterMonthWithOrigin: currentMonthFrame.origin)
-      let nextMonthFrame = frameProvider.frameOfMonth(nextMonth,  withOrigin: nextMonthOrigin)
+        afterMonthWithOrigin: currentMonthFrame.origin,
+        previousMonthHeaderHeight: monthHeaderHeight,
+        monthHeaderHeight: nextMonthHeaderHeight)
+      let nextMonthFrame = frameProvider.frameOfMonth(
+        nextMonth,
+        withOrigin: nextMonthOrigin,
+        monthHeaderHeight: monthHeaderHeight)
 
       currentMonth = nextMonth
       currentMonthFrame = nextMonthFrame
@@ -1046,7 +1168,6 @@ private struct VisibleItemsContext {
   var lastVisibleDay: Day?
   var firstVisibleMonth: Month?
   var lastVisibleMonth: Month?
-  var heightsForVisibleMonthHeaders = [Month: CGFloat]()
   var framesForVisibleMonths = [Month: CGRect]()
   var framesForVisibleDays = [Day: CGRect]()
   var framesForDaysForVisibleMonths = [Month: [Day: CGRect]]()
@@ -1057,6 +1178,7 @@ private struct VisibleItemsContext {
   var originsForMonths = [Month: CGPoint]()
   var handledDayRanges = Set<DayRange>()
   var heightOfPinnedContent: CGFloat = 0
+  var maxMonthHeight: CGFloat = 0
 }
 
 // MARK: - VisibleItemsDetails
@@ -1072,6 +1194,11 @@ struct VisibleItemsDetails {
   let contentEndBoundary: CGFloat?
   let heightOfPinnedContent: CGFloat
   let maxMonthHeight: CGFloat
+
+  var intrinsicHeight: CGFloat {
+    maxMonthHeight + heightOfPinnedContent
+  }
+
 }
 
 // MARK: - _DayRangeLayoutContext

--- a/Sources/Internal/VisibleMonthHeaderHeightTracker.swift
+++ b/Sources/Internal/VisibleMonthHeaderHeightTracker.swift
@@ -1,0 +1,82 @@
+// Created by Bryan Keller on 7/21/23.
+// Copyright © 2023 Airbnb Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import UIKit
+
+// MARK: - VisibleMonthHeaderHeightTracker
+
+/// Calculates heights for month headers by self-sizing views on the fly. Sizing views are reused to prevent unnecessary view allocations.
+final class VisibleMonthHeaderHeightTracker {
+
+  // MARK: Lifecycle
+
+  init(content: CalendarViewContent, size: CGSize, reuseManager: ItemViewReuseManager) {
+    self.content = content
+    self.size = size
+    self.reuseManager = reuseManager
+  }
+
+  // MARK: Internal
+
+  func monthHeaderHeight(for month: Month) -> CGFloat {
+    let monthHeaderHeight = monthHeaderHeightsForMonths.value(
+      for: month,
+      missingValueProvider: {
+        let monthHeaderItemModel = content.monthHeaderItemProvider(month)
+        let visibleItem = VisibleItem(
+          calendarItemModel: monthHeaderItemModel,
+          itemType: .layoutItemType(.monthHeader(month)),
+          frame: .zero)
+        var itemView: ItemView?
+        reuseManager.viewsForVisibleItems([visibleItem], viewHandler: { _itemView, visibleItem, _, _ in
+          _itemView.calendarItemModel = visibleItem.calendarItemModel
+          _itemView.itemType = visibleItem.itemType
+          itemView = _itemView
+        })
+
+        guard let itemView else {
+          fatalError("Failed to get a sizing month header view for month \(month).")
+        }
+
+        let monthWidth: CGFloat
+        switch content.monthsLayout {
+        case .vertical:
+          monthWidth = size.width
+        case .horizontal(let options):
+          monthWidth = options.monthWidth(
+            calendarWidth: size.width,
+            interMonthSpacing: content.interMonthSpacing)
+        }
+
+        let size = itemView.contentView.systemLayoutSizeFitting(
+          CGSize(width: monthWidth, height: 0),
+          withHorizontalFittingPriority: .required,
+          verticalFittingPriority: .fittingSizeLevel)
+
+        return size.height
+      })
+
+    return monthHeaderHeight
+  }
+
+  // MARK: Private
+
+  private let content: CalendarViewContent
+  private let size: CGSize
+  private let reuseManager: ItemViewReuseManager
+
+  private var monthHeaderHeightsForMonths = [Month: CGFloat]()
+
+}

--- a/Sources/Internal/VisibleMonthHeaderHeightTracker.swift
+++ b/Sources/Internal/VisibleMonthHeaderHeightTracker.swift
@@ -61,7 +61,7 @@ final class VisibleMonthHeaderHeightTracker {
         }
 
         let size = itemView.contentView.systemLayoutSizeFitting(
-          CGSize(width: monthWidth, height: 0),
+          CGSize(width: monthWidth, height: UIView.layoutFittingCompressedSize.height),
           withHorizontalFittingPriority: .required,
           verticalFittingPriority: .fittingSizeLevel)
 

--- a/Sources/Public/CalendarView.swift
+++ b/Sources/Public/CalendarView.swift
@@ -606,10 +606,10 @@ public final class CalendarView: UIView {
       let visibleItemsProvider = VisibleItemsProvider(
         calendar: calendar,
         content: content,
+        reuseManager: reuseManager,
         size: bounds.size,
         layoutMargins: directionalLayoutMargins,
         scale: scale,
-        monthHeaderHeight: monthHeaderHeight(calendarWidth: bounds.width),
         backgroundColor: backgroundColor)
       _visibleItemsProvider = visibleItemsProvider
       return visibleItemsProvider
@@ -699,29 +699,6 @@ public final class CalendarView: UIView {
         preconditionFailure("Could not find a corresponding frame for \(day).")
       }
     }
-  }
-
-  private func monthHeaderHeight(calendarWidth: CGFloat) -> CGFloat {
-    let monthWidth: CGFloat
-    switch content.monthsLayout {
-    case .vertical:
-      monthWidth = calendarWidth
-    case .horizontal(let options):
-      monthWidth = options.monthWidth(
-        calendarWidth: calendarWidth,
-        interMonthSpacing: content.interMonthSpacing)
-    }
-
-    let firstMonthHeaderItemModel = content.monthHeaderItemProvider(
-      content.monthRange.lowerBound)
-    let firstMonthHeader = firstMonthHeaderItemModel._makeView()
-    firstMonthHeaderItemModel._setContent(onViewOfSameType: firstMonthHeader)
-
-    let size = firstMonthHeader.systemLayoutSizeFitting(
-      CGSize(width: monthWidth, height: 0),
-      withHorizontalFittingPriority: .required,
-      verticalFittingPriority: .fittingSizeLevel)
-    return size.height
   }
 
   private func updateVisibleViews(
@@ -1087,10 +1064,10 @@ extension CalendarView: WidthDependentIntrinsicContentHeightProviding {
     let visibleItemsProvider = VisibleItemsProvider(
       calendar: calendar,
       content: content,
+      reuseManager: reuseManager,
       size: CGSize(width: calendarWidth, height: calendarHeight),
       layoutMargins: directionalLayoutMargins,
       scale: scale,
-      monthHeaderHeight: monthHeaderHeight(calendarWidth: calendarWidth),
       backgroundColor: backgroundColor)
 
     let anchorMonthHeaderLayoutItem = anchorLayoutItem(
@@ -1104,8 +1081,7 @@ extension CalendarView: WidthDependentIntrinsicContentHeightProviding {
       surroundingPreviouslyVisibleLayoutItem: anchorMonthHeaderLayoutItem,
       offset: scrollView.contentOffset)
 
-    let height = visibleItemsDetails.maxMonthHeight + visibleItemsDetails.heightOfPinnedContent
-    return CGSize(width: UIView.noIntrinsicMetric, height: height)
+    return CGSize(width: UIView.noIntrinsicMetric, height: visibleItemsDetails.intrinsicHeight)
   }
 
 }

--- a/Tests/FrameProviderTests.swift
+++ b/Tests/FrameProviderTests.swift
@@ -24,7 +24,6 @@ final class FrameProviderTests: XCTestCase {
 
   override func setUp() {
     let size = CGSize(width: 320, height: 480)
-    let monthHeaderHeight = CGFloat(50)
 
     let lowerBoundDate = calendar.date(from: DateComponents(year: 2020, month: 05, day: 15))!
     let upperBoundDate = calendar.date(from: DateComponents(year: 2020, month: 07, day: 20))!
@@ -40,8 +39,7 @@ final class FrameProviderTests: XCTestCase {
         .horizontalDayMargin(10),
       size: size,
       layoutMargins: .zero,
-      scale: 3,
-      monthHeaderHeight: monthHeaderHeight)
+      scale: 3)
     verticalPinnedDaysOfWeekFrameProvider = FrameProvider(
       content: CalendarViewContent(
         calendar: calendar,
@@ -53,8 +51,7 @@ final class FrameProviderTests: XCTestCase {
         .horizontalDayMargin(10),
       size: size,
       layoutMargins: .zero,
-      scale: 3,
-      monthHeaderHeight: monthHeaderHeight)
+      scale: 3)
     verticalPartialMonthFrameProvider = FrameProvider(
       content: CalendarViewContent(
         calendar: calendar,
@@ -67,8 +64,7 @@ final class FrameProviderTests: XCTestCase {
         .horizontalDayMargin(10),
       size: size,
       layoutMargins: .zero,
-      scale: 3,
-      monthHeaderHeight: monthHeaderHeight)
+      scale: 3)
     horizontalFrameProvider = FrameProvider(
       content: CalendarViewContent(
         calendar: calendar,
@@ -81,8 +77,7 @@ final class FrameProviderTests: XCTestCase {
         .horizontalDayMargin(10),
       size: size,
       layoutMargins: .zero,
-      scale: 3,
-      monthHeaderHeight: monthHeaderHeight)
+      scale: 3)
     rectangularDayFrameProvider = FrameProvider(
       content: CalendarViewContent(
         calendar: calendar,
@@ -96,26 +91,27 @@ final class FrameProviderTests: XCTestCase {
         .horizontalDayMargin(10),
       size: size,
       layoutMargins: .zero,
-      scale: 3,
-      monthHeaderHeight: monthHeaderHeight)
+      scale: 3)
   }
 
   func testMaxMonthHeight() {
-    let maxHeight1 = verticalFrameProvider.maxMonthHeight.alignedToPixel(forScreenWithScale: 3)
+    let maxHeight1 = verticalFrameProvider.maxMonthHeight(monthHeaderHeight: 50)
+      .alignedToPixel(forScreenWithScale: 3)
     let expectedMaxHeight1 = CGFloat(424).alignedToPixel(forScreenWithScale: 3)
     XCTAssert(maxHeight1 == expectedMaxHeight1, "Incorrect max month height.")
 
-    let maxHeight2 = verticalPinnedDaysOfWeekFrameProvider.maxMonthHeight
+    let maxHeight2 = verticalPinnedDaysOfWeekFrameProvider.maxMonthHeight(monthHeaderHeight: 50)
       .alignedToPixel(forScreenWithScale: 3)
     let expectedMaxHeight2 = CGFloat(369.1428571428571).alignedToPixel(forScreenWithScale: 3)
     XCTAssert(maxHeight2 == expectedMaxHeight2, "Incorrect max month height.")
 
-    let maxHeight3 = verticalPartialMonthFrameProvider.maxMonthHeight
+    let maxHeight3 = verticalPartialMonthFrameProvider.maxMonthHeight(monthHeaderHeight: 50)
       .alignedToPixel(forScreenWithScale: 3)
     let expectedMaxHeight3 = CGFloat(424).alignedToPixel(forScreenWithScale: 3)
     XCTAssert(maxHeight3 == expectedMaxHeight3, "Incorrect max month height.")
 
-    let maxHeight4 = horizontalFrameProvider.maxMonthHeight.alignedToPixel(forScreenWithScale: 3)
+    let maxHeight4 = horizontalFrameProvider.maxMonthHeight(monthHeaderHeight: 50)
+      .alignedToPixel(forScreenWithScale: 3)
     let expectedMaxHeight4 = CGFloat(404.0).alignedToPixel(forScreenWithScale: 3)
     XCTAssert(maxHeight4 == expectedMaxHeight4, "Incorrect max month height.")
   }
@@ -144,21 +140,25 @@ final class FrameProviderTests: XCTestCase {
   // MARK: Test initial month calculations
 
   func testInitialMonthHeaderFrame() {
-    let frame1 = verticalFrameProvider.frameOfMonthHeader(inMonthWithOrigin: CGPoint(x: 0, y: 100))
+    let frame1 = verticalFrameProvider.frameOfMonthHeader(
+      inMonthWithOrigin: CGPoint(x: 0, y: 100),
+      monthHeaderHeight: 50)
       .alignedToPixels(forScreenWithScale: 3)
     let expectedFrame1 = CGRect(x: 0, y: 100, width: 320, height: 50)
       .alignedToPixels(forScreenWithScale: 3)
     XCTAssert(frame1 == expectedFrame1, "Incorrect initial month header frame.")
 
     let frame2 = verticalPinnedDaysOfWeekFrameProvider.frameOfMonthHeader(
-      inMonthWithOrigin: CGPoint(x: 0, y: 100))
+      inMonthWithOrigin: CGPoint(x: 0, y: 100),
+      monthHeaderHeight: 50)
       .alignedToPixels(forScreenWithScale: 3)
     let expectedFrame2 = CGRect(x: 0, y: 100, width: 320, height: 50)
       .alignedToPixels(forScreenWithScale: 3)
     XCTAssert(frame2 == expectedFrame2, "Incorrect initial month header frame.")
 
     let frame3 = horizontalFrameProvider.frameOfMonthHeader(
-      inMonthWithOrigin: CGPoint(x: 100, y: 0))
+      inMonthWithOrigin: CGPoint(x: 100, y: 0),
+      monthHeaderHeight: 50)
       .alignedToPixels(forScreenWithScale: 3)
     let expectedFrame3 = CGRect(x: 100, y: 0, width: 300, height: 50)
     XCTAssert(frame3 == expectedFrame3, "Incorrect initial month header frame.")
@@ -202,7 +202,9 @@ final class FrameProviderTests: XCTestCase {
       let monthHeaderLayoutItem = LayoutItem(
         itemType: .monthHeader(Month(era: 1, year: 2020, month: 01, isInGregorianCalendar: true)),
         frame: CGRect(x: 0, y: 100, width: 320, height: 50))
-      let origin1 = frameProvider.originOfMonth(containing: monthHeaderLayoutItem)
+      let origin1 = frameProvider.originOfMonth(
+        containing: monthHeaderLayoutItem,
+        monthHeaderHeight: 50)
         .alignedToPixels(forScreenWithScale: 3)
       XCTAssert(
         origin1 == expectedOrigins1[index],
@@ -213,7 +215,9 @@ final class FrameProviderTests: XCTestCase {
           position: .fourth,
           month: Month(era: 1, year: 2020, month: 01, isInGregorianCalendar: true)),
         frame: CGRect(origin: CGPoint(x: 130, y: 200), size: frameProvider.daySize))
-      let origin2 = frameProvider.originOfMonth(containing: dayOfWeekLayoutItem)
+      let origin2 = frameProvider.originOfMonth(
+        containing: dayOfWeekLayoutItem,
+        monthHeaderHeight: 50)
         .alignedToPixels(forScreenWithScale: 3)
       XCTAssert(
         origin2 == expectedOrigins2[index],
@@ -223,7 +227,9 @@ final class FrameProviderTests: XCTestCase {
         itemType: .day(
           Day(month: Month(era: 1, year: 2020, month: 05, isInGregorianCalendar: true), day: 29)),
         frame: CGRect(origin: CGPoint(x: 250, y: 400), size: frameProvider.daySize))
-      let origin3 = frameProvider.originOfMonth(containing: dayLayoutItem1)
+      let origin3 = frameProvider.originOfMonth(
+        containing: dayLayoutItem1,
+        monthHeaderHeight: 50)
         .alignedToPixels(forScreenWithScale: 3)
       XCTAssert(origin3 == expectedOrigins3[index], "Incorrect month origin containing day.")
 
@@ -231,7 +237,9 @@ final class FrameProviderTests: XCTestCase {
         itemType: .day(
           Day(month: Month(era: 1, year: 2020, month: 05, isInGregorianCalendar: true), day: 18)),
         frame: CGRect(origin: CGPoint(x: 200, y: 300), size: frameProvider.daySize))
-      let origin4 = frameProvider.originOfMonth(containing: dayLayoutItem2)
+      let origin4 = frameProvider.originOfMonth(
+        containing: dayLayoutItem2,
+        monthHeaderHeight: 50)
         .alignedToPixels(forScreenWithScale: 3)
       XCTAssert(origin4 == expectedOrigins4[index], "Incorrect month origin containing day.")
     }
@@ -240,7 +248,9 @@ final class FrameProviderTests: XCTestCase {
   func testPrecedingMonthOrigin() {
     let origin1 = verticalFrameProvider.originOfMonth(
       Month(era: 1, year: 2020, month: 01, isInGregorianCalendar: true),
-      beforeMonthWithOrigin: CGPoint(x: 0, y: 200))
+      beforeMonthWithOrigin: CGPoint(x: 0, y: 200),
+      subsequentMonthHeaderHeight: 50,
+      monthHeaderHeight: 50)
       .alignedToPixels(forScreenWithScale: 3)
     let expectedOrigin1 = CGPoint(x: 0, y: -189.1428571428571)
       .alignedToPixels(forScreenWithScale: 3)
@@ -248,14 +258,18 @@ final class FrameProviderTests: XCTestCase {
 
     let origin2 = verticalPinnedDaysOfWeekFrameProvider.originOfMonth(
       Month(era: 1, year: 2020, month: 01, isInGregorianCalendar: true),
-      beforeMonthWithOrigin: CGPoint(x: 0, y: 400))
+      beforeMonthWithOrigin: CGPoint(x: 0, y: 400),
+      subsequentMonthHeaderHeight: 50,
+      monthHeaderHeight: 50)
       .alignedToPixels(forScreenWithScale: 3)
     let expectedOrigin2 = CGPoint(x: 0, y: 65.71428571428572).alignedToPixels(forScreenWithScale: 3)
     XCTAssert(origin2 == expectedOrigin2, "Incorrect origin for preceding month.")
 
     let origin3 = verticalPartialMonthFrameProvider.originOfMonth(
       Month(era: 1, year: 2020, month: 05, isInGregorianCalendar: true),
-      beforeMonthWithOrigin: CGPoint(x: 0, y: 200))
+      beforeMonthWithOrigin: CGPoint(x: 0, y: 200),
+      subsequentMonthHeaderHeight: 50,
+      monthHeaderHeight: 50)
       .alignedToPixels(forScreenWithScale: 3)
     let expectedOrigin3 = CGPoint(x: 0, y: -134.28571428571428)
       .alignedToPixels(forScreenWithScale: 3)
@@ -263,7 +277,9 @@ final class FrameProviderTests: XCTestCase {
 
     let origin4 = horizontalFrameProvider.originOfMonth(
       Month(era: 1, year: 2020, month: 01, isInGregorianCalendar: true),
-      beforeMonthWithOrigin: CGPoint(x: 200, y: 0))
+      beforeMonthWithOrigin: CGPoint(x: 200, y: 0),
+      subsequentMonthHeaderHeight: 50,
+      monthHeaderHeight: 50)
       .alignedToPixels(forScreenWithScale: 3)
     let expectedOrigin4 = CGPoint(x: -120, y: 0).alignedToPixels(forScreenWithScale: 3)
     XCTAssert(origin4 == expectedOrigin4, "Incorrect origin for preceding month.")
@@ -272,7 +288,9 @@ final class FrameProviderTests: XCTestCase {
   func testSucceedingMonthOrigin() {
     let origin1 = verticalFrameProvider.originOfMonth(
       Month(era: 1, year: 2020, month: 01, isInGregorianCalendar: true),
-      afterMonthWithOrigin: CGPoint(x: 0, y: 200))
+      afterMonthWithOrigin: CGPoint(x: 0, y: 200),
+      previousMonthHeaderHeight: 50,
+      monthHeaderHeight: 50)
       .alignedToPixels(forScreenWithScale: 3)
     let expectedOrigin1 = CGPoint(x: 0, y: 589.1428571428571)
       .alignedToPixels(forScreenWithScale: 3)
@@ -280,21 +298,27 @@ final class FrameProviderTests: XCTestCase {
 
     let origin2 = verticalPinnedDaysOfWeekFrameProvider.originOfMonth(
       Month(era: 1, year: 2020, month: 01, isInGregorianCalendar: true),
-      afterMonthWithOrigin: CGPoint(x: 0, y: 400))
+      afterMonthWithOrigin: CGPoint(x: 0, y: 400),
+      previousMonthHeaderHeight: 50,
+      monthHeaderHeight: 50)
       .alignedToPixels(forScreenWithScale: 3)
     let expectedOrigin2 = CGPoint(x: 0, y: 734.2857142857142).alignedToPixels(forScreenWithScale: 3)
     XCTAssert(origin2 == expectedOrigin2, "Incorrect origin for succeeding month.")
 
     let origin3 = verticalPartialMonthFrameProvider.originOfMonth(
       Month(era: 1, year: 2020, month: 06, isInGregorianCalendar: true),
-      afterMonthWithOrigin: CGPoint(x: 0, y: 400))
+      afterMonthWithOrigin: CGPoint(x: 0, y: 400),
+      previousMonthHeaderHeight: 50,
+      monthHeaderHeight: 50)
       .alignedToPixels(forScreenWithScale: 3)
     let expectedOrigin3 = CGPoint(x: 0, y: 734.2857142857142).alignedToPixels(forScreenWithScale: 3)
     XCTAssert(origin3 == expectedOrigin3, "Incorrect origin for succeeding month.")
 
     let origin4 = horizontalFrameProvider.originOfMonth(
       Month(era: 1, year: 2020, month: 01, isInGregorianCalendar: true),
-      afterMonthWithOrigin: CGPoint(x: 200, y: 0))
+      afterMonthWithOrigin: CGPoint(x: 200, y: 0),
+      previousMonthHeaderHeight: 50,
+      monthHeaderHeight: 50)
       .alignedToPixels(forScreenWithScale: 3)
     let expectedOrigin4 = CGPoint(x: 520, y: 0).alignedToPixels(forScreenWithScale: 3)
     XCTAssert(origin4 == expectedOrigin4, "Incorrect origin for succeeding month.")
@@ -303,7 +327,8 @@ final class FrameProviderTests: XCTestCase {
   func testFrameOfMonth() {
     let frame1 = verticalFrameProvider.frameOfMonth(
       Month(era: 1, year: 2020, month: 04, isInGregorianCalendar: true),
-      withOrigin: CGPoint(x: 0, y: 200))
+      withOrigin: CGPoint(x: 0, y: 200),
+      monthHeaderHeight: 50)
       .alignedToPixels(forScreenWithScale: 3)
     let expectedFrame1 = CGRect(x: 0.0, y: 200.0, width: 320.0, height: 369.1428571428571)
       .alignedToPixels(forScreenWithScale: 3)
@@ -311,7 +336,8 @@ final class FrameProviderTests: XCTestCase {
 
     let frame2 = verticalPinnedDaysOfWeekFrameProvider.frameOfMonth(
       Month(era: 1, year: 2020, month: 04, isInGregorianCalendar: true),
-      withOrigin: CGPoint(x: 0, y: 200))
+      withOrigin: CGPoint(x: 0, y: 200),
+      monthHeaderHeight: 50)
       .alignedToPixels(forScreenWithScale: 3)
     let expectedFrame2 = CGRect(x: 0.0, y: 200.0, width: 320.0, height: 314.2857142857143)
       .alignedToPixels(forScreenWithScale: 3)
@@ -319,7 +345,8 @@ final class FrameProviderTests: XCTestCase {
 
     let frame3 = verticalPartialMonthFrameProvider.frameOfMonth(
       Month(era: 1, year: 2020, month: 07, isInGregorianCalendar: true),
-      withOrigin: CGPoint(x: 0, y: 200))
+      withOrigin: CGPoint(x: 0, y: 200),
+      monthHeaderHeight: 50)
       .alignedToPixels(forScreenWithScale: 3)
     let expectedFrame3 = CGRect(x: 0.0, y: 200.0, width: 320.0, height: 314.2857142857143)
       .alignedToPixels(forScreenWithScale: 3)
@@ -327,7 +354,8 @@ final class FrameProviderTests: XCTestCase {
 
     let frame4 = horizontalFrameProvider.frameOfMonth(
       Month(era: 1, year: 2020, month: 04, isInGregorianCalendar: true),
-      withOrigin: CGPoint(x: 500, y: 0))
+      withOrigin: CGPoint(x: 500, y: 0),
+      monthHeaderHeight: 50)
       .alignedToPixels(forScreenWithScale: 3)
     let expectedFrame4 = CGRect(x: 500.0, y: 0.0, width: 300.0, height: 352.0)
       .alignedToPixels(forScreenWithScale: 3)
@@ -337,21 +365,25 @@ final class FrameProviderTests: XCTestCase {
   // MARK: Core item frame calculations
 
   func testMonthHeaderFrame() {
-    let frame1 = verticalFrameProvider.frameOfMonthHeader(inMonthWithOrigin: CGPoint(x: 0, y: 300))
+    let frame1 = verticalFrameProvider.frameOfMonthHeader(
+      inMonthWithOrigin: CGPoint(x: 0, y: 300),
+      monthHeaderHeight: 50)
       .alignedToPixels(forScreenWithScale: 3)
     let expectedFrame1 = CGRect(x: 0, y: 300, width: 320, height: 50)
       .alignedToPixels(forScreenWithScale: 3)
     XCTAssert(frame1 == expectedFrame1, "Incorrect frame for month header.")
 
     let frame2 = verticalPinnedDaysOfWeekFrameProvider.frameOfMonthHeader(
-      inMonthWithOrigin: CGPoint(x: 0, y: 300))
+      inMonthWithOrigin: CGPoint(x: 0, y: 300),
+      monthHeaderHeight: 50)
       .alignedToPixels(forScreenWithScale: 3)
     let expectedFrame2 = CGRect(x: 0, y: 300, width: 320, height: 50)
       .alignedToPixels(forScreenWithScale: 3)
     XCTAssert(frame2 == expectedFrame2, "Incorrect frame for month header.")
 
     let frame3 = horizontalFrameProvider.frameOfMonthHeader(
-      inMonthWithOrigin: CGPoint(x: 300, y: 0))
+      inMonthWithOrigin: CGPoint(x: 300, y: 0),
+      monthHeaderHeight: 50)
       .alignedToPixels(forScreenWithScale: 3)
     let expectedFrame3 = CGRect(x: 300, y: 0, width: 300, height: 50)
       .alignedToPixels(forScreenWithScale: 3)
@@ -361,7 +393,8 @@ final class FrameProviderTests: XCTestCase {
   func testDayOfWeekFrame() {
     let frame1 = verticalFrameProvider.frameOfDayOfWeek(
       at: .fifth,
-      inMonthWithOrigin: CGPoint(x: 0, y: 200))
+      inMonthWithOrigin: CGPoint(x: 0, y: 200),
+      monthHeaderHeight: 50)
       .alignedToPixels(forScreenWithScale: 3)
     let expectedFrame1 = CGRect(
       x: 187.42857142857142,
@@ -373,7 +406,8 @@ final class FrameProviderTests: XCTestCase {
 
     let frame2 = verticalPinnedDaysOfWeekFrameProvider.frameOfDayOfWeek(
       at: .first,
-      inMonthWithOrigin: CGPoint(x: 0, y: 200))
+      inMonthWithOrigin: CGPoint(x: 0, y: 200),
+      monthHeaderHeight: 50)
       .alignedToPixels(forScreenWithScale: 3)
     let expectedFrame2 = CGRect(x: 8, y: 255, width: 34.857142857142854, height: 34.857142857142854)
       .alignedToPixels(forScreenWithScale: 3)
@@ -381,7 +415,8 @@ final class FrameProviderTests: XCTestCase {
 
     let frame3 = horizontalFrameProvider.frameOfDayOfWeek(
       at: .last,
-      inMonthWithOrigin: CGPoint(x: 200, y: 0))
+      inMonthWithOrigin: CGPoint(x: 200, y: 0),
+      monthHeaderHeight: 50)
       .alignedToPixels(forScreenWithScale: 3)
     let expectedFrame3 = CGRect(x: 460, y: 55, width: 32, height: 32)
       .alignedToPixels(forScreenWithScale: 3)
@@ -389,7 +424,8 @@ final class FrameProviderTests: XCTestCase {
 
     let frame4 = rectangularDayFrameProvider.frameOfDayOfWeek(
       at: .fifth,
-      inMonthWithOrigin: CGPoint(x: 0, y: 200))
+      inMonthWithOrigin: CGPoint(x: 0, y: 200),
+      monthHeaderHeight: 50)
       .alignedToPixels(forScreenWithScale: 3)
     let expectedFrame4 = CGRect(
       x: 187.42857142857142,
@@ -403,7 +439,8 @@ final class FrameProviderTests: XCTestCase {
   func testDayFrameInMonth() {
     let frame1 = verticalFrameProvider.frameOfDay(
       Day(month: Month(era: 1, year: 2020, month: 04, isInGregorianCalendar: true), day: 20),
-      inMonthWithOrigin: CGPoint(x: 0, y: 69))
+      inMonthWithOrigin: CGPoint(x: 0, y: 69),
+      monthHeaderHeight: 50)
       .alignedToPixels(forScreenWithScale: 3)
     let expectedFrame1 = CGRect(
       x: 52.857142857142854,
@@ -415,7 +452,8 @@ final class FrameProviderTests: XCTestCase {
 
     let frame2 = verticalPinnedDaysOfWeekFrameProvider.frameOfDay(
       Day(month: Month(era: 1, year: 1994, month: 01, isInGregorianCalendar: true), day: 01),
-      inMonthWithOrigin: CGPoint(x: 0, y: 130))
+      inMonthWithOrigin: CGPoint(x: 0, y: 130),
+      monthHeaderHeight: 50)
       .alignedToPixels(forScreenWithScale: 3)
     let expectedFrame2 = CGRect(
       x: 277.1428571428571,
@@ -427,7 +465,8 @@ final class FrameProviderTests: XCTestCase {
 
     let frame3 = verticalPartialMonthFrameProvider.frameOfDay(
       Day(month: Month(era: 1, year: 2020, month: 05, isInGregorianCalendar: true), day: 29),
-      inMonthWithOrigin: CGPoint(x: 0, y: 69))
+      inMonthWithOrigin: CGPoint(x: 0, y: 69),
+      monthHeaderHeight: 50)
       .alignedToPixels(forScreenWithScale: 3)
     let expectedFrame3 = CGRect(
       x: 232.28571428571428,
@@ -439,7 +478,8 @@ final class FrameProviderTests: XCTestCase {
 
     let frame4 = horizontalFrameProvider.frameOfDay(
       Day(month: Month(era: 1, year: 2072, month: 06, isInGregorianCalendar: true), day: 30),
-      inMonthWithOrigin: CGPoint(x: 300, y: 0))
+      inMonthWithOrigin: CGPoint(x: 300, y: 0),
+      monthHeaderHeight: 50)
       .alignedToPixels(forScreenWithScale: 3)
     let expectedFrame4 = CGRect(x: 476, y: 315, width: 32, height: 32)
       .alignedToPixels(forScreenWithScale: 3)
@@ -447,7 +487,8 @@ final class FrameProviderTests: XCTestCase {
 
     let frame5 = rectangularDayFrameProvider.frameOfDay(
       Day(month: Month(era: 1, year: 2020, month: 04, isInGregorianCalendar: true), day: 20),
-      inMonthWithOrigin: CGPoint(x: 0, y: 69))
+      inMonthWithOrigin: CGPoint(x: 0, y: 69),
+      monthHeaderHeight: 50)
       .alignedToPixels(forScreenWithScale: 3)
     let expectedFrame5 = CGRect(
       x: 52.857142857142854,
@@ -465,7 +506,8 @@ final class FrameProviderTests: XCTestCase {
     let middleDayMonthOrigin = CGPoint(x: 0, y: 100)
     let middleDayFrame = verticalFrameProvider.frameOfDay(
       middleDay,
-      inMonthWithOrigin: middleDayMonthOrigin)
+      inMonthWithOrigin: middleDayMonthOrigin,
+      monthHeaderHeight: 50)
       .alignedToPixels(forScreenWithScale: 3)
     let frameBeforeMiddleDay = verticalFrameProvider.frameOfDay(
       calendar.day(byAddingDays: -1, to: middleDay),
@@ -500,7 +542,8 @@ final class FrameProviderTests: XCTestCase {
     let leftDayMonthOrigin = CGPoint(x: 0, y: 200)
     let leftDayFrame = verticalPinnedDaysOfWeekFrameProvider.frameOfDay(
       leftDay,
-      inMonthWithOrigin: leftDayMonthOrigin)
+      inMonthWithOrigin: leftDayMonthOrigin,
+      monthHeaderHeight: 50)
       .alignedToPixels(forScreenWithScale: 3)
     let frameBeforeLeftDay = verticalPinnedDaysOfWeekFrameProvider.frameOfDay(
       calendar.day(byAddingDays: -1, to: leftDay),
@@ -535,7 +578,8 @@ final class FrameProviderTests: XCTestCase {
     let rightDayMonthOrigin = CGPoint(x: 1000, y: 0)
     let rightDayFrame = horizontalFrameProvider.frameOfDay(
       rightDay,
-      inMonthWithOrigin: rightDayMonthOrigin)
+      inMonthWithOrigin: rightDayMonthOrigin,
+      monthHeaderHeight: 50)
       .alignedToPixels(forScreenWithScale: 3)
     let frameBeforeRightDay = horizontalFrameProvider.frameOfDay(
       calendar.day(byAddingDays: -1, to: rightDay),
@@ -574,8 +618,7 @@ final class FrameProviderTests: XCTestCase {
         .interMonthSpacing(24),
       size: CGSize(width: 375, height: 275),
       layoutMargins: .init(top: 8, leading: 8, bottom: 8, trailing: 8),
-      scale: 3,
-      monthHeaderHeight: 26.333333333333332)
+      scale: 3)
     
     let adjacentDayFrame = CGRect(
       x: 10218.857142857141,
@@ -650,7 +693,8 @@ final class FrameProviderTests: XCTestCase {
 
     let frame2 = verticalFrameProvider.frameOfDaysOfWeekRowSeparator(
       inMonthWithOrigin: CGPoint(x: 0, y: 120),
-      separatorHeight: 1)
+      separatorHeight: 1,
+      monthHeaderHeight: 50)
       .alignedToPixels(forScreenWithScale: 3)
     let expectedFrame2 = CGRect(x: 0, y: 208.85714285714286, width: 320, height: 1)
       .alignedToPixels(forScreenWithScale: 3)
@@ -658,7 +702,8 @@ final class FrameProviderTests: XCTestCase {
 
     let frame3 = horizontalFrameProvider.frameOfDaysOfWeekRowSeparator(
       inMonthWithOrigin: CGPoint(x: 421, y: 0),
-      separatorHeight: 10)
+      separatorHeight: 10,
+      monthHeaderHeight: 50)
       .alignedToPixels(forScreenWithScale: 3)
     let expectedFrame3 = CGRect(x: 421, y: 77, width: 300, height: 10)
       .alignedToPixels(forScreenWithScale: 3)
@@ -666,7 +711,8 @@ final class FrameProviderTests: XCTestCase {
 
     let frame4 = rectangularDayFrameProvider.frameOfDaysOfWeekRowSeparator(
       inMonthWithOrigin: CGPoint(x: 0, y: 120),
-      separatorHeight: 3)
+      separatorHeight: 3,
+      monthHeaderHeight: 50)
       .alignedToPixels(forScreenWithScale: 3)
     let expectedFrame4 = CGRect(x: 0, y: 224.28571428571428, width: 320, height: 3)
       .alignedToPixels(forScreenWithScale: 3)

--- a/Tests/VisibleItemsProviderTests.swift
+++ b/Tests/VisibleItemsProviderTests.swift
@@ -108,7 +108,7 @@ final class VisibleItemsProviderTests: XCTestCase {
       offset: CGPoint(x: 1000, y: 0),
       scrollPosition: .firstFullyVisiblePosition)
     XCTAssert(
-      monthHeaderItem1.description == "[itemType: .layoutItemType(.monthHeader(2020-11)), frame: (1000.0, 0.0, 300.0, 50.0)]",
+      monthHeaderItem1.description == "[itemType: .layoutItemType(.monthHeader(2020-11)), frame: (1000.0, 50.0, 300.0, 50.0)]",
       "Unexpected initial month header item.")
 
     let monthHeaderItem2 = horizontalVisibleItemsProvider.anchorMonthHeaderItem(
@@ -116,7 +116,7 @@ final class VisibleItemsProviderTests: XCTestCase {
       offset: CGPoint(x: 800, y: 0),
       scrollPosition: .lastFullyVisiblePosition)
     XCTAssert(
-      monthHeaderItem2.description == "[itemType: .layoutItemType(.monthHeader(2020-09)), frame: (820.0, 0.0, 300.0, 50.0)]",
+      monthHeaderItem2.description == "[itemType: .layoutItemType(.monthHeader(2020-09)), frame: (820.0, 50.0, 300.0, 50.0)]",
       "Unexpected initial month header item.")
 
     let monthHeaderItem3 = horizontalVisibleItemsProvider.anchorMonthHeaderItem(
@@ -124,7 +124,7 @@ final class VisibleItemsProviderTests: XCTestCase {
       offset: CGPoint(x: 500, y: 0),
       scrollPosition: .centered)
     XCTAssert(
-      monthHeaderItem3.description == "[itemType: .layoutItemType(.monthHeader(2020-10)), frame: (510.0, 0.0, 300.0, 50.0)]",
+      monthHeaderItem3.description == "[itemType: .layoutItemType(.monthHeader(2020-10)), frame: (510.0, 50.0, 300.0, 50.0)]",
       "Unexpected initial month header item.")
   }
 
@@ -186,7 +186,7 @@ final class VisibleItemsProviderTests: XCTestCase {
       offset: CGPoint(x: 600, y: 0),
       scrollPosition: .lastFullyVisiblePosition)
     XCTAssert(
-      dayItem4.description == "[itemType: .layoutItemType(.day(2020-01-01)), frame: (733.5, 133.0, 33.0, 32.5)]",
+      dayItem4.description == "[itemType: .layoutItemType(.day(2020-01-01)), frame: (733.5, 183.0, 33.0, 32.5)]",
       "Unexpected initial day item.")
 
     let dayItem5 = horizontalVisibleItemsProvider.anchorDayItem(
@@ -194,7 +194,7 @@ final class VisibleItemsProviderTests: XCTestCase {
       offset: CGPoint(x: 100, y: 0),
       scrollPosition: .firstFullyVisiblePosition)
     XCTAssert(
-      dayItem5.description == "[itemType: .layoutItemType(.day(2020-12-28)), frame: (168.0, 344.5, 32.5, 32.5)]",
+      dayItem5.description == "[itemType: .layoutItemType(.day(2020-12-28)), frame: (168.0, 394.5, 32.5, 32.5)]",
       "Unexpected initial day item.")
   }
 
@@ -262,7 +262,7 @@ final class VisibleItemsProviderTests: XCTestCase {
       offset: CGPoint(x: 300, y: 0),
       scrollPosition: .firstFullyVisiblePosition)
     XCTAssert(
-      dayItem1.description == "[itemType: .layoutItemType(.day(2020-04-20)), frame: (300.0, 291.5, 33.0, 33.0)]",
+      dayItem1.description == "[itemType: .layoutItemType(.day(2020-04-20)), frame: (300.0, 341.5, 33.0, 33.0)]",
       "Unexpected initial day item.")
 
     let dayItem2 = horizontalVisibleItemsProvider.anchorDayItem(
@@ -270,7 +270,7 @@ final class VisibleItemsProviderTests: XCTestCase {
       offset: CGPoint(x: 500, y: 0),
       scrollPosition: .lastFullyVisiblePosition)
     XCTAssert(
-      dayItem2.description == "[itemType: .layoutItemType(.day(2020-04-20)), frame: (787.0, 291.5, 33.0, 33.0)]",
+      dayItem2.description == "[itemType: .layoutItemType(.day(2020-04-20)), frame: (787.0, 341.5, 33.0, 33.0)]",
       "Unexpected initial day item.")
 
     let dayItem3 = horizontalVisibleItemsProvider.anchorDayItem(
@@ -278,7 +278,7 @@ final class VisibleItemsProviderTests: XCTestCase {
       offset: CGPoint(x: 0, y: 0),
       scrollPosition: .centered)
     XCTAssert(
-      dayItem3.description == "[itemType: .layoutItemType(.day(2020-04-20)), frame: (143.5, 291.5, 33.0, 33.0)]",
+      dayItem3.description == "[itemType: .layoutItemType(.day(2020-04-20)), frame: (143.5, 341.5, 33.0, 33.0)]",
       "Unexpected initial day item.")
   }
 
@@ -1808,10 +1808,10 @@ final class VisibleItemsProviderTests: XCTestCase {
         calendar: calendar,
         visibleDateRange: dateRange,
         monthsLayout: .vertical(options: VerticalMonthsLayoutOptions()))),
+    reuseManager: ItemViewReuseManager(),
     size: size,
     layoutMargins: .zero,
     scale: 2,
-    monthHeaderHeight: 50,
     backgroundColor: nil)
 
   private var verticalShortDayAspectRatioVisibleItemsProvider = VisibleItemsProvider(
@@ -1823,10 +1823,10 @@ final class VisibleItemsProviderTests: XCTestCase {
         monthsLayout: .vertical(options: VerticalMonthsLayoutOptions())))
       .dayAspectRatio(0.5)
       .dayOfWeekAspectRatio(0.5),
+    reuseManager: ItemViewReuseManager(),
     size: size,
     layoutMargins: .zero,
     scale: 2,
-    monthHeaderHeight: 50,
     backgroundColor: nil)
 
   private var verticalPinnedDaysOfWeekVisibleItemsProvider = VisibleItemsProvider(
@@ -1836,10 +1836,10 @@ final class VisibleItemsProviderTests: XCTestCase {
         calendar: calendar,
         visibleDateRange: dateRange,
         monthsLayout: .vertical(options: VerticalMonthsLayoutOptions(pinDaysOfWeekToTop: true)))),
+    reuseManager: ItemViewReuseManager(),
     size: size,
     layoutMargins: .zero,
     scale: 2,
-    monthHeaderHeight: 50,
     backgroundColor: nil)
 
   private var verticalPartialMonthVisibleItemsProvider = VisibleItemsProvider(
@@ -1850,10 +1850,10 @@ final class VisibleItemsProviderTests: XCTestCase {
         visibleDateRange: dateRange,
         monthsLayout: .vertical(
           options: VerticalMonthsLayoutOptions(alwaysShowCompleteBoundaryMonths: false)))),
+    reuseManager: ItemViewReuseManager(),
     size: size,
     layoutMargins: .zero,
     scale: 2,
-    monthHeaderHeight: 50,
     backgroundColor: nil)
 
   private var horizontalVisibleItemsProvider = VisibleItemsProvider(
@@ -1864,24 +1864,33 @@ final class VisibleItemsProviderTests: XCTestCase {
         visibleDateRange: dateRange,
         monthsLayout: .horizontal(
           options: HorizontalMonthsLayoutOptions(maximumFullyVisibleMonths: 64/63)))),
+    reuseManager: ItemViewReuseManager(),
     size: size,
     layoutMargins: .zero,
     scale: 2,
-    monthHeaderHeight: 50,
     backgroundColor: nil)
 
   private static var mockCalendarItemModel: AnyCalendarItemModel {
     final class MockView: UIView, CalendarItemViewRepresentable {
+
+      typealias Height = CGFloat
+
       static func makeView(
-        withInvariantViewProperties invariantViewProperties: Int)
+        withInvariantViewProperties height: Height)
         -> MockView
       {
-        MockView()
+        let view = MockView()
+        let heightConstraint = view.heightAnchor.constraint(equalToConstant: height)
+        heightConstraint.priority = .defaultLow
+        heightConstraint.isActive = true
+        return view
       }
+
       static func setContent(_ content: Int, on view: MockView) { }
+
     }
 
-    return MockView.calendarItemModel(invariantViewProperties: 0, content: 0)
+    return MockView.calendarItemModel(invariantViewProperties: 50, content: 0)
   }
 
   private static func makeContent(


### PR DESCRIPTION
## Details

This adds support for self-sizing month headers. I still need to add unit tests in a follow-up PR. Want to unblock some Airbnb dev first though.

## Related Issue

N/A

## Motivation and Context

Prior to this change, all month headers would have the same height as the first month header in the calendar. This could cause things to break if you later scrolled to a month header that needed 2 lines of text, for example.

## How Has This Been Tested

Example project, horizontal and vertical calendar, SwiftUI and UIKit

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
