### PR TITLE
Prevent unnecessary layout pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed an issue that could cause the calendar to programmatically scroll to a month or day to which it had previously scrolled
 - Fixed Storyboard support by removing the `fatalError` in `init?(coder: NSCoder)`
+- Fixed an issue that could cause the calendar to layout unnecessarily due to a trait collection change notification
 
 ### Changed
 - Removed all deprecated code, simplifying the public API in preparation for a 2.0 release

--- a/Sources/Public/CalendarView.swift
+++ b/Sources/Public/CalendarView.swift
@@ -165,6 +165,13 @@ public final class CalendarView: UIView {
 
   public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
     super.traitCollectionDidChange(previousTraitCollection)
+
+    // This can be called with a different trait collection instance, even if nothing in the trait
+    // collection has changed (noticed from SwiftUI). We guard against this to prevent and
+    // unnecessary layout pass.
+    guard traitCollection.layoutDirection != previousTraitCollection?.layoutDirection else {
+      return
+    }
     setNeedsLayout()
   }
 


### PR DESCRIPTION
## Details

Instead of unconditionally marking the layout as dirty, we should just do it if the layout direction changed. This works around an expected behavior of SwiftUI, which might cause it to give new trait collections to views even if nothing has changed.

## Related Issue

N/A

## Motivation and Context

Internal Airbnb issue

## How Has This Been Tested

Example project

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
