### PR TITLE
Use hitTest and pointInside for user interaction capability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated the default `HorizontalMonthLayoutOptions` to use a `restingPosition` of `.atLeadingEdgeOfEachMonth`, which is probably what most people want
 - Updated more publicly-exposed types conform to `Hashable`, because why not - maybe API consumers want to stick things in a `Set` or `Dictionary`.
 - Allowed `CalendarItemViewRepresentable` to have no `Content` type if the conforming view does not depend on any variable data
+- Changed `ItemView` to determine user interaction capabilities from its content view's `hitTest` / `pointInside` functions 
 
 ## [v1.16.0](https://github.com/airbnb/HorizonCalendar/compare/v1.15.0...v1.16.0) - 2023-01-30
 

--- a/Sources/Internal/ItemView.swift
+++ b/Sources/Internal/ItemView.swift
@@ -73,19 +73,33 @@ final class ItemView: UIView {
   override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
     super.touchesEnded(touches, with: event)
 
+    func isTouchInView(_ touch: UITouch) -> Bool {
+      contentView.bounds.contains(touch.location(in: contentView))
+    }
+
     if touches.first.map(isTouchInView(_:)) ?? false {
       selectionHandler?()
     }
+  }
+
+  override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+    let view = super.hitTest(point, with: event)
+
+    // If the returned view is `self`, that means that our `contentView` isn't interactive for this
+    // `point`. This can happen if the `contentView` also overrides `hitTest` or `pointInside` to
+    // customize the interaction. It can also happen if our `contentView` has
+    // `isUserInteractionEnabled` set to `false`.
+    if view === self {
+      return nil
+    }
+
+    return view
   }
 
   // MARK: Private
 
   private func updateContent() {
     calendarItemModel._setContent(onViewOfSameType: contentView)
-  }
-
-  private func isTouchInView(_ touch: UITouch) -> Bool {
-    contentView.bounds.contains(touch.location(in: contentView))
   }
 
 }

--- a/Sources/Internal/VisibleItem.swift
+++ b/Sources/Internal/VisibleItem.swift
@@ -88,21 +88,6 @@ extension VisibleItem {
     case daysOfWeekRowSeparator(Month)
     case dayRange(DayRange)
     case overlayItem(OverlaidItemLocation)
-
-    var isUserInteractionEnabled: Bool {
-      switch self {
-      case .layoutItemType: return true
-      case .pinnedDayOfWeek: return true
-      case .pinnedDaysOfWeekRowBackground: return true
-
-      case .dayBackground: return false
-      case .monthBackground: return false
-      case .pinnedDaysOfWeekRowSeparator: return false
-      case .daysOfWeekRowSeparator: return false
-      case .dayRange: return false
-      case .overlayItem: return false
-      }
-    }
   }
 
 }

--- a/Sources/Public/CalendarView.swift
+++ b/Sources/Public/CalendarView.swift
@@ -762,8 +762,6 @@ public final class CalendarView: UIView {
       view.transform = .identity
     }
 
-    view.isUserInteractionEnabled = visibleItem.itemType.isUserInteractionEnabled
-
     // Set up the selection handler
     if case .layoutItemType(.day(let day)) = visibleItem.itemType {
       view.selectionHandler = { [weak self] in


### PR DESCRIPTION
## Details

This PR lays the groundwork for HorizonCalendar to support tappable day range indicators. Currently, day ranges are always drawn behind days (but above day backgrounds). Day ranges, day views, and all other views displayed in the calendar are wrapped in an internal `ItemView` type. Since day views are on top of day ranges, it was impossible to tap on a day range view "through" a day view.

This PR allows people with this advanced use case to customize the pointInside function on their day view and day range view, allowing the day view (and its `superview`, the internal `ItemView`, to pass through touches to the day range view.

Here's what it looks like in practice:

https://github.com/airbnb/HorizonCalendar/assets/746571/d8e1eeb6-24b0-4416-a857-51df92e21eb6

- Each red square is a day view (that would previously capture touches
- The blue outlined box is the border of the entire day range view (which spans 2 rows of days, and is behind the translucent red day views)

Note that the days are only tappable in the top portion containing the label (due to an overridden `pointInside` implementation), and the day ranges are tappable even through they're behind the day views (thanks to the day view not capturing all touches, and the day range view implementing its own overridden `pointInside` function that).

It's a bit low level, but it provides some extra flexibility for some advanced use cases. In the future, we might add an accessory view slot so that these tappable day ranges that appear below a row of days are possible without using hit-testing logic.

## Related Issue

<!--- If this is related to any issues, link them here. -->

## Motivation and Context

Airbnb (and one other app that I'm aware of) needs this

## How Has This Been Tested

Example app

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
