### PR TITLE
Bk/animation offscreen items improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed an issue that could cause the calendar to programmatically scroll to a month or day to which it had previously scrolled
 - Fixed Storyboard support by removing the `fatalError` in `init?(coder: NSCoder)`
 - Fixed an issue that could cause the calendar to layout unnecessarily due to a trait collection change notification
+- Fixed an issue that could cause off-screen items to appear or disappear instantly, rather than animating in or out during animated content changes
 
 ### Changed
 - Removed all deprecated code, simplifying the public API in preparation for a 2.0 release

--- a/Sources/Internal/VisibleItemsProvider.swift
+++ b/Sources/Internal/VisibleItemsProvider.swift
@@ -155,7 +155,8 @@ final class VisibleItemsProvider {
 
   func detailsForVisibleItems(
     surroundingPreviouslyVisibleLayoutItem previouslyVisibleLayoutItem: LayoutItem,
-    offset: CGPoint)
+    offset: CGPoint,
+    size: CGSize)
     -> VisibleItemsDetails
   {
     // Default the initial capacity to 100, which is approximately enough room for 3 months worth of

--- a/Sources/Public/CalendarView.swift
+++ b/Sources/Public/CalendarView.swift
@@ -198,60 +198,10 @@ public final class CalendarView: UIView {
 
     guard isReadyForLayout else { return }
 
-    scrollView.performWithoutNotifyingDelegate {
-      scrollMetricsMutator.setUpInitialMetricsIfNeeded()
-      scrollMetricsMutator.updateContentSizePerpendicularToScrollAxis(viewportSize: bounds.size)
-    }
+    _layoutSubviews()
 
-    let anchorLayoutItem: LayoutItem
-    if let scrollToItemContext = scrollToItemContext, !scrollToItemContext.animated {
-      anchorLayoutItem = self.anchorLayoutItem(
-        for: scrollToItemContext,
-        visibleItemsProvider: visibleItemsProvider)
-      // Clear the `scrollToItemContext` once we use it. This could happen over the course of
-      // several layout pass attempts since `isReadyForLayout` might be false initially.
-      self.scrollToItemContext = nil
-    } else if let previousAnchorLayoutItem = self.anchorLayoutItem {
-      anchorLayoutItem = previousAnchorLayoutItem
-    } else {
-      let initialScrollToItemContext = ScrollToItemContext(
-        targetItem: .month(content.monthRange.lowerBound),
-        scrollPosition: .firstFullyVisiblePosition,
-        animated: false)
-      anchorLayoutItem = self.anchorLayoutItem(
-        for: initialScrollToItemContext,
-        visibleItemsProvider: visibleItemsProvider)
-    }
-
-    let currentVisibleItemsDetails = visibleItemsProvider.detailsForVisibleItems(
-      surroundingPreviouslyVisibleLayoutItem: anchorLayoutItem,
-      offset: scrollView.contentOffset)
-    self.anchorLayoutItem = currentVisibleItemsDetails.centermostLayoutItem
-
-    updateVisibleViews(
-      withVisibleItems: currentVisibleItemsDetails.visibleItems,
-      previouslyVisibleItems: visibleItemsDetails?.visibleItems ?? [])
-
-    visibleItemsDetails = currentVisibleItemsDetails
-
-    let minimumScrollOffset = visibleItemsDetails?.contentStartBoundary.map {
-      ($0 - firstLayoutMarginValue).alignedToPixel(forScreenWithScale: scale)
-    }
-    let maximumScrollOffset = visibleItemsDetails?.contentEndBoundary.map {
-      ($0 + lastLayoutMarginValue).alignedToPixel(forScreenWithScale: scale)
-    }
-    scrollView.performWithoutNotifyingDelegate {
-      scrollMetricsMutator.updateScrollBoundaries(
-        minimumScrollOffset: minimumScrollOffset,
-        maximumScrollOffset: maximumScrollOffset)
-    }
-
-    cachedAccessibilityElements = nil
-    if let element = focusedAccessibilityElement as? OffScreenCalendarItemAccessibilityElement {
-      UIAccessibility.post(
-        notification: .screenChanged,
-        argument: visibleViewsForVisibleItems[element.correspondingItem])
-    }
+    // The layout / update pass has completed, and we can set this back to `false`.
+    isAnimatedUpdatePass = false
   }
 
   /// Sets the content of the `CalendarView`, causing it to re-render.
@@ -260,6 +210,15 @@ public final class CalendarView: UIView {
   ///   - content: The content to use when rendering `CalendarView`.
   public func setContent(_ content: CalendarViewContent) {
     let oldContent = self.content
+
+    // Do a preparation layout pass with an extended bounds, if we're animating. This ensures that
+    // views don't pop in if they're animating in from outside the actual bounds.
+    isAnimatedUpdatePass = UIView.inheritedAnimationDuration > 0 && UIView.areAnimationsEnabled
+    if isAnimatedUpdatePass {
+      UIView.performWithoutAnimation {
+        _layoutSubviews()
+      }
+    }
 
     _visibleItemsProvider = nil
 
@@ -527,6 +486,8 @@ public final class CalendarView: UIView {
   private var visibleItemsDetails: VisibleItemsDetails?
   private var visibleViewsForVisibleItems = [VisibleItem: ItemView]()
 
+  private var isAnimatedUpdatePass = false
+
   private var previousBounds = CGRect.zero
   private var previousLayoutMargins = UIEdgeInsets.zero
 
@@ -704,6 +665,88 @@ public final class CalendarView: UIView {
       } else {
         preconditionFailure("Could not find a corresponding frame for \(day).")
       }
+    }
+  }
+
+  // This exists so that we can force a layout ourselves in preparation for an animated update.
+  private func _layoutSubviews() {
+    scrollView.performWithoutNotifyingDelegate {
+      scrollMetricsMutator.setUpInitialMetricsIfNeeded()
+      scrollMetricsMutator.updateContentSizePerpendicularToScrollAxis(viewportSize: bounds.size)
+    }
+
+    let anchorLayoutItem: LayoutItem
+    if let scrollToItemContext = scrollToItemContext, !scrollToItemContext.animated {
+      anchorLayoutItem = self.anchorLayoutItem(
+        for: scrollToItemContext,
+        visibleItemsProvider: visibleItemsProvider)
+      // Clear the `scrollToItemContext` once we use it. This could happen over the course of
+      // several layout pass attempts since `isReadyForLayout` might be false initially.
+      self.scrollToItemContext = nil
+    } else if let previousAnchorLayoutItem = self.anchorLayoutItem {
+      anchorLayoutItem = previousAnchorLayoutItem
+    } else {
+      let initialScrollToItemContext = ScrollToItemContext(
+        targetItem: .month(content.monthRange.lowerBound),
+        scrollPosition: .firstFullyVisiblePosition,
+        animated: false)
+      anchorLayoutItem = self.anchorLayoutItem(
+        for: initialScrollToItemContext,
+        visibleItemsProvider: visibleItemsProvider)
+    }
+
+    // Use an extended bounds (3x the viewport size) if we're in an animated update pass, reducing
+    // the likelihood of an item popping in / out.
+    let offset: CGPoint
+    let size: CGSize
+    if isAnimatedUpdatePass {
+      switch content.monthsLayout {
+      case .vertical:
+        offset = CGPoint(
+          x: scrollView.contentOffset.x,
+          y: scrollView.contentOffset.y - bounds.height)
+        size = CGSize(width: bounds.size.width, height: bounds.size.height * 3)
+
+      case .horizontal:
+        offset = CGPoint(
+          x: scrollView.contentOffset.x - bounds.width,
+          y: scrollView.contentOffset.y)
+        size = CGSize(width: bounds.size.width * 3, height: bounds.size.height)
+      }
+    } else {
+      offset = scrollView.contentOffset
+      size = bounds.size
+    }
+
+    let currentVisibleItemsDetails = visibleItemsProvider.detailsForVisibleItems(
+      surroundingPreviouslyVisibleLayoutItem: anchorLayoutItem,
+      offset: offset,
+      size: size)
+    self.anchorLayoutItem = currentVisibleItemsDetails.centermostLayoutItem
+
+    updateVisibleViews(
+      withVisibleItems: currentVisibleItemsDetails.visibleItems,
+      previouslyVisibleItems: visibleItemsDetails?.visibleItems ?? [])
+
+    visibleItemsDetails = currentVisibleItemsDetails
+
+    let minimumScrollOffset = visibleItemsDetails?.contentStartBoundary.map {
+      ($0 - firstLayoutMarginValue).alignedToPixel(forScreenWithScale: scale)
+    }
+    let maximumScrollOffset = visibleItemsDetails?.contentEndBoundary.map {
+      ($0 + lastLayoutMarginValue).alignedToPixel(forScreenWithScale: scale)
+    }
+    scrollView.performWithoutNotifyingDelegate {
+      scrollMetricsMutator.updateScrollBoundaries(
+        minimumScrollOffset: minimumScrollOffset,
+        maximumScrollOffset: maximumScrollOffset)
+    }
+
+    cachedAccessibilityElements = nil
+    if let element = focusedAccessibilityElement as? OffScreenCalendarItemAccessibilityElement {
+      UIAccessibility.post(
+        notification: .screenChanged,
+        argument: visibleViewsForVisibleItems[element.correspondingItem])
     }
   }
 
@@ -1064,6 +1107,7 @@ extension CalendarView: WidthDependentIntrinsicContentHeightProviding {
     } else {
       calendarHeight = bounds.height
     }
+    let size = CGSize(width: calendarWidth, height: calendarHeight)
 
     let visibleItemsProvider = VisibleItemsProvider(
       calendar: calendar,
@@ -1082,7 +1126,8 @@ extension CalendarView: WidthDependentIntrinsicContentHeightProviding {
 
     let visibleItemsDetails = visibleItemsProvider.detailsForVisibleItems(
       surroundingPreviouslyVisibleLayoutItem: anchorMonthHeaderLayoutItem,
-      offset: scrollView.contentOffset)
+      offset: scrollView.contentOffset,
+      size: size)
 
     return CGSize(width: UIView.noIntrinsicMetric, height: visibleItemsDetails.intrinsicHeight)
   }

--- a/Sources/Public/CalendarView.swift
+++ b/Sources/Public/CalendarView.swift
@@ -198,7 +198,7 @@ public final class CalendarView: UIView {
 
     guard isReadyForLayout else { return }
 
-    _layoutSubviews()
+    _layoutSubviews(isAnimatedUpdatePass: isAnimatedUpdatePass)
 
     // The layout / update pass has completed, and we can set this back to `false`.
     isAnimatedUpdatePass = false
@@ -216,7 +216,7 @@ public final class CalendarView: UIView {
     isAnimatedUpdatePass = UIView.inheritedAnimationDuration > 0 && UIView.areAnimationsEnabled
     if isAnimatedUpdatePass {
       UIView.performWithoutAnimation {
-        _layoutSubviews()
+        _layoutSubviews(isAnimatedUpdatePass: isAnimatedUpdatePass)
       }
     }
 
@@ -669,7 +669,7 @@ public final class CalendarView: UIView {
   }
 
   // This exists so that we can force a layout ourselves in preparation for an animated update.
-  private func _layoutSubviews() {
+  private func _layoutSubviews(isAnimatedUpdatePass: Bool) {
     scrollView.performWithoutNotifyingDelegate {
       scrollMetricsMutator.setUpInitialMetricsIfNeeded()
       scrollMetricsMutator.updateContentSizePerpendicularToScrollAxis(viewportSize: bounds.size)
@@ -697,6 +697,7 @@ public final class CalendarView: UIView {
 
     // Use an extended bounds (3x the viewport size) if we're in an animated update pass, reducing
     // the likelihood of an item popping in / out.
+    let boundsMultiplier = CGFloat(3)
     let offset: CGPoint
     let size: CGSize
     if isAnimatedUpdatePass {
@@ -705,13 +706,13 @@ public final class CalendarView: UIView {
         offset = CGPoint(
           x: scrollView.contentOffset.x,
           y: scrollView.contentOffset.y - bounds.height)
-        size = CGSize(width: bounds.size.width, height: bounds.size.height * 3)
+        size = CGSize(width: bounds.size.width, height: bounds.size.height * boundsMultiplier)
 
       case .horizontal:
         offset = CGPoint(
           x: scrollView.contentOffset.x - bounds.width,
           y: scrollView.contentOffset.y)
-        size = CGSize(width: bounds.size.width * 3, height: bounds.size.height)
+        size = CGSize(width: bounds.size.width * boundsMultiplier, height: bounds.size.height)
       }
     } else {
       offset = scrollView.contentOffset

--- a/Tests/VisibleItemsProviderTests.swift
+++ b/Tests/VisibleItemsProviderTests.swift
@@ -291,11 +291,13 @@ final class VisibleItemsProviderTests: XCTestCase {
       surroundingPreviouslyVisibleLayoutItem: LayoutItem(
         itemType: .monthHeader(Month(era: 1, year: 2020, month: 03, isInGregorianCalendar: true)),
         frame: CGRect(x: 0, y: 200, width: 320, height: 50)),
-      offset: CGPoint(x: 0, y: 150))
+      offset: CGPoint(x: 0, y: 150),
+      size: verticalVisibleItemsProvider.size)
       .centermostLayoutItem
     let details = verticalShortDayAspectRatioVisibleItemsProvider.detailsForVisibleItems(
       surroundingPreviouslyVisibleLayoutItem: anchorLayoutItem,
-      offset: CGPoint(x: 0, y: 150))
+      offset: CGPoint(x: 0, y: 150),
+      size: verticalShortDayAspectRatioVisibleItemsProvider.size)
 
     let expectedVisibleItemDescriptions: Set<String> = [
       "[itemType: .dayBackground(2020-02-11), frame: (96.5, 145.0, 35.5, 18.0)]",
@@ -399,7 +401,8 @@ final class VisibleItemsProviderTests: XCTestCase {
       surroundingPreviouslyVisibleLayoutItem: LayoutItem(
         itemType: .monthHeader(Month(era: 1, year: 2020, month: 03, isInGregorianCalendar: true)),
         frame: CGRect(x: 0, y: 200, width: 320, height: 50)),
-      offset: CGPoint(x: 0, y: 150))
+      offset: CGPoint(x: 0, y: 150),
+      size: verticalVisibleItemsProvider.size)
 
     let expectedVisibleItemDescriptions: Set<String> = [
       "[itemType: .dayBackground(2020-03-11), frame: (142.0, 391.5, 36.0, 35.5)]",
@@ -483,7 +486,8 @@ final class VisibleItemsProviderTests: XCTestCase {
       surroundingPreviouslyVisibleLayoutItem: LayoutItem(
         itemType: .monthHeader(Month(era: 1, year: 2020, month: 06, isInGregorianCalendar: true)),
         frame: CGRect(x: 0, y: 450, width: 320, height: 40)),
-      offset: CGPoint(x: 0, y: 450))
+      offset: CGPoint(x: 0, y: 450),
+      size: verticalPinnedDaysOfWeekVisibleItemsProvider.size)
 
     let expectedVisibleItemDescriptions: Set<String> = [
       "[itemType: .dayBackground(2020-06-11), frame: (188.0, 585.5, 35.5, 36.0)]",
@@ -561,7 +565,8 @@ final class VisibleItemsProviderTests: XCTestCase {
       surroundingPreviouslyVisibleLayoutItem: LayoutItem(
         itemType: .monthHeader(Month(era: 1, year: 2020, month: 01, isInGregorianCalendar: true)),
         frame: CGRect(x: 0, y: 200, width: 320, height: 50)),
-      offset: CGPoint(x: 0, y: 150))
+      offset: CGPoint(x: 0, y: 150),
+      size: verticalPartialMonthVisibleItemsProvider.size)
 
     let expectedVisibleItemDescriptions: Set<String> = [
       "[itemType: .daysOfWeekRowSeparator(2020-1), frame: (0.0, 314.5, 320.0, 1.0)]",
@@ -611,7 +616,8 @@ final class VisibleItemsProviderTests: XCTestCase {
       surroundingPreviouslyVisibleLayoutItem: LayoutItem(
         itemType: .monthHeader(Month(era: 1, year: 2020, month: 05, isInGregorianCalendar: true)),
         frame: CGRect(x: 250, y: 0, width: 300, height: 50)),
-      offset: CGPoint(x: 100, y: 0))
+      offset: CGPoint(x: 100, y: 0),
+      size: horizontalVisibleItemsProvider.size)
 
     let expectedVisibleItemDescriptions: Set<String> = [
       "[itemType: .dayBackground(2020-04-11), frame: (197.0, 185.5, 33.0, 33.0)]",
@@ -695,7 +701,8 @@ final class VisibleItemsProviderTests: XCTestCase {
       surroundingPreviouslyVisibleLayoutItem: LayoutItem(
         itemType: .monthHeader(Month(era: 1, year: 2020, month: 12, isInGregorianCalendar: true)),
         frame: CGRect(x: 0, y: 3000, width: 320, height: 50)),
-      offset: CGPoint(x: 0, y: 150))
+      offset: CGPoint(x: 0, y: 150),
+      size: verticalVisibleItemsProvider.size)
 
     let expectedVisibleItemDescriptions: Set<String> = [
       "[itemType: .dayBackground(2020-05-11), frame: (50.5, 220.5, 36.0, 36.0)]",
@@ -775,7 +782,8 @@ final class VisibleItemsProviderTests: XCTestCase {
       surroundingPreviouslyVisibleLayoutItem: LayoutItem(
         itemType: .monthHeader(Month(era: 1, year: 2020, month: 2, isInGregorianCalendar: true)),
         frame: CGRect(x: 315, y: 0, width: 300, height: 50)),
-      offset: CGPoint(x: 295, y: 0))
+      offset: CGPoint(x: 295, y: 0),
+      size: horizontalVisibleItemsProvider.size)
 
     let expectedVisibleItemDescriptions: Set<String> = [
       "[itemType: .dayBackground(2020-02-11), frame: (405.5, 238.5, 33.0, 33.0)]",
@@ -843,7 +851,8 @@ final class VisibleItemsProviderTests: XCTestCase {
       surroundingPreviouslyVisibleLayoutItem: LayoutItem(
         itemType: .monthHeader(Month(era: 1, year: 2020, month: 01, isInGregorianCalendar: true)),
         frame: CGRect(x: 0, y: 0, width: 320, height: 50)),
-      offset: CGPoint(x: 0, y: -50))
+      offset: CGPoint(x: 0, y: -50),
+      size: verticalVisibleItemsProvider.size)
 
     let expectedVisibleItemDescriptions: Set<String> = [
       "[itemType: .dayBackground(2020-01-11), frame: (279.5, 191.5, 35.5, 35.5)]",
@@ -919,7 +928,8 @@ final class VisibleItemsProviderTests: XCTestCase {
       surroundingPreviouslyVisibleLayoutItem: LayoutItem(
         itemType: .monthHeader(Month(era: 1, year: 2020, month: 01, isInGregorianCalendar: true)),
         frame: CGRect(x: 0, y: 45, width: 320, height: 40)),
-      offset: CGPoint(x: 0, y: 50))
+      offset: CGPoint(x: 0, y: 50),
+      size: verticalPinnedDaysOfWeekVisibleItemsProvider.size)
 
     let expectedVisibleItemDescriptions: Set<String> = [
       "[itemType: .dayBackground(2020-01-11), frame: (279.5, 180.5, 35.5, 36.0)]",
@@ -998,7 +1008,8 @@ final class VisibleItemsProviderTests: XCTestCase {
       surroundingPreviouslyVisibleLayoutItem: LayoutItem(
         itemType: .monthHeader(Month(era: 1, year: 2020, month: 12, isInGregorianCalendar: true)),
         frame: CGRect(x: 0, y: 690, width: 320, height: 50)),
-      offset: CGPoint(x: 0, y: 690))
+      offset: CGPoint(x: 0, y: 690),
+      size: verticalPartialMonthVisibleItemsProvider.size)
 
     let expectedVisibleItemDescriptions: Set<String> = [
       "[itemType: .daysOfWeekRowSeparator(2020-12), frame: (0.0, 854.5, 320.0, 1.0)]",
@@ -1033,7 +1044,8 @@ final class VisibleItemsProviderTests: XCTestCase {
       surroundingPreviouslyVisibleLayoutItem: LayoutItem(
         itemType: .monthHeader(Month(era: 1, year: 2020, month: 12, isInGregorianCalendar: true)),
         frame: CGRect(x: 1200, y: 0, width: 300, height: 50)),
-      offset: CGPoint(x: 1000, y: 0))
+      offset: CGPoint(x: 1000, y: 0),
+      size: horizontalVisibleItemsProvider.size)
 
     let expectedVisibleItemDescriptions: Set<String> = [
       "[itemType: .dayBackground(2020-11-11), frame: (1018.5, 235.5, 33.0, 33.0)]",


### PR DESCRIPTION
## Details

This improves animations that involve views animating in / out of view. The root issue is that offscreen views get hidden from the view hierarchy. In order to work around this, we do the following:

- Detect that we're animating in `setContent`
- Internally force layout immediately with an _extended bounds_ that gets "offscreen" views visible (even though they're still technically out of view)
- Let `setContent` finish running, updating internal state to contain the latest content values
- The feature code / caller's `calendarView.layoutIfNeeded()` is called, forcing a layout with _extended bounds_ with the new content values in an animation closure
- After this animated layout pass, we stop using _extended bounds_ during layout and return to normal behavior of hiding views that are not visible

| Before | After |
| ---- | ---- |
| ![Simulator Screen Recording - iPhone 14 Pro - 2023-08-23 at 18 10 56](https://github.com/airbnb/HorizonCalendar/assets/746571/68042258-bd0d-4da9-b1d8-87c8537eb0b3) | ![Simulator Screen Recording - iPhone 14 Pro - 2023-08-23 at 18 09 52](https://github.com/airbnb/HorizonCalendar/assets/746571/c0d317c7-bfed-41b1-a8cb-4af86beae8bd) | 

## Related Issue

N/A

## Motivation and Context

Animation improvements

## How Has This Been Tested

Example app

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
