### PR TITLE
Add animated content update support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a `multiDaySelectionDragHandler`, enabling developers to implement multiple-day-selection via a drag gesture (similar to multi-select in the iOS Photos app)
 - Added the ability to change the aspect ratio of individual day-of-the-week items
 - Added support for self-sizing month headers
+- Added a new `setContent(_:animated:)` function, allowing people to perform animated content updates
 
 ### Fixed
 - Fixed an issue that could cause the calendar to programmatically scroll to a month or day to which it had previously scrolled

--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ Features:
 
 - Supports all calendars from `Foundation.Calendar` (Gregorian, Japanese, Hebrew, etc.)
 - Display months in a vertically-scrolling or horizontally-scrolling layout
-- Declarative API that enables unidirectional data flow for updating the content of the calendar
+- Declarative API that encourages unidirectional data flow for updating the content of the calendar
 - A custom layout system that enables virtually infinite date ranges without increasing memory usage
+- Animated content updates
 - Pagination for horizontally-scrolling calendars
 - Self-sizing month headers
 - Specify custom views (`UIView` or SwiftUI `View`) for individual days, month headers, and days of the week

--- a/Sources/Public/CalendarViewRepresentable.swift
+++ b/Sources/Public/CalendarViewRepresentable.swift
@@ -80,7 +80,9 @@ public struct CalendarViewRepresentable: UIViewRepresentable {
     calendarView.didEndDragging = didEndDragging
     calendarView.didEndDecelerating = didEndDecelerating
 
-    calendarView.setContent(makeContent())
+    // There's no public API for inheriting the `context.transaction.animation`'s properties here so
+    // that we can do an equivalent `UIView` animation.
+    calendarView.setContent(makeContent(), animated: false)
   }
 
   // MARK: Fileprivate


### PR DESCRIPTION
## Details

This adds animated `setContent` support to `HorizonCalendar`. Due to SwiftUI animation / UIKit-interop limitations, we don't currently attempt to animate from `CalendarViewRepresentable`. There's a hacky path forward if we mirror some private properties like this:

```
(lldb) po Mirror(reflecting: context.transaction.animation!).children.map { ($0, $1) }
▿ 1 element
  ▿ 0 : 2 elements
    ▿ .0 : Optional<String>
      - some : "base"
    ▿ .1 : BezierAnimation
      - duration : 0.35
      ▿ curve : BezierTimingCurve
        - ax : 0.52
        - bx : -0.78
        - cx : 1.26
        - ay : -2.0
        - by : 3.0
        - cy : 0.0
```

## Related Issue

N/A

## Motivation and Context

Improve animation support.

## How Has This Been Tested

Example app.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
