### PR TITLE
Accessibility scrolling enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed an issue that could cause the calendar to layout unnecessarily due to a trait collection change notification
 - Fixed an issue that could cause off-screen items to appear or disappear instantly, rather than animating in or out during animated content changes
 - Fixed an issue that caused a SwiftUI view being used as a calendar item to not receive calls to `onAppear`
+- Fixed an accessibility issue that prevented scrolling callbacks from firing when scrolling via voiceover.
 
 ### Changed
 - Removed all deprecated code, simplifying the public API in preparation for a 2.0 release

--- a/Sources/Public/CalendarView.swift
+++ b/Sources/Public/CalendarView.swift
@@ -1259,6 +1259,13 @@ extension CalendarView {
     let accessibilityScrollText = targetMonthView.accessibilityLabel
     UIAccessibility.post(notification: .pageScrolled, argument: accessibilityScrollText)
 
+    // ensure that scrolling related callbacks are still fired when performing scrolling via accessibility
+    if let visibleDayRange {
+      didEndDecelerating?(visibleDayRange)
+      didEndDragging?(visibleDayRange, false)
+      didScroll?(visibleDayRange, true)
+    }
+
     return true
   }
 

--- a/Sources/Public/CalendarView.swift
+++ b/Sources/Public/CalendarView.swift
@@ -1261,9 +1261,9 @@ extension CalendarView {
 
     // ensure that scrolling related callbacks are still fired when performing scrolling via accessibility
     if let visibleDayRange {
+      didScroll?(visibleDayRange, false)
+      didEndDragging?(visibleDayRange, true)
       didEndDecelerating?(visibleDayRange)
-      didEndDragging?(visibleDayRange, false)
-      didScroll?(visibleDayRange, true)
     }
 
     return true


### PR DESCRIPTION
## Details

When scrolling the `CalendarView` via accessibility methods (specifically using the 3 finger swipe with voiceover), the related scrolling delegate methods (`didScroll`, `didEndDragging`, and `didEndDecelerating`) were not called. 

This could lead to missing functionality for surfaces which relied on those callbacks to implement functionality, such as loading new data from the network when scrolling to new a new data range.

This PR adds those callbacks to the `accessibilityScroll` method, ensuring that they're fired whenever a user scrolls - whether through accessibility means or not.

## Related Issue

<!--- If this is related to any issues, link them here. -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

Tested changes in example app on device to ensure that the relevant delegate methods are called.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
