### PR TITLE
Support disabling touches via allowsHitTesting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,12 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/airbnb/HorizonCalendar/compare/v1.16.0...HEAD)
+## [Unreleased](https://github.com/airbnb/HorizonCalendar/compare/v2.0.0...HEAD)
+
+### Added
+- Added support for disabling touch handling on SwiftUI views via the `allowsHitTesting` modifier
+
+## [v2.0.0](https://github.com/airbnb/HorizonCalendar/compare/v1.16.0...v2.0.0) - 2023-12-19
 
 ### Added
 - Added `MonthsLayout.vertical` and `MonthsLayout.horizontal` as more concise alternatives to `MonthsLayout.vertical(options: .init())` and `MonthsLayout.horizontal(options: .init())`, respectively

--- a/Sources/Public/CalendarView.swift
+++ b/Sources/Public/CalendarView.swift
@@ -1016,8 +1016,6 @@ public final class CalendarView: UIView {
   }
 
   private func updateSelectedDayRange(gestureRecognizer: UIGestureRecognizer) {
-    let locationInScrollView = gestureRecognizer.location(in: scrollView)
-
     // Find the intersected day
     var intersectedDay: Day?
     for subview in scrollView.subviews {
@@ -1025,7 +1023,7 @@ public final class CalendarView: UIView {
         !subview.isHidden,
         let itemView = subview as? ItemView,
         case .layoutItemType(.day(let day)) = itemView.itemType,
-        itemView.frame.contains(locationInScrollView)
+        itemView.hitTest(gestureRecognizer.location(in: itemView), with: nil) != nil
       else {
         continue
       }

--- a/Sources/Public/ItemViews/SwiftUIWrapperView.swift
+++ b/Sources/Public/ItemViews/SwiftUIWrapperView.swift
@@ -60,6 +60,20 @@ public final class SwiftUIWrapperView<Content: View>: UIView {
     }
   }
 
+  public override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
+    // `_UIHostingView`'s `isUserInteractionEnabled` is not affected by the `allowsHitTesting`
+    // modifier. Its first subview's `isUserInteractionEnabled` _does_ appear to be affected by the
+    // `allowsHitTesting` modifier, enabling us to properly ignore touch handling.
+    if
+      let firstSubview = hostingController.view.subviews.first,
+      !firstSubview.isUserInteractionEnabled
+    {
+      return false
+    } else {
+      return super.point(inside: point, with: event)
+    }
+  }
+
   public override func layoutSubviews() {
     super.layoutSubviews()
     hostingControllerView?.frame = bounds


### PR DESCRIPTION
## Details

This PR enables folks to disable user interaction on SwiftUI views by using the `allowsHitTesting` modifier.

## Related Issue

https://github.com/airbnb/HorizonCalendar/issues/291

## Motivation and Context

Fix issues (we also ran into this at Airbnb recently when trying to disable certain days from being tappable)

## How Has This Been Tested

Example app

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
