### PR TITLE
Bk/another accessibility refactor

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -1,4 +1,4 @@
-name: Swift
+name: CI
 
 on:
   push:
@@ -8,22 +8,25 @@ on:
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: macos-13
     strategy:
       matrix:
-        destination: ['platform=iOS Simulator,OS=11.0,name=iPhone 8', 'platform=iOS Simulator,OS=16.2,name=iPhone 14']
+        xcode:
+        - '15.0' # Swift 5.9
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Build
-        run: xcodebuild clean build -scheme HorizonCalendar
+        run: xcodebuild clean build -scheme HorizonCalendar -destination "generic/platform=iOS Simulator"
       - name: Run tests
-        run: xcodebuild clean test -project HorizonCalendar.xcodeproj -scheme HorizonCalendar -destination "name=iPhone 8,OS=16.2"
+        run: xcodebuild clean test -project HorizonCalendar.xcodeproj -scheme HorizonCalendar -destination "name=iPhone 14,OS=17.2"
 
   lint-swift:
     runs-on: macos-13
+    strategy:
+      matrix:
+        xcode:
+        - '15.0' # Swift 5.9
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Lint Swift
         run: swift package --allow-writing-to-package-directory format --lint
-
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added support for disabling touch handling on SwiftUI views via the `allowsHitTesting` modifier
 
+### Fixed
+- Fixed an issue that could cause accessibility focus to shift unexpectedly
+
+### Changed
+- Rewrote accessibility code to avoid posting notifications, which causes poor Voice Over performance and odd focus bugs
+
 ## [v2.0.0](https://github.com/airbnb/HorizonCalendar/compare/v1.16.0...v2.0.0) - 2023-12-19
 
 ### Added

--- a/HorizonCalendar.podspec
+++ b/HorizonCalendar.podspec
@@ -36,7 +36,7 @@ Features:
   spec.homepage = "https://github.com/airbnb/HorizonCalendar"
   spec.authors = { "Bryan Keller" => "kellerbryan19@gmail.com" }
   spec.social_media_url = "https://twitter.com/BKYourWay19"
-  spec.swift_version = "5.8"
-  spec.ios.deployment_target = '11.0'
+  spec.swift_version = "5.9"
+  spec.ios.deployment_target = '12.0'
   spec.source_files = "Sources/**/*.{swift,h}"
 end

--- a/HorizonCalendar.xcodeproj/project.pbxproj
+++ b/HorizonCalendar.xcodeproj/project.pbxproj
@@ -565,6 +565,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -622,6 +623,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 5.0;
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -644,7 +646,7 @@
 				GCC_WARN_UNUSED_PARAMETER = YES;
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -678,7 +680,7 @@
 				GCC_WARN_UNUSED_PARAMETER = YES;
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -702,7 +704,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 5Q5SGQT2R4;
 				INFOPLIST_FILE = Tests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -722,7 +724,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 5Q5SGQT2R4;
 				INFOPLIST_FILE = Tests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Package.swift
+++ b/Package.swift
@@ -1,11 +1,10 @@
-// swift-tools-version:5.8
-
+// swift-tools-version: 5.8.1
 import PackageDescription
 
 let package = Package(
   name: "HorizonCalendar",
   platforms: [
-    .iOS(.v11),
+    .iOS(.v12),
   ],
   products: [
     .library(name: "HorizonCalendar", targets: ["HorizonCalendar"]),

--- a/Sources/Internal/ItemViewReuseManager.swift
+++ b/Sources/Internal/ItemViewReuseManager.swift
@@ -25,6 +25,7 @@ final class ItemViewReuseManager {
 
   func viewsForVisibleItems(
     _ visibleItems: Set<VisibleItem>,
+    recycleOldViews: Bool,
     viewHandler: (
       ItemView,
       VisibleItem,
@@ -56,6 +57,7 @@ final class ItemViewReuseManager {
 
       let context = reusedViewContext(
         for: visibleItem,
+        recycleOldViews: recycleOldViews,
         unusedPreviouslyVisibleItems: &visibleItemsDifference)
       viewHandler(
         context.view,
@@ -76,6 +78,7 @@ final class ItemViewReuseManager {
 
   private func reusedViewContext(
     for visibleItem: VisibleItem,
+    recycleOldViews: Bool,
     unusedPreviouslyVisibleItems: inout Set<VisibleItem>)
     -> ReusedViewContext
   {
@@ -103,7 +106,7 @@ final class ItemViewReuseManager {
         visibleItemsForItemViewDifferentiators[differentiator]?.remove(visibleItem)
         viewsForVisibleItems.removeValue(forKey: visibleItem)
       } else {
-        if let previouslyVisibleItem = unusedPreviouslyVisibleItems.first {
+        if recycleOldViews, let previouslyVisibleItem = unusedPreviouslyVisibleItems.first {
           // An unused, previously-visible item is available, so reuse it.
 
           guard let previousView = viewsForVisibleItems[previouslyVisibleItem] else {
@@ -122,7 +125,8 @@ final class ItemViewReuseManager {
           visibleItemsForItemViewDifferentiators[differentiator]?.remove(previouslyVisibleItem)
           viewsForVisibleItems.removeValue(forKey: previouslyVisibleItem)
         } else {
-          // No previously-visible item is available for reuse, so create a new view.
+          // No previously-visible item is available for reuse (or view recycling is disabled), so
+          // create a new view.
           view = ItemView(initialCalendarItemModel: visibleItem.calendarItemModel)
           previousBackingVisibleItem = nil
           isReusedViewSameAsPreviousView = false

--- a/Sources/Internal/ItemViewReuseManager.swift
+++ b/Sources/Internal/ItemViewReuseManager.swift
@@ -25,7 +25,7 @@ final class ItemViewReuseManager {
 
   func viewsForVisibleItems(
     _ visibleItems: Set<VisibleItem>,
-    recycleOldViews: Bool,
+    recycleUnusedViews: Bool,
     viewHandler: (
       ItemView,
       VisibleItem,
@@ -57,7 +57,7 @@ final class ItemViewReuseManager {
 
       let context = reusedViewContext(
         for: visibleItem,
-        recycleOldViews: recycleOldViews,
+        recycleUnusedViews: recycleUnusedViews,
         unusedPreviouslyVisibleItems: &visibleItemsDifference)
       viewHandler(
         context.view,
@@ -78,7 +78,7 @@ final class ItemViewReuseManager {
 
   private func reusedViewContext(
     for visibleItem: VisibleItem,
-    recycleOldViews: Bool,
+    recycleUnusedViews: Bool,
     unusedPreviouslyVisibleItems: inout Set<VisibleItem>)
     -> ReusedViewContext
   {
@@ -106,7 +106,7 @@ final class ItemViewReuseManager {
         visibleItemsForItemViewDifferentiators[differentiator]?.remove(visibleItem)
         viewsForVisibleItems.removeValue(forKey: visibleItem)
       } else {
-        if recycleOldViews, let previouslyVisibleItem = unusedPreviouslyVisibleItems.first {
+        if recycleUnusedViews, let previouslyVisibleItem = unusedPreviouslyVisibleItems.first {
           // An unused, previously-visible item is available, so reuse it.
 
           guard let previousView = viewsForVisibleItems[previouslyVisibleItem] else {

--- a/Sources/Internal/SubviewInsertionIndexTracker.swift
+++ b/Sources/Internal/SubviewInsertionIndexTracker.swift
@@ -27,77 +27,31 @@ final class SubviewInsertionIndexTracker {
     switch itemType {
     case .monthBackground:
       index = monthBackgroundItemsEndIndex
-      monthBackgroundItemsEndIndex += 1
-      dayRangeItemsEndIndex += 1
-      mainItemsEndIndex += 1
-      daysOfWeekRowSeparatorItemsEndIndex += 1
-      overlayItemsEndIndex += 1
-      pinnedDaysOfWeekRowBackgroundEndIndex += 1
-      pinnedDayOfWeekItemsEndIndex += 1
-      pinnedDaysOfWeekRowSeparatorEndIndex += 1
-
     case .dayBackground:
       index = dayBackgroundItemsEndIndex
-      dayBackgroundItemsEndIndex += 1
-      dayRangeItemsEndIndex += 1
-      mainItemsEndIndex += 1
-      daysOfWeekRowSeparatorItemsEndIndex += 1
-      overlayItemsEndIndex += 1
-      pinnedDaysOfWeekRowBackgroundEndIndex += 1
-      pinnedDayOfWeekItemsEndIndex += 1
-      pinnedDaysOfWeekRowSeparatorEndIndex += 1
-
     case .dayRange:
       index = dayRangeItemsEndIndex
-      dayRangeItemsEndIndex += 1
-      mainItemsEndIndex += 1
-      daysOfWeekRowSeparatorItemsEndIndex += 1
-      overlayItemsEndIndex += 1
-      pinnedDaysOfWeekRowBackgroundEndIndex += 1
-      pinnedDayOfWeekItemsEndIndex += 1
-      pinnedDaysOfWeekRowSeparatorEndIndex += 1
-
     case .layoutItemType:
       index = mainItemsEndIndex
-      mainItemsEndIndex += 1
-      daysOfWeekRowSeparatorItemsEndIndex += 1
-      overlayItemsEndIndex += 1
-      pinnedDaysOfWeekRowBackgroundEndIndex += 1
-      pinnedDayOfWeekItemsEndIndex += 1
-      pinnedDaysOfWeekRowSeparatorEndIndex += 1
-
     case .daysOfWeekRowSeparator:
       index = daysOfWeekRowSeparatorItemsEndIndex
-      daysOfWeekRowSeparatorItemsEndIndex += 1
-      overlayItemsEndIndex += 1
-      pinnedDaysOfWeekRowBackgroundEndIndex += 1
-      pinnedDayOfWeekItemsEndIndex += 1
-      pinnedDaysOfWeekRowSeparatorEndIndex += 1
-
     case .overlayItem:
       index = overlayItemsEndIndex
-      overlayItemsEndIndex += 1
-      pinnedDaysOfWeekRowBackgroundEndIndex += 1
-      pinnedDayOfWeekItemsEndIndex += 1
-      pinnedDaysOfWeekRowSeparatorEndIndex += 1
-
     case .pinnedDaysOfWeekRowBackground:
       index = pinnedDaysOfWeekRowBackgroundEndIndex
-      pinnedDaysOfWeekRowBackgroundEndIndex += 1
-      pinnedDayOfWeekItemsEndIndex += 1
-      pinnedDaysOfWeekRowSeparatorEndIndex += 1
-
     case .pinnedDayOfWeek:
       index = pinnedDayOfWeekItemsEndIndex
-      pinnedDayOfWeekItemsEndIndex += 1
-      pinnedDaysOfWeekRowSeparatorEndIndex += 1
-
     case .pinnedDaysOfWeekRowSeparator:
       index = pinnedDaysOfWeekRowSeparatorEndIndex
-      pinnedDaysOfWeekRowSeparatorEndIndex += 1
     }
 
+    addValue(1, toItemTypesAffectedBy: itemType)
+
     return index
+  }
+
+  func removedSubview(withCorrespondingItemType itemType: VisibleItem.ItemType) {
+    addValue(-1, toItemTypesAffectedBy: itemType)
   }
 
   // MARK: Private
@@ -111,5 +65,71 @@ final class SubviewInsertionIndexTracker {
   private var pinnedDaysOfWeekRowBackgroundEndIndex = 0
   private var pinnedDayOfWeekItemsEndIndex = 0
   private var pinnedDaysOfWeekRowSeparatorEndIndex = 0
+
+  private func addValue(_ value: Int, toItemTypesAffectedBy itemType: VisibleItem.ItemType) {
+    switch itemType {
+    case .monthBackground:
+      monthBackgroundItemsEndIndex += value
+      dayRangeItemsEndIndex += value
+      mainItemsEndIndex += value
+      daysOfWeekRowSeparatorItemsEndIndex += value
+      overlayItemsEndIndex += value
+      pinnedDaysOfWeekRowBackgroundEndIndex += value
+      pinnedDayOfWeekItemsEndIndex += value
+      pinnedDaysOfWeekRowSeparatorEndIndex += value
+
+    case .dayBackground:
+      dayBackgroundItemsEndIndex += value
+      dayRangeItemsEndIndex += value
+      mainItemsEndIndex += value
+      daysOfWeekRowSeparatorItemsEndIndex += value
+      overlayItemsEndIndex += value
+      pinnedDaysOfWeekRowBackgroundEndIndex += value
+      pinnedDayOfWeekItemsEndIndex += value
+      pinnedDaysOfWeekRowSeparatorEndIndex += value
+
+    case .dayRange:
+      dayRangeItemsEndIndex += value
+      mainItemsEndIndex += value
+      daysOfWeekRowSeparatorItemsEndIndex += value
+      overlayItemsEndIndex += value
+      pinnedDaysOfWeekRowBackgroundEndIndex += value
+      pinnedDayOfWeekItemsEndIndex += value
+      pinnedDaysOfWeekRowSeparatorEndIndex += value
+
+    case .layoutItemType:
+      mainItemsEndIndex += value
+      daysOfWeekRowSeparatorItemsEndIndex += value
+      overlayItemsEndIndex += value
+      pinnedDaysOfWeekRowBackgroundEndIndex += value
+      pinnedDayOfWeekItemsEndIndex += value
+      pinnedDaysOfWeekRowSeparatorEndIndex += value
+
+    case .daysOfWeekRowSeparator:
+      daysOfWeekRowSeparatorItemsEndIndex += value
+      overlayItemsEndIndex += value
+      pinnedDaysOfWeekRowBackgroundEndIndex += value
+      pinnedDayOfWeekItemsEndIndex += value
+      pinnedDaysOfWeekRowSeparatorEndIndex += value
+
+    case .overlayItem:
+      overlayItemsEndIndex += value
+      pinnedDaysOfWeekRowBackgroundEndIndex += value
+      pinnedDayOfWeekItemsEndIndex += value
+      pinnedDaysOfWeekRowSeparatorEndIndex += value
+
+    case .pinnedDaysOfWeekRowBackground:
+      pinnedDaysOfWeekRowBackgroundEndIndex += value
+      pinnedDayOfWeekItemsEndIndex += value
+      pinnedDaysOfWeekRowSeparatorEndIndex += value
+
+    case .pinnedDayOfWeek:
+      pinnedDayOfWeekItemsEndIndex += value
+      pinnedDaysOfWeekRowSeparatorEndIndex += value
+
+    case .pinnedDaysOfWeekRowSeparator:
+      pinnedDaysOfWeekRowSeparatorEndIndex += value
+    }
+  }
 
 }

--- a/Sources/Public/CalendarView.swift
+++ b/Sources/Public/CalendarView.swift
@@ -520,14 +520,6 @@ public final class CalendarView: UIView {
   private lazy var scrollViewDelegate = ScrollViewDelegate(calendarView: self)
   private lazy var gestureRecognizerDelegate = GestureRecognizerDelegate(calendarView: self)
 
-  private var initialItemViewWasFocused = false {
-    didSet {
-      guard initialItemViewWasFocused != oldValue else { return }
-      setNeedsLayout()
-      layoutIfNeeded()
-    }
-  }
-
   // Necessary to work around a `UIScrollView` behavior difference on Mac. See `scrollViewDidScroll`
   // and `preventLargeOverScrollIfNeeded` for more context.
   private lazy var isRunningOnMac: Bool = {
@@ -539,6 +531,14 @@ public final class CalendarView: UIView {
 
     return false
   }()
+
+  private var initialItemViewWasFocused = false {
+    didSet {
+      guard initialItemViewWasFocused != oldValue else { return }
+      setNeedsLayout()
+      layoutIfNeeded()
+    }
+  }
 
   private var isReadyForLayout: Bool {
     // There's no reason to attempt layout unless we have a non-zero `bounds.size`. We'll have a

--- a/Tests/ItemViewReuseManagerTests.swift
+++ b/Tests/ItemViewReuseManagerTests.swift
@@ -58,7 +58,7 @@ final class ItemViewReuseManagerTests: XCTestCase {
 
     reuseManager.viewsForVisibleItems(
       visibleItems,
-      recycleOldViews: true,
+      recycleUnusedViews: true,
       viewHandler: { _, _, previousBackingItem, isReusedViewSameAsPreviousView in
         XCTAssert(
           previousBackingItem == nil,
@@ -104,13 +104,13 @@ final class ItemViewReuseManagerTests: XCTestCase {
     // Populate the reuse manager with the initial visible items
     reuseManager.viewsForVisibleItems(
       initialVisibleItems,
-      recycleOldViews: true,
+      recycleUnusedViews: true,
       viewHandler: { _, _, _, _ in })
 
     // Ensure all views are reused by using the exact same previous views
     reuseManager.viewsForVisibleItems(
       subsequentVisibleItems,
-      recycleOldViews: true,
+      recycleUnusedViews: true,
       viewHandler: { _, item, previousBackingItem, isReusedViewSameAsPreviousView in
         XCTAssert(
           item == previousBackingItem,
@@ -186,13 +186,13 @@ final class ItemViewReuseManagerTests: XCTestCase {
     // Populate the reuse manager with the initial visible items
     reuseManager.viewsForVisibleItems(
       initialVisibleItems,
-      recycleOldViews: true,
+      recycleUnusedViews: true,
       viewHandler: { _, _, _, _ in })
 
     // Ensure all views are reused given the subsequent visible items
     reuseManager.viewsForVisibleItems(
       subsequentVisibleItems,
-      recycleOldViews: true,
+      recycleUnusedViews: true,
       viewHandler: { _, item, previousBackingItem, _ in
         XCTAssert(
           item.calendarItemModel._itemViewDifferentiator == previousBackingItem?.calendarItemModel._itemViewDifferentiator,
@@ -281,13 +281,13 @@ final class ItemViewReuseManagerTests: XCTestCase {
     // Populate the reuse manager with the initial visible items
     reuseManager.viewsForVisibleItems(
       initialVisibleItems,
-      recycleOldViews: true,
+      recycleUnusedViews: true,
       viewHandler: { _, _, _, _ in })
 
     // Ensure the correct subset of views are reused given the subsequent visible items
     reuseManager.viewsForVisibleItems(
       subsequentVisibleItems,
-      recycleOldViews: true,
+      recycleUnusedViews: true,
       viewHandler: { _, item, previousBackingItem, isReusedViewSameAsPreviousView in
         guard let itemModel = item.calendarItemModel as? MockCalendarItemModel else {
           preconditionFailure(
@@ -423,7 +423,7 @@ final class ItemViewReuseManagerTests: XCTestCase {
     // Populate the reuse manager with the initial visible items
     reuseManager.viewsForVisibleItems(
       initialVisibleItems,
-      recycleOldViews: true,
+      recycleUnusedViews: true,
       viewHandler: { _, _, _, _ in })
 
     // Ensure the correct subset of views are reused given the subsequent visible items
@@ -431,7 +431,7 @@ final class ItemViewReuseManagerTests: XCTestCase {
     var newViewCountsForDifferentiators = [_CalendarItemViewDifferentiator: Int]()
     reuseManager.viewsForVisibleItems(
       subsequentVisibleItems,
-      recycleOldViews: true,
+      recycleUnusedViews: true,
       viewHandler: { _, item, previousBackingItem, _ in
         if previousBackingItem != nil {
           let reuseCount = (reuseCountsForDifferentiators[item.calendarItemModel._itemViewDifferentiator] ?? 0) + 1
@@ -539,13 +539,13 @@ final class ItemViewReuseManagerTests: XCTestCase {
     // Populate the reuse manager with the initial visible items
     reuseManager.viewsForVisibleItems(
       initialVisibleItems,
-      recycleOldViews: false,
+      recycleUnusedViews: false,
       viewHandler: { _, _, _, _ in })
 
     // Ensure the correct subset of views are reused given the subsequent visible items
     reuseManager.viewsForVisibleItems(
       subsequentVisibleItems,
-      recycleOldViews: false,
+      recycleUnusedViews: false,
       viewHandler: { _, item, previousBackingItem, isReusedViewSameAsPreviousView in
         guard let itemModel = item.calendarItemModel as? MockCalendarItemModel else {
           preconditionFailure(

--- a/Tests/ItemViewReuseManagerTests.swift
+++ b/Tests/ItemViewReuseManagerTests.swift
@@ -58,6 +58,7 @@ final class ItemViewReuseManagerTests: XCTestCase {
 
     reuseManager.viewsForVisibleItems(
       visibleItems,
+      recycleOldViews: true,
       viewHandler: { _, _, previousBackingItem, isReusedViewSameAsPreviousView in
         XCTAssert(
           previousBackingItem == nil,
@@ -101,11 +102,15 @@ final class ItemViewReuseManagerTests: XCTestCase {
     let subsequentVisibleItems = initialVisibleItems
 
     // Populate the reuse manager with the initial visible items
-    reuseManager.viewsForVisibleItems(initialVisibleItems, viewHandler: { _, _, _, _ in })
+    reuseManager.viewsForVisibleItems(
+      initialVisibleItems,
+      recycleOldViews: true,
+      viewHandler: { _, _, _, _ in })
 
     // Ensure all views are reused by using the exact same previous views
     reuseManager.viewsForVisibleItems(
       subsequentVisibleItems,
+      recycleOldViews: true,
       viewHandler: { _, item, previousBackingItem, isReusedViewSameAsPreviousView in
         XCTAssert(
           item == previousBackingItem,
@@ -179,11 +184,15 @@ final class ItemViewReuseManagerTests: XCTestCase {
     ]
 
     // Populate the reuse manager with the initial visible items
-    reuseManager.viewsForVisibleItems(initialVisibleItems, viewHandler: { _, _, _, _ in })
+    reuseManager.viewsForVisibleItems(
+      initialVisibleItems,
+      recycleOldViews: true,
+      viewHandler: { _, _, _, _ in })
 
     // Ensure all views are reused given the subsequent visible items
     reuseManager.viewsForVisibleItems(
       subsequentVisibleItems,
+      recycleOldViews: true,
       viewHandler: { _, item, previousBackingItem, _ in
         XCTAssert(
           item.calendarItemModel._itemViewDifferentiator == previousBackingItem?.calendarItemModel._itemViewDifferentiator,
@@ -270,11 +279,15 @@ final class ItemViewReuseManagerTests: XCTestCase {
     ]
 
     // Populate the reuse manager with the initial visible items
-    reuseManager.viewsForVisibleItems(initialVisibleItems, viewHandler: { _, _, _, _ in })
+    reuseManager.viewsForVisibleItems(
+      initialVisibleItems,
+      recycleOldViews: true,
+      viewHandler: { _, _, _, _ in })
 
     // Ensure the correct subset of views are reused given the subsequent visible items
     reuseManager.viewsForVisibleItems(
       subsequentVisibleItems,
+      recycleOldViews: true,
       viewHandler: { _, item, previousBackingItem, isReusedViewSameAsPreviousView in
         guard let itemModel = item.calendarItemModel as? MockCalendarItemModel else {
           preconditionFailure(
@@ -408,13 +421,17 @@ final class ItemViewReuseManagerTests: XCTestCase {
     ]
 
     // Populate the reuse manager with the initial visible items
-    reuseManager.viewsForVisibleItems(initialVisibleItems, viewHandler: { _, _, _, _ in })
+    reuseManager.viewsForVisibleItems(
+      initialVisibleItems,
+      recycleOldViews: true,
+      viewHandler: { _, _, _, _ in })
 
     // Ensure the correct subset of views are reused given the subsequent visible items
     var reuseCountsForDifferentiators = [_CalendarItemViewDifferentiator: Int]()
     var newViewCountsForDifferentiators = [_CalendarItemViewDifferentiator: Int]()
     reuseManager.viewsForVisibleItems(
       subsequentVisibleItems,
+      recycleOldViews: true,
       viewHandler: { _, item, previousBackingItem, _ in
         if previousBackingItem != nil {
           let reuseCount = (reuseCountsForDifferentiators[item.calendarItemModel._itemViewDifferentiator] ?? 0) + 1
@@ -442,6 +459,116 @@ final class ItemViewReuseManagerTests: XCTestCase {
     XCTAssert(
       newViewCountsForDifferentiators == expectedNewViewCountsForDifferentiators,
       "The number of new view creations does not match the expected number of new view creations.")
+  }
+
+  func testDisablingViewRecycling() {
+    let initialVisibleItems: Set<VisibleItem> = [
+      .init(
+        calendarItemModel: MockCalendarItemModel.variant0,
+        itemType: .layoutItemType(
+          .monthHeader(Month(era: 1, year: 2020, month: 01, isInGregorianCalendar: true))),
+        frame: .zero),
+      .init(
+        calendarItemModel: MockCalendarItemModel.variant0,
+        itemType: .layoutItemType(
+          .monthHeader(Month(era: 1, year: 2020, month: 02, isInGregorianCalendar: true))),
+        frame: .zero),
+      .init(
+        calendarItemModel: MockCalendarItemModel.variant1,
+        itemType: .layoutItemType(
+          .day(
+            Day(
+              month: Month(era: 1, year: 2020, month: 01, isInGregorianCalendar: true),
+              day: 01))),
+        frame: .zero),
+      .init(
+        calendarItemModel: MockCalendarItemModel.variant1,
+        itemType: .layoutItemType(
+          .day(
+            Day(
+              month: Month(era: 1, year: 2020, month: 02, isInGregorianCalendar: true),
+              day: 01))),
+        frame: .zero),
+      .init(
+        calendarItemModel: MockCalendarItemModel.variant2,
+        itemType: .layoutItemType(
+          .day(
+            Day(
+              month: Month(era: 1, year: 2020, month: 02, isInGregorianCalendar: true),
+              day: 01))),
+        frame: .zero),
+      .init(
+        calendarItemModel: MockCalendarItemModel.variant3,
+        itemType: .layoutItemType(
+          .day(
+            Day(
+              month: Month(era: 1, year: 2020, month: 02, isInGregorianCalendar: true),
+              day: 01))),
+        frame: .zero),
+    ]
+
+    let subsequentVisibleItems: Set<VisibleItem> = [
+      .init(
+        calendarItemModel: MockCalendarItemModel.variant1,
+        itemType: .layoutItemType(
+          .day(
+            Day(
+              month: Month(era: 1, year: 2020, month: 05, isInGregorianCalendar: true),
+              day: 01))),
+        frame: .zero),
+      .init(
+        calendarItemModel: MockCalendarItemModel.variant3,
+        itemType: .layoutItemType(
+          .day(
+            Day(
+              month: Month(era: 1, year: 2020, month: 05, isInGregorianCalendar: true),
+              day: 01))),
+        frame: .zero),
+      .init(
+        calendarItemModel: MockCalendarItemModel.variant4,
+        itemType: .layoutItemType(
+          .monthHeader(Month(era: 1, year: 2020, month: 04, isInGregorianCalendar: true))),
+        frame: .zero),
+      .init(
+        calendarItemModel: MockCalendarItemModel.variant5,
+        itemType: .layoutItemType(
+          .monthHeader(Month(era: 1, year: 2020, month: 05, isInGregorianCalendar: true))),
+        frame: .zero),
+    ]
+
+    // Populate the reuse manager with the initial visible items
+    reuseManager.viewsForVisibleItems(
+      initialVisibleItems,
+      recycleOldViews: false,
+      viewHandler: { _, _, _, _ in })
+
+    // Ensure the correct subset of views are reused given the subsequent visible items
+    reuseManager.viewsForVisibleItems(
+      subsequentVisibleItems,
+      recycleOldViews: false,
+      viewHandler: { _, item, previousBackingItem, isReusedViewSameAsPreviousView in
+        guard let itemModel = item.calendarItemModel as? MockCalendarItemModel else {
+          preconditionFailure(
+            "Failed to convert the calendar item model to an instance of MockCalendarItemModel.")
+        }
+
+        switch itemModel {
+        case .variant1, .variant3:
+          XCTAssert(
+            previousBackingItem == nil,
+            "Previous backing item should be nil since view recycling is disabled.")
+          XCTAssert(
+            !isReusedViewSameAsPreviousView,
+            "isReusedViewSameAsPreviousView should be false when a different view was reused.")
+        default:
+          XCTAssert(
+            previousBackingItem == nil,
+            "Previous backing item should be nil since there are no views to reuse.")
+          XCTAssert(
+            !isReusedViewSameAsPreviousView,
+            "isReusedViewSameAsPreviousView should be false when a different view was reused.")
+        }
+      })
   }
 
   // MARK: Private


### PR DESCRIPTION
## Details

This PR makes further accessibility improvements. The main thing here is that we no longer post `.layoutChanged` or `.screenChanged` notifications to force focus, and instead rely on UIScrollView to handle maintaining element focus for us (which works well, as long as views aren't reused!).

Speaking of that, this disables view recycling when voice over is active. This greatly simplifies things, and removes the need to constantly try to regain control over the focus. I should have thought of this sooner 🫠 We still have flat memory usage since off-screen views are simply deallocated. We pay a small CPU performance price, but Voice Over users won't be scrolling super fast anyways, so the tradeoff seems good. The overall UX for Voice Over users is significantly improved since focus never temporarily jumps around.

## Related Issue

N/A

## Motivation and Context

Improve VO UX

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
