### PR TITLE
Make DayComponentRange initializer public to support pre-selected date range in the calendar.

### DIFF
--- a/Sources/Public/DayRange.swift
+++ b/Sources/Public/DayRange.swift
@@ -27,7 +27,7 @@ extension DayComponentsRange {
 
   /// Instantiates a `DayRange` that encapsulates the `dateRange` in the `calendar` as closely as possible. For example,
   /// a date range of [2020-05-20T23:59:59, 2021-01-01T00:00:00] will result in a day range of [2020-05-20, 2021-01-01].
-  init(containing dateRange: ClosedRange<Date>, in calendar: Calendar) {
+  public init(containing dateRange: ClosedRange<Date>, in calendar: Calendar) {
     self.init(
       uncheckedBounds: (
         lower: calendar.day(containing: dateRange.lowerBound),


### PR DESCRIPTION
## Details

Make initializer of DayComponentRange with Date range public

## Related Issue

[programmatically update de selection range](https://github.com/airbnb/HorizonCalendar/issues/230)

## Motivation and Context

In the application that I am currently developing there is a need for a calendar with a selection of date ranges. In this case, I need to pass the date range already selected by the user to the calendar itself, and he can edit it. In your example you use DayComponentsRange to represent date ranges, this is very convenient and works for me. But I can't initialize it with Date objects. So I'll just make initializer public

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
