### PR TITLE
Public initialisers for DayComponent and MonthComponent to support pre-selected date range in the calendar.

### DIFF
--- a/Sources/Public/Day.swift
+++ b/Sources/Public/Day.swift
@@ -44,6 +44,14 @@ public struct DayComponents: Hashable {
 
 }
 
+extension DayComponents {
+    public init(from date: Date, calendar: Calendar = Calendar.current) {
+        let month = Month(from: date, calendar: calendar)
+        let day = calendar.component(.day, from: date)
+        self = Day(month: month, day: day)
+    }
+}
+
 // MARK: CustomStringConvertible
 
 extension DayComponents: CustomStringConvertible {

--- a/Sources/Public/Day.swift
+++ b/Sources/Public/Day.swift
@@ -44,6 +44,8 @@ public struct DayComponents: Hashable {
 
 }
 
+// MARK: Public init from date
+
 extension DayComponents {
     public init(from date: Date, calendar: Calendar = Calendar.current) {
         let month = Month(from: date, calendar: calendar)

--- a/Sources/Public/Month.swift
+++ b/Sources/Public/Month.swift
@@ -53,6 +53,12 @@ public struct MonthComponents: Hashable {
 
 }
 
+extension MonthComponents {
+    public init(from date: Date, calendar: Calendar = Calendar.current) {
+     self = calendar.month(containing: date)
+  }
+}
+
 // MARK: CustomStringConvertible
 
 extension MonthComponents: CustomStringConvertible {

--- a/Sources/Public/Month.swift
+++ b/Sources/Public/Month.swift
@@ -53,6 +53,8 @@ public struct MonthComponents: Hashable {
 
 }
 
+// MARK: Public init from date
+
 extension MonthComponents {
     public init(from date: Date, calendar: Calendar = Calendar.current) {
      self = calendar.month(containing: date)

--- a/Tests/DayHelperTests.swift
+++ b/Tests/DayHelperTests.swift
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 import XCTest
+
 @testable import HorizonCalendar
 
 // MARK: - DayHelperTests
@@ -25,101 +26,129 @@ final class DayHelperTests: XCTestCase {
   func testDayComparable() {
     let january2020Day = Day(
       month: Month(era: 1, year: 2020, month: 01, isInGregorianCalendar: true),
-      day: 19)
+      day: 19
+    )
     let december2020Day = Day(
       month: Month(era: 1, year: 2020, month: 12, isInGregorianCalendar: true),
-      day: 05)
+      day: 05
+    )
     XCTAssert(january2020Day < december2020Day, "Expected January 19, 2020 < December 5, 2020.")
 
     let june0006Day = Day(
       month: Month(era: 0, year: 0006, month: 06, isInGregorianCalendar: true),
-      day: 10)
+      day: 10
+    )
     let january0005Day = Day(
       month: Month(era: 1, year: 0005, month: 01, isInGregorianCalendar: true),
-      day: 09)
+      day: 09
+    )
     XCTAssert(june0006Day < january0005Day, "Expected June 10, 0006 BCE < January 9, 0005 CE.")
 
     let june30Day = Day(
       month: Month(era: 235, year: 30, month: 06, isInGregorianCalendar: false),
-      day: 25)
+      day: 25
+    )
     let august01Day = Day(
       month: Month(era: 236, year: 01, month: 08, isInGregorianCalendar: false),
-      day: 30)
+      day: 30
+    )
     XCTAssert(june30Day < august01Day, "Expected June 30, 30 era 235 < August 30, 02 era 236.")
   }
 
   func testDayContainingDate() {
     let january2020Date = gregorianCalendar.date(
-      from: DateComponents(year: 2020, month: 01, day: 19))!
+      from: DateComponents(year: 2020, month: 01, day: 19)
+    )!
     let january2020Day = Day(
       month: Month(era: 1, year: 2020, month: 01, isInGregorianCalendar: true),
-      day: 19)
+      day: 19
+    )
     XCTAssert(
       gregorianCalendar.day(containing: january2020Date) == january2020Day,
-      "Expected the day to be January 19, 2020.")
+      "Expected the day to be January 19, 2020."
+    )
 
     let december0005Date = gregorianCalendar.date(
-      from: DateComponents(era: 0, year: 0005, month: 12, day: 08))!
+      from: DateComponents(era: 0, year: 0005, month: 12, day: 08)
+    )!
     let december0005Day = Day(
       month: Month(era: 0, year: 0005, month: 12, isInGregorianCalendar: true),
-      day: 08)
+      day: 08
+    )
     XCTAssert(
       gregorianCalendar.day(containing: december0005Date) == december0005Day,
-      "Expected the day to be December 8, 0005.")
+      "Expected the day to be December 8, 0005."
+    )
 
     let september02Date = japaneseCalendar.date(
-      from: DateComponents(era: 236, year: 02, month: 09, day: 21))!
+      from: DateComponents(era: 236, year: 02, month: 09, day: 21)
+    )!
     let september02Day = Day(
       month: Month(era: 236, year: 02, month: 09, isInGregorianCalendar: false),
-      day: 21)
+      day: 21
+    )
     XCTAssert(
       japaneseCalendar.day(containing: september02Date) == september02Day,
-      "Expected the day to be September 21, 02.")
+      "Expected the day to be September 21, 02."
+    )
   }
 
   func testStartDateOfDay() {
     let november2020Day = Day(
       month: Month(era: 1, year: 2020, month: 11, isInGregorianCalendar: true),
-      day: 17)
+      day: 17
+    )
     let november2020Date = gregorianCalendar.date(
-      from: DateComponents(year: 2020, month: 11, day: 17))!
+      from: DateComponents(year: 2020, month: 11, day: 17)
+    )!
     XCTAssert(
       gregorianCalendar.startDate(of: november2020Day) == november2020Date,
-      "Expected the date to be the earliest possible time for November 17, 2020.")
+      "Expected the date to be the earliest possible time for November 17, 2020."
+    )
 
     let january0100Day = Day(
       month: Month(era: 0, year: 0100, month: 01, isInGregorianCalendar: true),
-      day: 14)
+      day: 14
+    )
     let january0100Date = gregorianCalendar.date(
-      from: DateComponents(era: 0, year: 0100, month: 01, day: 14))!
+      from: DateComponents(era: 0, year: 0100, month: 01, day: 14)
+    )!
     XCTAssert(
       gregorianCalendar.startDate(of: january0100Day) == january0100Date,
-      "Expected the date to be the earliest possible time for January 14, 0100 BCE.")
+      "Expected the date to be the earliest possible time for January 14, 0100 BCE."
+    )
 
     let june02Day = Day(
       month: Month(era: 236, year: 02, month: 06, isInGregorianCalendar: false),
-      day: 11)
+      day: 11
+    )
     let june02Date = japaneseCalendar.date(
-      from: DateComponents(era: 236, year: 02, month: 06, day: 11))!
+      from: DateComponents(era: 236, year: 02, month: 06, day: 11)
+    )!
     XCTAssert(
       japaneseCalendar.startDate(of: june02Day) == june02Date,
-      "Expected the date to be the earliest possible time for June 11, 02.")
+      "Expected the date to be the earliest possible time for June 11, 02."
+    )
   }
 
   func testDayByAddingDays() {
     let january2021Day = Day(
       month: Month(era: 1, year: 2021, month: 01, isInGregorianCalendar: true),
-      day: 19)
+      day: 19
+    )
     let june2020Day = Day(
       month: Month(era: 1, year: 2020, month: 11, isInGregorianCalendar: true),
-      day: 16)
+      day: 16
+    )
     XCTAssert(
       gregorianCalendar.day(byAddingDays: -64, to: january2021Day) == june2020Day,
-      "Expected January 19, 2021 - 100 = June 16, 2020.")
+      "Expected January 19, 2021 - 100 = June 16, 2020."
+    )
 
     let april0069Day = Day(
       month: Month(era: 0, year: 0069, month: 04, isInGregorianCalendar: true),
-      day: 20)
+      day: 20
+    )
     let may0069Day = Day(
       month: Month(era: 0, year: 0069, month: 05, isInGregorianCalendar: true),
       day: 01)
@@ -135,7 +164,25 @@ final class DayHelperTests: XCTestCase {
       day: 31)
     XCTAssert(
       japaneseCalendar.day(byAddingDays: -1, to: january02Day) == december01Day,
-      "Expected January 1, 02 - 1 = December 31, 01.")
+      "Expected January 1, 02 - 1 = December 31, 01."
+    )
+  }
+
+  func testCreateDayFromDate() {
+    var components = DateComponents()
+    components.era = 1
+    components.year = 2020
+    components.month = 03
+    components.day = 02
+    guard let date = gregorianCalendar.date(from: components) else {
+      XCTFail("Expected a date created from components")
+      return
+    }
+    let day = Day(from: date)
+    XCTAssert(
+      day == Day(month: Month(era: 1, year: 2020, month: 03, isInGregorianCalendar: true), day: 02),
+      "Expected 2020-03."
+    )
   }
 
   // MARK: Private

--- a/Tests/DayHelperTests.swift
+++ b/Tests/DayHelperTests.swift
@@ -14,7 +14,6 @@
 // limitations under the License.
 
 import XCTest
-
 @testable import HorizonCalendar
 
 // MARK: - DayHelperTests
@@ -26,129 +25,101 @@ final class DayHelperTests: XCTestCase {
   func testDayComparable() {
     let january2020Day = Day(
       month: Month(era: 1, year: 2020, month: 01, isInGregorianCalendar: true),
-      day: 19
-    )
+      day: 19)
     let december2020Day = Day(
       month: Month(era: 1, year: 2020, month: 12, isInGregorianCalendar: true),
-      day: 05
-    )
+      day: 05)
     XCTAssert(january2020Day < december2020Day, "Expected January 19, 2020 < December 5, 2020.")
 
     let june0006Day = Day(
       month: Month(era: 0, year: 0006, month: 06, isInGregorianCalendar: true),
-      day: 10
-    )
+      day: 10)
     let january0005Day = Day(
       month: Month(era: 1, year: 0005, month: 01, isInGregorianCalendar: true),
-      day: 09
-    )
+      day: 09)
     XCTAssert(june0006Day < january0005Day, "Expected June 10, 0006 BCE < January 9, 0005 CE.")
 
     let june30Day = Day(
       month: Month(era: 235, year: 30, month: 06, isInGregorianCalendar: false),
-      day: 25
-    )
+      day: 25)
     let august01Day = Day(
       month: Month(era: 236, year: 01, month: 08, isInGregorianCalendar: false),
-      day: 30
-    )
+      day: 30)
     XCTAssert(june30Day < august01Day, "Expected June 30, 30 era 235 < August 30, 02 era 236.")
   }
 
   func testDayContainingDate() {
     let january2020Date = gregorianCalendar.date(
-      from: DateComponents(year: 2020, month: 01, day: 19)
-    )!
+      from: DateComponents(year: 2020, month: 01, day: 19))!
     let january2020Day = Day(
       month: Month(era: 1, year: 2020, month: 01, isInGregorianCalendar: true),
-      day: 19
-    )
+      day: 19)
     XCTAssert(
       gregorianCalendar.day(containing: january2020Date) == january2020Day,
-      "Expected the day to be January 19, 2020."
-    )
+      "Expected the day to be January 19, 2020.")
 
     let december0005Date = gregorianCalendar.date(
-      from: DateComponents(era: 0, year: 0005, month: 12, day: 08)
-    )!
+      from: DateComponents(era: 0, year: 0005, month: 12, day: 08))!
     let december0005Day = Day(
       month: Month(era: 0, year: 0005, month: 12, isInGregorianCalendar: true),
-      day: 08
-    )
+      day: 08)
     XCTAssert(
       gregorianCalendar.day(containing: december0005Date) == december0005Day,
-      "Expected the day to be December 8, 0005."
-    )
+      "Expected the day to be December 8, 0005.")
 
     let september02Date = japaneseCalendar.date(
-      from: DateComponents(era: 236, year: 02, month: 09, day: 21)
-    )!
+      from: DateComponents(era: 236, year: 02, month: 09, day: 21))!
     let september02Day = Day(
       month: Month(era: 236, year: 02, month: 09, isInGregorianCalendar: false),
-      day: 21
-    )
+      day: 21)
     XCTAssert(
       japaneseCalendar.day(containing: september02Date) == september02Day,
-      "Expected the day to be September 21, 02."
-    )
+      "Expected the day to be September 21, 02.")
   }
 
   func testStartDateOfDay() {
     let november2020Day = Day(
       month: Month(era: 1, year: 2020, month: 11, isInGregorianCalendar: true),
-      day: 17
-    )
+      day: 17)
     let november2020Date = gregorianCalendar.date(
-      from: DateComponents(year: 2020, month: 11, day: 17)
-    )!
+      from: DateComponents(year: 2020, month: 11, day: 17))!
     XCTAssert(
       gregorianCalendar.startDate(of: november2020Day) == november2020Date,
-      "Expected the date to be the earliest possible time for November 17, 2020."
-    )
+      "Expected the date to be the earliest possible time for November 17, 2020.")
 
     let january0100Day = Day(
       month: Month(era: 0, year: 0100, month: 01, isInGregorianCalendar: true),
-      day: 14
-    )
+      day: 14)
     let january0100Date = gregorianCalendar.date(
-      from: DateComponents(era: 0, year: 0100, month: 01, day: 14)
-    )!
+      from: DateComponents(era: 0, year: 0100, month: 01, day: 14))!
     XCTAssert(
       gregorianCalendar.startDate(of: january0100Day) == january0100Date,
-      "Expected the date to be the earliest possible time for January 14, 0100 BCE."
-    )
+      "Expected the date to be the earliest possible time for January 14, 0100 BCE.")
 
     let june02Day = Day(
       month: Month(era: 236, year: 02, month: 06, isInGregorianCalendar: false),
-      day: 11
-    )
+      day: 11)
     let june02Date = japaneseCalendar.date(
-      from: DateComponents(era: 236, year: 02, month: 06, day: 11)
-    )!
+      from: DateComponents(era: 236, year: 02, month: 06, day: 11))!
     XCTAssert(
       japaneseCalendar.startDate(of: june02Day) == june02Date,
-      "Expected the date to be the earliest possible time for June 11, 02."
-    )
+      "Expected the date to be the earliest possible time for June 11, 02.")
   }
 
   func testDayByAddingDays() {
     let january2021Day = Day(
       month: Month(era: 1, year: 2021, month: 01, isInGregorianCalendar: true),
-      day: 19
-    )
+      day: 19)
     let june2020Day = Day(
       month: Month(era: 1, year: 2020, month: 11, isInGregorianCalendar: true),
-      day: 16
-    )
+      day: 16)
     XCTAssert(
       gregorianCalendar.day(byAddingDays: -64, to: january2021Day) == june2020Day,
-      "Expected January 19, 2021 - 100 = June 16, 2020."
-    )
+      "Expected January 19, 2021 - 100 = June 16, 2020.")
 
     let april0069Day = Day(
       month: Month(era: 0, year: 0069, month: 04, isInGregorianCalendar: true),
-      day: 20
-    )
+      day: 20)
     let may0069Day = Day(
       month: Month(era: 0, year: 0069, month: 05, isInGregorianCalendar: true),
       day: 01)
@@ -164,8 +135,7 @@ final class DayHelperTests: XCTestCase {
       day: 31)
     XCTAssert(
       japaneseCalendar.day(byAddingDays: -1, to: january02Day) == december01Day,
-      "Expected January 1, 02 - 1 = December 31, 01."
-    )
+      "Expected January 1, 02 - 1 = December 31, 01.")
   }
 
   func testCreateDayFromDate() {

--- a/Tests/MonthTests.swift
+++ b/Tests/MonthTests.swift
@@ -54,6 +54,19 @@ final class MonthTests: XCTestCase {
       to: Month(era: 1, year: 2020, month: 06, isInGregorianCalendar: true))
     XCTAssert(month2 == Month(era: 1, year: 2018, month: 05, isInGregorianCalendar: true), "Expected 2018-05.")
   }
+    
+    func testCreateMonthFromDate() {
+        var components = DateComponents()
+        components.era = 1
+        components.year = 2020
+        components.month = 03
+        guard let date = calendar.date(from: components) else {
+            XCTFail("Expected a date created from components")
+            return
+        }
+        let month = Month(from: date)
+        XCTAssert(month == Month(era: 1, year: 2020, month: 03, isInGregorianCalendar: true), "Expected 2020-03.")
+    }
 
   // MARK: Private
 


### PR DESCRIPTION
## Details

Added a extension to `DayComponent` and `MonthComponent` with a public initialiser.

## Related Issue

- [Programmatically update de selection range](https://github.com/airbnb/HorizonCalendar/issues/230)
- [Make DayComponentRange initializer public to support pre-selected date range in the calendar](https://github.com/airbnb/HorizonCalendar/pull/298)

## Motivation and Context

We found the need to programatically select dates in the calendar without user interaction, due to the initialiser for `DayComponent` and `MonthComponent` it's not possible for us to initialise a `DateComponentRange`. To adres this we created new public initialisers for those models.

## How Has This Been Tested

- Running the app and displaying a pre-selected date range in HorizonCalendar.
- Updating the pre-selected range to ensure user interaction works fine.
- Running all the tests.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
