### PR TITLE
Bk/optimize view reuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Rewrote accessibility code to avoid posting notifications, which causes poor Voice Over performance and odd focus bugs
+- Rewrote `ItemViewReuseManager` to perform fewer set operations, improving CPU usage by ~15% when scrolling quickly on an iPhone XR
 
 ## [v2.0.0](https://github.com/airbnb/HorizonCalendar/compare/v1.16.0...v2.0.0) - 2023-12-19
 

--- a/Sources/Internal/ItemViewReuseManager.swift
+++ b/Sources/Internal/ItemViewReuseManager.swift
@@ -23,139 +23,67 @@ final class ItemViewReuseManager {
 
   // MARK: Internal
 
-  func viewsForVisibleItems(
-    _ visibleItems: Set<VisibleItem>,
-    recycleUnusedViews: Bool,
-    viewHandler: (
-      ItemView,
-      VisibleItem,
-      _ previousBackingVisibleItem: VisibleItem?,
-      _ isReusedViewSameAsPreviousView: Bool)
-      -> Void)
+  func reusedViewContexts(
+    visibleItems: Set<VisibleItem>,
+    reuseUnusedViews: Bool)
+    -> [ReusedViewContext]
   {
-    var visibleItemsDifferencesItemViewDifferentiators = [
-      _CalendarItemViewDifferentiator: Set<VisibleItem>
-    ]()
+    var contexts = [ReusedViewContext]()
 
-    // For each reuse ID, track the difference between the new set of visible items and the previous
-    // set of visible items. The remaining previous visible items after subtracting the current
-    // visible items are the previously visible items that aren't currently visible, and are
-    // therefore free to be reused.
+    var previousViewsForVisibleItems = viewsForVisibleItems
+    viewsForVisibleItems.removeAll(keepingCapacity: true)
+
     for visibleItem in visibleItems {
-      let differentiator = visibleItem.calendarItemModel._itemViewDifferentiator
+      let viewDifferentiator = visibleItem.calendarItemModel._itemViewDifferentiator
 
-      var visibleItemsDifference: Set<VisibleItem>
-      if let difference = visibleItemsDifferencesItemViewDifferentiators[differentiator] {
-        visibleItemsDifference = difference
-      } else if
-        let previouslyVisibleItems = visibleItemsForItemViewDifferentiators[differentiator]
-      {
-        visibleItemsDifference = previouslyVisibleItems.subtracting(visibleItems)
-      } else {
-        visibleItemsDifference = []
-      }
+      let context: ReusedViewContext =
+        if let view = previousViewsForVisibleItems.removeValue(forKey: visibleItem) {
+          ReusedViewContext(
+            view: view,
+            visibleItem: visibleItem,
+            isViewReused: true,
+            isReusedViewSameAsPreviousView: true)
+        } else if !(unusedViewsForViewDifferentiators[viewDifferentiator]?.isEmpty ?? true) {
+          ReusedViewContext(
+            view: unusedViewsForViewDifferentiators[viewDifferentiator]!.remove(at: 0),
+            visibleItem: visibleItem,
+            isViewReused: true,
+            isReusedViewSameAsPreviousView: false)
+        } else {
+          ReusedViewContext(
+            view: ItemView(initialCalendarItemModel: visibleItem.calendarItemModel),
+            visibleItem: visibleItem,
+            isViewReused: false,
+            isReusedViewSameAsPreviousView: false)
+        }
 
-      let context = reusedViewContext(
-        for: visibleItem,
-        recycleUnusedViews: recycleUnusedViews,
-        unusedPreviouslyVisibleItems: &visibleItemsDifference)
-      viewHandler(
-        context.view,
-        visibleItem,
-        context.previousBackingVisibleItem,
-        context.isReusedViewSameAsPreviousView)
+      contexts.append(context)
 
-      visibleItemsDifferencesItemViewDifferentiators[differentiator] = visibleItemsDifference
+      viewsForVisibleItems[visibleItem] = context.view
     }
+
+    if reuseUnusedViews {
+      for (visibleItem, unusedView) in previousViewsForVisibleItems {
+        let viewDifferentiator = visibleItem.calendarItemModel._itemViewDifferentiator
+        unusedViewsForViewDifferentiators[viewDifferentiator, default: .init()].append(unusedView)
+      }
+    }
+
+    return contexts
   }
 
   // MARK: Private
 
-  private var visibleItemsForItemViewDifferentiators = [
-    _CalendarItemViewDifferentiator: Set<VisibleItem>
-  ]()
   private var viewsForVisibleItems = [VisibleItem: ItemView]()
-
-  private func reusedViewContext(
-    for visibleItem: VisibleItem,
-    recycleUnusedViews: Bool,
-    unusedPreviouslyVisibleItems: inout Set<VisibleItem>)
-    -> ReusedViewContext
-  {
-    let differentiator = visibleItem.calendarItemModel._itemViewDifferentiator
-
-    let view: ItemView
-    let previousBackingVisibleItem: VisibleItem?
-    let isReusedViewSameAsPreviousView: Bool
-
-    if let previouslyVisibleItems = visibleItemsForItemViewDifferentiators[differentiator] {
-      if previouslyVisibleItems.contains(visibleItem) {
-        // New visible item was also an old visible item, so we can just use the same view again.
-
-        guard let previousView = viewsForVisibleItems[visibleItem] else {
-          preconditionFailure("""
-              `viewsForVisibleItems` must have a key for every member in
-              `visibleItemsForItemViewDifferentiators`'s values.
-            """)
-        }
-
-        view = previousView
-        previousBackingVisibleItem = visibleItem
-        isReusedViewSameAsPreviousView = true
-
-        visibleItemsForItemViewDifferentiators[differentiator]?.remove(visibleItem)
-        viewsForVisibleItems.removeValue(forKey: visibleItem)
-      } else {
-        if recycleUnusedViews, let previouslyVisibleItem = unusedPreviouslyVisibleItems.first {
-          // An unused, previously-visible item is available, so reuse it.
-
-          guard let previousView = viewsForVisibleItems[previouslyVisibleItem] else {
-            preconditionFailure("""
-                `viewsForVisibleItems` must have a key for every member in
-                `visibleItemsForItemViewDifferentiators`'s values.
-              """)
-          }
-
-          view = previousView
-          previousBackingVisibleItem = previouslyVisibleItem
-          isReusedViewSameAsPreviousView = false
-
-          unusedPreviouslyVisibleItems.remove(previouslyVisibleItem)
-
-          visibleItemsForItemViewDifferentiators[differentiator]?.remove(previouslyVisibleItem)
-          viewsForVisibleItems.removeValue(forKey: previouslyVisibleItem)
-        } else {
-          // No previously-visible item is available for reuse (or view recycling is disabled), so
-          // create a new view.
-          view = ItemView(initialCalendarItemModel: visibleItem.calendarItemModel)
-          previousBackingVisibleItem = nil
-          isReusedViewSameAsPreviousView = false
-        }
-      }
-    } else {
-      // No previously-visible item is available for reuse, so create a new view.
-      view = ItemView(initialCalendarItemModel: visibleItem.calendarItemModel)
-      previousBackingVisibleItem = nil
-      isReusedViewSameAsPreviousView = false
-    }
-
-    let newVisibleItems = visibleItemsForItemViewDifferentiators[differentiator] ?? []
-    visibleItemsForItemViewDifferentiators[differentiator] = newVisibleItems
-    visibleItemsForItemViewDifferentiators[differentiator]?.insert(visibleItem)
-    viewsForVisibleItems[visibleItem] = view
-
-    return ReusedViewContext(
-      view: view,
-      previousBackingVisibleItem: previousBackingVisibleItem,
-      isReusedViewSameAsPreviousView: isReusedViewSameAsPreviousView)
-  }
+  private var unusedViewsForViewDifferentiators = [_CalendarItemViewDifferentiator: [ItemView]]()
 
 }
 
 // MARK: - ReusedViewContext
 
-private struct ReusedViewContext {
+struct ReusedViewContext {
   let view: ItemView
-  let previousBackingVisibleItem: VisibleItem?
+  let visibleItem: VisibleItem
+  let isViewReused: Bool
   let isReusedViewSameAsPreviousView: Bool
 }

--- a/Sources/Internal/ItemViewReuseManager.swift
+++ b/Sources/Internal/ItemViewReuseManager.swift
@@ -37,25 +37,26 @@ final class ItemViewReuseManager {
       let viewDifferentiator = visibleItem.calendarItemModel._itemViewDifferentiator
 
       let context: ReusedViewContext =
-        if let view = previousViewsForVisibleItems.removeValue(forKey: visibleItem) {
-          ReusedViewContext(
-            view: view,
-            visibleItem: visibleItem,
-            isViewReused: true,
-            isReusedViewSameAsPreviousView: true)
-        } else if !(unusedViewsForViewDifferentiators[viewDifferentiator]?.isEmpty ?? true) {
-          ReusedViewContext(
-            view: unusedViewsForViewDifferentiators[viewDifferentiator]!.remove(at: 0),
-            visibleItem: visibleItem,
-            isViewReused: true,
-            isReusedViewSameAsPreviousView: false)
-        } else {
-          ReusedViewContext(
-            view: ItemView(initialCalendarItemModel: visibleItem.calendarItemModel),
-            visibleItem: visibleItem,
-            isViewReused: false,
-            isReusedViewSameAsPreviousView: false)
-        }
+        if let view = previousViewsForVisibleItems.removeValue(forKey: visibleItem)
+      {
+        ReusedViewContext(
+          view: view,
+          visibleItem: visibleItem,
+          isViewReused: true,
+          isReusedViewSameAsPreviousView: true)
+      } else if !(unusedViewsForViewDifferentiators[viewDifferentiator]?.isEmpty ?? true) {
+        ReusedViewContext(
+          view: unusedViewsForViewDifferentiators[viewDifferentiator]!.remove(at: 0),
+          visibleItem: visibleItem,
+          isViewReused: true,
+          isReusedViewSameAsPreviousView: false)
+      } else {
+        ReusedViewContext(
+          view: ItemView(initialCalendarItemModel: visibleItem.calendarItemModel),
+          visibleItem: visibleItem,
+          isViewReused: false,
+          isReusedViewSameAsPreviousView: false)
+      }
 
       contexts.append(context)
 

--- a/Sources/Public/AnyCalendarItemModel.swift
+++ b/Sources/Public/AnyCalendarItemModel.swift
@@ -54,7 +54,6 @@ public protocol AnyCalendarItemModel {
 ///
 /// - Note: There is no reason to create an instance of this enum from your feature code; it should only be invoked internally.
 public struct _CalendarItemViewDifferentiator: Hashable {
-  let viewRepresentableTypeDescription: String
-  let viewTypeDescription: String
+  let viewType: ObjectIdentifier
   let invariantViewProperties: AnyHashable
 }

--- a/Sources/Public/CalendarItemModel.swift
+++ b/Sources/Public/CalendarItemModel.swift
@@ -46,8 +46,7 @@ public struct CalendarItemModel<ViewRepresentable>: AnyCalendarItemModel where
     content: ViewRepresentable.Content)
   {
     _itemViewDifferentiator = _CalendarItemViewDifferentiator(
-      viewRepresentableTypeDescription: String(reflecting: ViewRepresentable.self),
-      viewTypeDescription: String(reflecting: ViewRepresentable.ViewType.self),
+      viewType: ObjectIdentifier(ViewRepresentable.self),
       invariantViewProperties: invariantViewProperties)
 
     self.invariantViewProperties = invariantViewProperties
@@ -115,8 +114,7 @@ extension CalendarItemModel where ViewRepresentable.Content == Never {
   ///   and `font`, assuming none of those values change in response to `content` updates.
   public init(invariantViewProperties: ViewRepresentable.InvariantViewProperties) {
     _itemViewDifferentiator = _CalendarItemViewDifferentiator(
-      viewRepresentableTypeDescription: String(reflecting: ViewRepresentable.self),
-      viewTypeDescription: String(reflecting: ViewRepresentable.ViewType.self),
+      viewType: ObjectIdentifier(ViewRepresentable.self),
       invariantViewProperties: invariantViewProperties)
 
     self.invariantViewProperties = invariantViewProperties


### PR DESCRIPTION
## Details

This reduced the number of `Set` operations in the ItemViewReuseManager, reducing CPU usage by about 15% (65% -> 50%) when scrolling fast on an iPhone XR.

## Related Issue

N/A

## Motivation and Context

Performance improvement work

## How Has This Been Tested

Example app

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
