### PR TITLE
Add visibleMonthRange and visibleDayRange to proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added support for disabling touch handling on SwiftUI views via the `allowsHitTesting` modifier
 - Added SwiftUI documentation to the README.md
+- Added properties to `CalendarViewProxy` for getting the `visibleMonthRange` and `visibleDayRange` 
 
 ### Fixed
 - Fixed an issue that could cause accessibility focus to shift unexpectedly

--- a/Sources/Public/CalendarViewProxy.swift
+++ b/Sources/Public/CalendarViewProxy.swift
@@ -26,6 +26,16 @@ public final class CalendarViewProxy: ObservableObject {
 
   // MARK: Public
 
+  /// The range of months that are partially of fully visible.
+  public var visibleMonthRange: MonthComponentsRange? {
+    calendarView.visibleMonthRange
+  }
+
+  /// The range of months that are partially of fully visible.
+  public var visibleDayRange: DayComponentsRange? {
+    calendarView.visibleDayRange
+  }
+
   /// Scrolls the calendar to the specified month with the specified position.
   ///
   /// If the calendar has a non-zero frame, this function will scroll to the specified month immediately. Otherwise the scroll-to-month

--- a/Sources/Public/CalendarViewProxy.swift
+++ b/Sources/Public/CalendarViewProxy.swift
@@ -31,7 +31,7 @@ public final class CalendarViewProxy: ObservableObject {
     calendarView.visibleMonthRange
   }
 
-  /// The range of months that are partially of fully visible.
+  /// The range of months that are partially or fully visible.
   public var visibleDayRange: DayComponentsRange? {
     calendarView.visibleDayRange
   }

--- a/Sources/Public/CalendarViewProxy.swift
+++ b/Sources/Public/CalendarViewProxy.swift
@@ -26,7 +26,7 @@ public final class CalendarViewProxy: ObservableObject {
 
   // MARK: Public
 
-  /// The range of months that are partially of fully visible.
+  /// The range of months that are partially or fully visible.
   public var visibleMonthRange: MonthComponentsRange? {
     calendarView.visibleMonthRange
   }


### PR DESCRIPTION
## Details

Adds properties for getting the visible month and day range on `CalendarViewProxy`.

## Related Issue

N/A

## Motivation and Context

Filling a gap in the SwiftUI API

## How Has This Been Tested

Example app

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
