### PR TITLE
Fix sizing month header on every frame and add more calendar model caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed an issue that could cause accessibility focus to shift unexpectedly
 - Fixed a screen-pixel alignment issue
+- Fixed a performance issue caused by month headers recalculating their size too often
+- Fixed a performance issue caused by the item models for day ranges and month backgrounds not being cached
 
 ### Changed
 - Rewrote accessibility code to avoid posting notifications, which causes poor Voice Over performance and odd focus bugs


### PR DESCRIPTION
## Details

This PR fixes 2 issues:

1. I was never caching the result of self-sizing a month header, causing us to call systemLayoutSizeFitting on every frame 💀
2. We weren't caching calendar item models for some calendar slots, like for day ranges and month backgrounds

## Related Issue

N/A

## Motivation and Context

Performance improvements

## How Has This Been Tested

Example app, Airbnb app