### PR TITLE
Improve SwiftUIWrapperView performance

### DIFF
--- a/Sources/Public/ItemViews/SwiftUIWrapperView.swift
+++ b/Sources/Public/ItemViews/SwiftUIWrapperView.swift
@@ -29,7 +29,7 @@ public final class SwiftUIWrapperView<Content: View>: UIView {
 
   public init(contentAndID: ContentAndID) {
     self.contentAndID = contentAndID
-    hostingController = UIHostingController(rootView: AnyView(contentAndID.content))
+    hostingController = UIHostingController(rootView: contentAndID.content)
     hostingController._disableSafeArea = true
 
     super.init(frame: .zero)
@@ -59,7 +59,9 @@ public final class SwiftUIWrapperView<Content: View>: UIView {
   public override var isHidden: Bool {
     didSet {
       if isHidden {
-        hostingController.rootView = AnyView(EmptyView())
+        hostingControllerView.removeFromSuperview()
+      } else {
+        addSubview(hostingControllerView)
       }
     }
   }
@@ -99,14 +101,14 @@ public final class SwiftUIWrapperView<Content: View>: UIView {
 
   fileprivate var contentAndID: ContentAndID {
     didSet {
-      hostingController.rootView = AnyView(contentAndID.content)
+      hostingController.rootView = contentAndID.content
       configureGestureRecognizers()
     }
   }
 
   // MARK: Private
 
-  private let hostingController: UIHostingController<AnyView>
+  private let hostingController: UIHostingController<Content>
 
   private var hostingControllerView: UIView {
     hostingController.view


### PR DESCRIPTION
## Details

This is a follow-up to https://github.com/airbnb/HorizonCalendar/pull/320. 

I made the mistake of only testing with a simple view during my performance investigation, which led me to believe that setting the hosting controller's `rootView` to an `Any(EmptyView())` when it went off screen was the best way to get appearance callbacks to work. Although that approach was faster than removing the hosting controller's view from the hierarchy for a very simple view, it gets slower the more complicated the view is. Even a simple `Text` with a background shape is 10% slower if we set the `rootView` to an `Any(EmptyView())` vs. just removing the hosting controller's view from the hierarchy.

I'm assuming this is the case because it's more expensive to tear down and set up a complicated view from scratch vs. whatever price we pay for removing and adding subviews dynamically.

## Related Issue

N/A

## Motivation and Context

Performance improvements

## How Has This Been Tested

Example app, Airbnb app
