### PR TITLE
Fix VisibleItemsProvider.correctedScrollToItemFrameForContentBoundaries

### DIFF
--- a/Sources/Internal/VisibleItemsProvider.swift
+++ b/Sources/Internal/VisibleItemsProvider.swift
@@ -1131,10 +1131,13 @@ final class VisibleItemsProvider {
     case .vertical:
       if
         let contentStartBoundary = context.contentStartBoundary,
-        contentStartBoundary >= bounds.minY || context.contentEndBoundary != nil
+        contentStartBoundary >= bounds.minY ||
+        (context.contentEndBoundary != nil &&
+          ((context.contentEndBoundary! + layoutMargins.bottom) -
+          (contentStartBoundary - layoutMargins.top)) <= bounds.height)
       {
-        // If the `maximumScrollOffset` is also non-nil, then we know the content is smaller than
-        // `bounds.height` and can simply adjust based on the `minimumScrollOffset`.
+        // If the `maximumScrollOffset` is also non-nil and the content is smaller than
+        // `bounds.height`, we can simply adjust based on the `minimumScrollOffset`.
         return proposedFrame.applying(
           .init(translationX: 0, y: bounds.minY - contentStartBoundary + layoutMargins.top))
       } else if
@@ -1150,10 +1153,13 @@ final class VisibleItemsProvider {
     case .horizontal:
       if
         let contentStartBoundary = context.contentStartBoundary,
-        contentStartBoundary >= bounds.minX || context.contentEndBoundary != nil
+        contentStartBoundary >= bounds.minX ||
+        (context.contentEndBoundary != nil &&
+          ((context.contentEndBoundary! + layoutMargins.trailing) -
+          (contentStartBoundary - layoutMargins.leading)) <= bounds.width)
       {
-        // If the `maximumScrollOffset` is also non-nil, then we know the content is smaller than
-        // `bounds.width` and can simply adjust based on the `minimumScrollOffset`.
+        // If the `maximumScrollOffset` is also non-nil and the content is smaller than
+        // `bounds.width`, can simply adjust based on the `minimumScrollOffset`.
         return proposedFrame.applying(
           .init(translationX: bounds.minX - contentStartBoundary + layoutMargins.leading, y: 0))
       } else if


### PR DESCRIPTION
## Details

This fixes the behaviour of VisibleItemsProvider.correctedScrollToItemFrameForContentBoundaries during animated scroll to a date on calendars with scrollable content where all months can be visible at once, fully or partially. 
The main issue is that the calendar scrolls to the very top, when requested to scroll to an arbitrary date of the first month using firstFullyVisiblePosition. 
This is due to an incorrect assumption in VisibleItemsProvider.correctedScrollToItemFrameForContentBoundaries, that if context.contentEndBoundary is known, then content is smaller than `bounds`. There certainly can be cases, when the first and the last months in the calendar are visible (i.e. context.contentStartBoundary and context.contentEndBoundary are known) and the content is still larger than `bounds`. Therefore, we should explicitly check if the content is actually smaller than `bounds`, before adjusting scroll towards `minimumScrollOffset`.

| Before fix | After fix |
| ------- | ------- |
| https://github.com/user-attachments/assets/c05d249b-5d29-4616-9dbb-43874f6e1281 | https://github.com/user-attachments/assets/58be438f-05e0-4ce4-92fb-83b61ea96ed6 |

## Related Issue

N/A

## Motivation and Context

Bug fix / animation improvements

## How Has This Been Tested

Example app. In SingleDaySelectionDemoViewController, update the endDate, so that the visibleDateRange has a span of three months:

`let endDate = calendar.date(from: DateComponents(year: 2020, month: 03, day: 31))!`

and add a call to `scroll` method at the end of `daySelectionHandler`:

```
if let selectedDate {
  calendarView.scroll(toDayContaining: selectedDate, scrollPosition: .firstFullyVisiblePosition, animated: true)
}
```
Build and run.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
