### PR TITLE
Make DayComponents initializer public for external use

### DIFF
--- a/Sources/Public/Day.swift
+++ b/Sources/Public/Day.swift
@@ -28,7 +28,7 @@ public struct DayComponents: Hashable {
 
   // MARK: Lifecycle
 
-  init(month: MonthComponents, day: Int) {
+  public init(month: MonthComponents, day: Int) {
     self.month = month
     self.day = day
   }


### PR DESCRIPTION
## Details

This change updates the access control of the `DayComponents` initializer from `internal` to `public`. This enables developers to instantiate `DayComponents` directly when using the package via Swift Package Manager, which is currently impossible due to the restricted access level.

```swift
// Before
init(month: MonthComponents, day: Int) { ... }

// After
public init(month: MonthComponents, day: Int) { ... }
