### PR TITLE
Fix bug that causes items to disappear if rotating while scrolling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a screen-pixel alignment issue
 - Fixed a performance issue caused by month headers recalculating their size too often
 - Fixed a performance issue caused by the item models for day ranges and month backgrounds not being cached
+- Fixed an issue that could cause the calendar to appear blank after rotating the device
 
 ### Changed
 - Rewrote accessibility code to avoid posting notifications, which causes poor Voice Over performance and odd focus bugs

--- a/Sources/Public/CalendarView.swift
+++ b/Sources/Public/CalendarView.swift
@@ -940,7 +940,6 @@ public final class CalendarView: UIView {
 
   private func maintainScrollPositionAfterBoundsOrMarginsChange() {
     guard
-      !scrollView.isDragging,
       let framesForVisibleMonths = visibleItemsDetails?.framesForVisibleMonths,
       let firstVisibleMonth = visibleMonthRange?.lowerBound,
       let frameOfFirstVisibleMonth = framesForVisibleMonths[firstVisibleMonth]


### PR DESCRIPTION
## Details

Items could disappear if the width of the calendar changed while scrolling. The root cause was that we were using a stale anchor layout item (with an off-screen frame) from _before_ the width change, when we should have generated a new anchor layout item for the new width / bounds.

The logic to do this was already implemented, but we short-circuited if the scroll view was dragging. This logic was wrong. Any time the width changes, we should create a new anchor layout item, regardless of whether a user is dragging the scroll view or not.
