### PR TITLE
Fix hit-testing on iOS 26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a performance issue caused by month headers recalculating their size too often
 - Fixed a performance issue caused by the item models for day ranges and month backgrounds not being cached
 - Fixed an issue that could cause the calendar to appear blank after rotating the device
+- Fixed an issue with touch handling on iOS 26
 
 ### Changed
 - Rewrote accessibility code to avoid posting notifications, which causes poor Voice Over performance and odd focus bugs

--- a/Sources/Public/ItemViews/SwiftUIWrapperView.swift
+++ b/Sources/Public/ItemViews/SwiftUIWrapperView.swift
@@ -68,11 +68,19 @@ public final class SwiftUIWrapperView<Content: View>: UIView {
 
   public override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
     // `_UIHostingView`'s `isUserInteractionEnabled` is not affected by the `allowsHitTesting`
-    // modifier. Its first subview's `isUserInteractionEnabled` _does_ appear to be affected by the
+    // modifier.
+    // Prior to iOS 26, the first subview `isUserInteractionEnabled` _does_ appear to be affected by the
     // `allowsHitTesting` modifier, enabling us to properly ignore touch handling.
+    // Starting with iOS 26, we can check the first sublayer's `allowHitTesting` property.
     if
       let firstSubview = hostingControllerView.subviews.first,
       !firstSubview.isUserInteractionEnabled
+    {
+      return false
+    } else if
+      let firstSublayer = hostingControllerView.layer.sublayers?.first,
+      let allowsHitTesting = firstSublayer.value(forKey: "allowsHitTesting") as? Bool,
+      !allowsHitTesting
     {
       return false
     } else {


### PR DESCRIPTION
## Details

This fixes an issue that causes overlays (like tooltips) to capture touches on iOS 26 and higher, preventing the calendar from being interacted with.

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
