### PR TITLE
Filter non-ItemView subviews out of accessibilityElements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a performance issue caused by the item models for day ranges and month backgrounds not being cached
 - Fixed an issue that could cause the calendar to appear blank after rotating the device
 - Fixed an issue with touch handling on iOS 26
+- Fixed a crash when accessibility is enabled on iOS 27, caused by assuming that every subview of the calendar's scroll view is an item view
 
 ### Changed
 - Rewrote accessibility code to avoid posting notifications, which causes poor Voice Over performance and odd focus bugs

--- a/HorizonCalendar.xcodeproj/project.pbxproj
+++ b/HorizonCalendar.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		086333B02AB8D36900CC6125 /* CalendarContentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 086333AE2AB8D34700CC6125 /* CalendarContentTests.swift */; };
+		AB1200000000000000000002 /* CalendarScrollViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1200000000000000000001 /* CalendarScrollViewTests.swift */; };
 		9321957E26EEB44C0001C7E9 /* DayOfWeekView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9321957D26EEB44C0001C7E9 /* DayOfWeekView.swift */; };
 		9321958026EEB6330001C7E9 /* Shape.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9321957F26EEB6330001C7E9 /* Shape.swift */; };
 		9321958226EEB6AB0001C7E9 /* DrawingConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9321958126EEB6AB0001C7E9 /* DrawingConfig.swift */; };
@@ -88,6 +89,7 @@
 
 /* Begin PBXFileReference section */
 		086333AE2AB8D34700CC6125 /* CalendarContentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarContentTests.swift; sourceTree = "<group>"; };
+		AB1200000000000000000001 /* CalendarScrollViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarScrollViewTests.swift; sourceTree = "<group>"; };
 		9321957D26EEB44C0001C7E9 /* DayOfWeekView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DayOfWeekView.swift; sourceTree = "<group>"; };
 		9321957F26EEB6330001C7E9 /* Shape.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Shape.swift; sourceTree = "<group>"; };
 		9321958126EEB6AB0001C7E9 /* DrawingConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawingConfig.swift; sourceTree = "<group>"; };
@@ -243,6 +245,7 @@
 				939E694D2484B14400A8BCC7 /* VisibleItemsProviderTests.swift */,
 				9396F3D22483261B008AD306 /* Info.plist */,
 				086333AE2AB8D34700CC6125 /* CalendarContentTests.swift */,
+				AB1200000000000000000001 /* CalendarScrollViewTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -487,6 +490,7 @@
 				939E695C2484B22600A8BCC7 /* VisibleItemsProviderTests.swift in Sources */,
 				93A0062C24F206BE00F667A3 /* ItemViewReuseManagerTests.swift in Sources */,
 				086333B02AB8D36900CC6125 /* CalendarContentTests.swift in Sources */,
+				AB1200000000000000000002 /* CalendarScrollViewTests.swift in Sources */,
 				939E69592484B21700A8BCC7 /* LayoutItemTypeEnumeratorTests.swift in Sources */,
 				93FA64F2248D93EA00A8B7B1 /* MonthRowTests.swift in Sources */,
 				932E24142558DF6E001648D2 /* HorizontalMonthsLayoutOptionsTests.swift in Sources */,

--- a/Sources/Internal/CalendarScrollView.swift
+++ b/Sources/Internal/CalendarScrollView.swift
@@ -51,9 +51,9 @@ final class CalendarScrollView: UIScrollView {
 
   override var accessibilityElements: [Any]? {
     get {
-      guard let itemViews = subviews as? [ItemView] else {
-        fatalError("Only `ItemView`s can be used as subviews of the scroll view.")
-      }
+      // UIKit can add subviews of its own - on iOS 27 it adds `_UITouchPassthroughView`s - so we
+      // filter to the item views rather than requiring that every subview is one.
+      let itemViews = subviews.compactMap { $0 as? ItemView }
       cachedAccessibilityElements = cachedAccessibilityElements ?? itemViews
         .filter {
           switch $0.itemType {

--- a/Tests/CalendarScrollViewTests.swift
+++ b/Tests/CalendarScrollViewTests.swift
@@ -1,0 +1,78 @@
+// Created by Andy Bartholomew on 8/12/26.
+// Copyright © 2026 Airbnb Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import XCTest
+@testable import HorizonCalendar
+
+// MARK: - CalendarScrollViewTests
+
+final class CalendarScrollViewTests: XCTestCase {
+
+  // MARK: Internal
+
+  func testAccessibilityElementsIgnoresSubviewsThatAreNotItemViews() {
+    let scrollView = CalendarScrollView()
+    let itemView = itemView(for: .monthHeader(month))
+    scrollView.addSubview(itemView)
+
+    // UIKit adds subviews of its own on some OS versions - `_UITouchPassthroughView`s on iOS 27, for
+    // example - which must not prevent the item views from being returned.
+    scrollView.addSubview(UIView())
+
+    XCTAssertEqual(scrollView.accessibilityElements?.count, 1)
+    XCTAssert(scrollView.accessibilityElements?.first as? ItemView === itemView)
+  }
+
+  func testAccessibilityElementsWithNoItemViews() {
+    let scrollView = CalendarScrollView()
+    scrollView.addSubview(UIView())
+
+    XCTAssertEqual(scrollView.accessibilityElements?.count, 0)
+  }
+
+  // MARK: Private
+
+  private let month = Month(era: 1, year: 2026, month: 08, isInGregorianCalendar: true)
+
+  private func itemView(for itemType: LayoutItem.ItemType) -> ItemView {
+    let itemView = ItemView(initialCalendarItemModel: MockCalendarItemModel())
+    itemView.itemType = .layoutItemType(itemType)
+    return itemView
+  }
+
+}
+
+// MARK: - MockCalendarItemModel
+
+private struct MockCalendarItemModel: AnyCalendarItemModel {
+
+  var _itemViewDifferentiator = _CalendarItemViewDifferentiator(
+    viewType: ObjectIdentifier(UIView.self),
+    invariantViewProperties: AnyHashable(0)
+  )
+
+  func _makeView() -> UIView {
+    UIView()
+  }
+
+  func _setContent(onViewOfSameType _: UIView) { }
+
+  func _isContentEqual(toContentOf _: AnyCalendarItemModel) -> Bool {
+    false
+  }
+
+  mutating func _setSwiftUIWrapperViewContentIDIfNeeded(_: AnyHashable) { }
+
+}


### PR DESCRIPTION
## Details

`CalendarScrollView.accessibilityElements` force-casts every subview to `[ItemView]`, and `fatalError`s if the cast fails:

```swift
guard let itemViews = subviews as? [ItemView] else {
  fatalError("Only `ItemView`s can be used as subviews of the scroll view.")
}
```

That invariant holds only while HorizonCalendar is the sole contributor of subviews. On iOS 27, UIKit adds two `_UITouchPassthroughView`s to the scroll view, so the cast fails and the app dies:

```
HorizonCalendar/CalendarScrollView.swift:55: Fatal error:
Only `ItemView`s can be used as subviews of the scroll view.
```

This filters to the item views instead of requiring that every subview is one:

```swift
let itemViews = subviews.compactMap { $0 as? ItemView }
```

I left the `fatalError` in the `sorted` closure below alone, since the `filter` above it means it is unreachable.

I also considered pairing the filter with an `assertionFailure`, to keep a development signal that an unexpected subview showed up. It seemed wrong here: on iOS 27 the unexpected subviews are normal and arrive on every calendar, so the assert would fire constantly while telling developers about something they cannot act on.

## Related Issue

None filed. Happy to open one if you would prefer to track it separately.

## Motivation and Context

This is a crash rather than a cosmetic problem, and because it is a `fatalError` inside the library, a consumer cannot work around it — there is no way to stop UIKit from adding those subviews, and no way to avoid the property being read.

Only the accessibility path reads `accessibilityElements`, so it stays hidden until something queries accessibility. It surfaced for us in accessibility snapshot tests on Xcode 27, which took out every calendar-bearing screen we snapshot while everything else stayed green. It should equally affect real users who have Voice Over enabled on iOS 27.

The two views UIKit adds are private hit-testing views that carry no content, so filtering them out produces the same element set that the force-cast produced on iOS 26 and earlier. Voice Over behavior is unchanged.

We are running this as a local patch against `470234795d31` at Airbnb to unblock our Xcode 27 work.

## How Has This Been Tested

- Added `CalendarScrollViewTests`, which adds a plain `UIView` alongside an `ItemView` and asserts that the item view is still returned. It does not depend on UIKit inserting anything, so it reproduces the crash on any OS version. I checked that it does — reverting just the fix and rerunning it on iOS 26 crashes in the test:

  ```
  HorizonCalendar/CalendarScrollView.swift:55: Fatal error:
  Only `ItemView`s can be used as subviews of the scroll view.
  ```

- Ran the full test suite on iOS 26 (`xcodebuild test -destination "name=iPhone 16"`), 107 tests green.
- The test file needed adding to the test target in `HorizonCalendar.xcodeproj`, which is the only reason the project file is in this diff.
- Verified the fix end to end in the Airbnb app under Xcode 27.0 beta 4 on an iOS 27.0 simulator. Before: `Fatal error`, and the accessibility snapshot suite executed 0 tests. After: the suite passes and captures its snapshots.
- Confirmed on iOS 26 that snapshots are byte-identical with and without the change, so this is not a behavior change on shipping OS versions.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

One note on the CONTRIBUTING checklist: it asks for a version bump in the Xcode project and podspec, and I have not done one. The recent merged PRs (#338, #340, #342) update only the CHANGELOG under `[Unreleased]`, so I followed that. Glad to add a bump if you want it.

## Please Review
@bryankeller @brynbodayle @marybm-dev 