### PR TITLE
Make MonthGridBackgroundView initializer and framesOfDays public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added ability to disable `DisplayLink` animations for test purposes (to prevent crashes) with an environment variable.
 
 ### Fixed
+- Fixed `MonthGridBackgroundView` initializer and `framesOfDays` being inaccessible outside the defining file, which blocked the SwiftUI `UIViewRepresentable` usage shown in the README
 - Fixed an issue that could cause accessibility focus to shift unexpectedly
 - Fixed a screen-pixel alignment issue
 - Fixed a performance issue caused by month headers recalculating their size too often

--- a/HorizonCalendar.podspec
+++ b/HorizonCalendar.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name = "HorizonCalendar"
-  spec.version = "2.0.0"
+  spec.version = "2.0.1"
   spec.license = "Apache License, Version 2.0"
   spec.summary = "A declarative, performant, calendar UI component that supports use cases ranging from simple date pickers to fully-featured calendar apps."
 

--- a/HorizonCalendar.xcodeproj/project.pbxproj
+++ b/HorizonCalendar.xcodeproj/project.pbxproj
@@ -656,7 +656,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.15.0;
+				MARKETING_VERSION = 2.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.HorizonCalendar;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -690,7 +690,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.15.0;
+				MARKETING_VERSION = 2.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.HorizonCalendar;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Sources/Public/ItemViews/MonthGridBackgroundView.swift
+++ b/Sources/Public/ItemViews/MonthGridBackgroundView.swift
@@ -22,7 +22,7 @@ public final class MonthGridBackgroundView: UIView {
 
   // MARK: Lifecycle
 
-  fileprivate init(invariantViewProperties: InvariantViewProperties) {
+  public init(invariantViewProperties: InvariantViewProperties) {
     self.invariantViewProperties = invariantViewProperties
     super.init(frame: .zero)
     backgroundColor = .clear
@@ -61,9 +61,7 @@ public final class MonthGridBackgroundView: UIView {
     setNeedsDisplay()
   }
 
-  // MARK: Fileprivate
-
-  fileprivate var framesOfDays = [CGRect]() {
+  public var framesOfDays = [CGRect]() {
     didSet {
       guard framesOfDays != oldValue else { return }
       setNeedsDisplay()


### PR DESCRIPTION
## Details

MonthGridBackgroundView had a fileprivate initializer and framesOfDays property. The README SwiftUI UIViewRepresentable example needs both to be public, so this change exposes them and bumps the library version to 2.0.1.

## Related Issue

Fixes #333

## Motivation and Context

The README documents wrapping MonthGridBackgroundView for SwiftUI month backgrounds, but the API was inaccessible outside the defining file.

## How Has This Been Tested

Reviewed against the README Adding grid lines SwiftUI sample. Confirmed the public API matches that usage. No automated tests cover this access level.

## Types of changes

* Bug fix (nonbreaking change which fixes an issue)

## Checklist

* My code follows the code style of this project.
* My change does not require a documentation change (README already shows the intended API).
* I have read the CONTRIBUTING document.
* Version bumped to 2.0.1 in the Xcode project and podspec per SemVer for a public API fix.